### PR TITLE
fix: suppress spurious timed out errors from commander channel recv

### DIFF
--- a/lnvps_api/src/worker.rs
+++ b/lnvps_api/src/worker.rs
@@ -2206,7 +2206,10 @@ impl Worker {
                     }
                 }
                 Err(e) => {
-                    error!("Failed to listen on commander channel: {}", e);
+                    let msg = e.to_string();
+                    if !msg.contains("timed out") {
+                        error!("Failed to listen on commander channel: {}", e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- The Redis `XREAD BLOCK` command legitimately holds the connection open, causing the multiplexed connection's response timeout to fire periodically and log a noisy `Failed to listen on commander channel: timed out` error every few minutes.
- Errors containing `"timed out"` are now silently ignored in the worker recv loop; all other errors continue to be logged.