### PR TITLE
feat(admin-api): add endpoint to list free IPs in IPv4 range

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -1886,6 +1886,33 @@ Required Permission: `ip_range::delete`
 Note: IP ranges with active IP assignments cannot be deleted. You must first remove all IP assignments before deleting
 an IP range.
 
+#### List Free IPs in Range
+
+```
+GET /api/admin/v1/ip_ranges/{id}/free_ips
+```
+
+Required Permission: `ip_range::view`
+
+Returns a list of all unassigned (free) IP addresses in the specified IPv4 range.
+
+**Limitations:**
+- Only available for IPv4 ranges. IPv6 ranges are too large to enumerate and will return an error.
+- Reserved IPs (gateway, network address, broadcast address) are excluded from the list.
+
+Response:
+
+```json
+{
+  "data": [
+    "192.168.1.2",
+    "192.168.1.3",
+    "192.168.1.5",
+    "..."
+  ]
+}
+```
+
 ### Access Policy Management
 
 #### List Access Policies

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **2026-02-21** - Added endpoint to list free IPs in an IPv4 range (Admin API)
+  - `GET /api/admin/v1/ip_ranges/{id}/free_ips` — Returns list of unassigned IP addresses
+  - Only available for IPv4 ranges; IPv6 ranges return an error (too large to enumerate)
+  - Excludes reserved IPs (gateway, network address, broadcast address)
+
 - **2026-02-20** - Added `supported_currencies` to payment method configuration
   - `AdminPaymentMethodConfigInfo` — New `supported_currencies` field (array of currency codes)
   - `CreatePaymentMethodConfigRequest` — New optional `supported_currencies` field


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/v1/ip_ranges/{id}/free_ips` endpoint to list unassigned IPs
- Add `list_free_ips_in_range` method to `NetworkProvisioner` for reusable IP enumeration
- Only available for IPv4 ranges (IPv6 ranges are too large to enumerate)

## Changes
- `lnvps_api_common/src/network.rs`: Added `list_free_ips_in_range` method and tests
- `lnvps_api_admin/src/admin/ip_ranges.rs`: Added new endpoint handler
- `ADMIN_API_ENDPOINTS.md`: Documented new endpoint
- `API_CHANGELOG.md`: Added changelog entry

Closes #59