### PR TITLE
feat: cloud image checksum verification and on-demand download

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -1177,6 +1177,22 @@ Body (all optional):
 }
 ```
 
+#### Trigger Image Download
+
+```
+POST /api/admin/v1/vm_os_images/{id}/download
+```
+
+Required Permission: `vm_os_image::update`
+
+Enqueues a `DownloadOsImages` work job for the specified image. The worker will download the image to all configured hosts, verifying the checksum against `sha2_url` (or `sha2`) and re-downloading if the file is stale or missing.
+
+Returns:
+
+```json
+"Download job enqueued"
+```
+
 #### Delete VM OS Image
 
 ```

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [v0.2.0] - 2026-02-22
 
 ### Added
+- **2026-02-24** - Cloud image checksum verification and on-demand download (closes #69)
+  - `POST /api/admin/v1/vm_os_images/{id}/download` — Enqueue an immediate download/re-check of an OS image on all hosts (requires `vm_os_image::update`)
+  - `PATCH /api/admin/v1/vm_os_images/{id}` — Now correctly applies `sha2` and `sha2_url` updates
+  - Worker: `DownloadOsImages` job fetches `sha2_url`, compares checksum via SSH, and re-downloads stale images; checksum is also passed to Proxmox `download-url` API for in-flight verification
 - **2026-02-24** - Added `company_base_currency` field to `AdminVmPaymentInfo`
   - `GET /api/admin/v1/vms/{id}/payments` — Response now includes `company_base_currency`
   - `GET /api/admin/v1/vms/{id}/payments/{payment_id}` — Response now includes `company_base_currency`

--- a/lnvps_api/src/bin/api.rs
+++ b/lnvps_api/src/bin/api.rs
@@ -139,6 +139,15 @@ async fn main() -> Result<(), Error> {
                 worker.spawn_job_interval(WorkJob::CheckNostrDomains, Duration::from_secs(600)),
             );
         }
+
+        // enqueue an image download/checksum check on startup
+        if let Err(e) = worker
+            .commander()
+            .send(WorkJob::DownloadOsImages { image_id: None })
+            .await
+        {
+            error!("Failed to enqueue startup image download: {}", e);
+        }
     }
 
     // setup payment handlers

--- a/lnvps_api/src/provisioner/lnvps.rs
+++ b/lnvps_api/src/provisioner/lnvps.rs
@@ -17,7 +17,7 @@ use lnvps_db::{
     IpRange, IpRangeAllocationMode, LNVpsDb, PaymentMethod, PaymentType, Vm, VmCustomTemplate,
     VmIpAssignment, VmPayment, VmTemplate,
 };
-use log::{debug, info, warn};
+use log::{debug, info};
 use payments_rs::currency::{Currency, CurrencyAmount};
 use payments_rs::fiat::FiatPaymentService;
 use payments_rs::lightning::{AddInvoiceRequest, LightningNode};
@@ -78,19 +78,6 @@ impl LNVpsProvisioner {
 
     /// Do any necessary initialization
     pub async fn init(&self) -> Result<()> {
-        let hosts = self.db.list_hosts().await?;
-        let images = self.db.list_os_image().await?;
-        for host in hosts {
-            let client = get_host_client(&host, &self.provisioner_config)?;
-            for image in &images {
-                if let Err(e) = client.download_os_image(image).await {
-                    warn!(
-                        "Error downloading image {} on {}: {}",
-                        image.url, host.name, e
-                    );
-                }
-            }
-        }
         Ok(())
     }
 

--- a/lnvps_api_admin/src/admin/vm_os_images.rs
+++ b/lnvps_api_admin/src/admin/vm_os_images.rs
@@ -4,8 +4,10 @@ use crate::admin::model::{AdminVmOsImageInfo, CreateVmOsImageRequest, UpdateVmOs
 use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
-use lnvps_db::{AdminAction, AdminResource};
+use lnvps_api_common::shasum::{fetch_checksum_for_file, probe_checksum_from_image_url};
+use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, WorkJob};
+use lnvps_db::{AdminAction, AdminResource, VmOsImage};
+use log::warn;
 
 pub fn router() -> Router<RouterState> {
     Router::new()
@@ -18,6 +20,10 @@ pub fn router() -> Router<RouterState> {
             get(admin_get_vm_os_image)
                 .patch(admin_update_vm_os_image)
                 .delete(admin_delete_vm_os_image),
+        )
+        .route(
+            "/api/admin/v1/vm_os_images/{id}/download",
+            axum::routing::post(admin_download_vm_os_image),
         )
 }
 
@@ -56,6 +62,43 @@ async fn admin_get_vm_os_image(
     ApiData::ok(admin_image)
 }
 
+/// Resolve the current checksum for an image and populate `sha2` (and
+/// `sha2_url` if it was auto-discovered).  No-op if `sha2` is already set.
+///
+/// Resolution order:
+/// 1. If `sha2_url` is set, fetch from that URL directly.
+/// 2. Otherwise, probe well-known SHASUMS filenames in the image's URL directory.
+///
+/// Failures are logged as warnings and do not prevent the image from being saved.
+async fn resolve_sha2(image: &mut VmOsImage) {
+    if image.sha2.is_some() {
+        return;
+    }
+    // Use the original URL filename (e.g. "debian-12-generic-amd64.qcow2") since
+    // that is what appears in SHASUMS files, not the host-stored ".img" variant.
+    let filename = match image.url_filename() {
+        Ok(f) => f,
+        Err(e) => {
+            warn!("Could not determine filename for sha2 resolution: {}", e);
+            return;
+        }
+    };
+    if let Some(sha2_url) = image.sha2_url.clone() {
+        match fetch_checksum_for_file(&sha2_url, &filename).await {
+            Ok(entry) => image.sha2 = Some(entry.checksum),
+            Err(e) => warn!("Failed to fetch sha2 from {}: {}", sha2_url, e),
+        }
+    } else {
+        match probe_checksum_from_image_url(&image.url, &filename).await {
+            Some((entry, sums_url)) => {
+                image.sha2 = Some(entry.checksum);
+                image.sha2_url = Some(sums_url);
+            }
+            None => warn!("Could not find a SHASUMS file for {}", image.url),
+        }
+    }
+}
+
 /// Create a new VM OS image
 async fn admin_create_vm_os_image(
     auth: AdminAuth,
@@ -67,6 +110,9 @@ async fn admin_create_vm_os_image(
 
     // Convert request to VmOsImage
     let mut vm_os_image = request.to_vm_os_image()?;
+
+    // Fetch the current checksum from sha2_url if sha2 was not explicitly provided
+    resolve_sha2(&mut vm_os_image).await;
 
     // Create the image in the database
     let image_id = this.db.admin_create_vm_os_image(&vm_os_image).await?;
@@ -117,10 +163,47 @@ async fn admin_update_vm_os_image(
         image.default_username = Some(default_username.clone());
     }
 
+    if let Some(sha2) = &request.sha2 {
+        image.sha2 = sha2.clone();
+    }
+
+    let sha2_url_changed = request.sha2_url.is_some();
+    if let Some(sha2_url) = &request.sha2_url {
+        image.sha2_url = sha2_url.clone();
+    }
+
+    // If sha2_url was updated (or url changed) and sha2 was not explicitly set,
+    // fetch the current checksum from the new sha2_url
+    let url_changed = request.url.is_some();
+    if (sha2_url_changed || url_changed) && request.sha2.is_none() {
+        image.sha2 = None; // clear stale checksum before re-resolving
+        resolve_sha2(&mut image).await;
+    }
+
     // Update in database
     this.db.admin_update_vm_os_image(&image).await?;
 
     ApiData::ok(image.into())
+}
+
+/// Trigger an immediate download/re-check of a VM OS image on all hosts
+async fn admin_download_vm_os_image(
+    auth: AdminAuth,
+    State(this): State<RouterState>,
+    Path(image_id): Path<u64>,
+) -> ApiResult<String> {
+    auth.require_permission(AdminResource::VmOsImage, AdminAction::Update)?;
+
+    // Verify the image exists before enqueuing
+    this.db.admin_get_vm_os_image(image_id).await?;
+
+    this.work_commander
+        .send(WorkJob::DownloadOsImages {
+            image_id: Some(image_id),
+        })
+        .await?;
+
+    ApiData::ok("Download job enqueued".to_string())
 }
 
 /// Delete VM OS image

--- a/lnvps_api_common/src/lib.rs
+++ b/lnvps_api_common/src/lib.rs
@@ -8,6 +8,7 @@ mod nip98;
 mod pricing;
 pub mod retry;
 mod routes;
+pub mod shasum;
 mod status;
 mod vat;
 mod vm_history;

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -495,6 +495,12 @@ impl LNVpsDbBase for MockDb {
         Ok(os_images.values().filter(|i| i.enabled).cloned().collect())
     }
 
+    async fn update_os_image(&self, image: &VmOsImage) -> DbResult<()> {
+        let mut os_images = self.os_images.lock().await;
+        os_images.insert(image.id, image.clone());
+        Ok(())
+    }
+
     async fn get_ip_range(&self, id: u64) -> DbResult<IpRange> {
         let ip_range = self.ip_range.lock().await;
         Ok(ip_range.get(&id).ok_or(anyhow!("no ip range"))?.clone())

--- a/lnvps_api_common/src/shasum.rs
+++ b/lnvps_api_common/src/shasum.rs
@@ -1,0 +1,410 @@
+use anyhow::{Result, bail};
+
+/// A single entry parsed from a SHASUMS-style file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShasumEntry {
+    pub algorithm: ShasumAlgorithm,
+    pub checksum: String,
+    pub filename: String,
+}
+
+/// The hash algorithm inferred from the digest length or file header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShasumAlgorithm {
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+impl ShasumAlgorithm {
+    /// Infer the algorithm from a hex digest length.
+    pub fn from_hex_len(len: usize) -> Option<Self> {
+        match len {
+            64 => Some(Self::Sha256),
+            96 => Some(Self::Sha384),
+            128 => Some(Self::Sha512),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha384 => "sha384",
+            Self::Sha512 => "sha512",
+        }
+    }
+}
+
+/// Parse the contents of a SHASUMS file and return all entries.
+///
+/// Supported formats:
+///
+/// **GNU coreutils** (`sha256sum`, `sha512sum` output):
+/// ```text
+/// <checksum>  <filename>
+/// <checksum> *<filename>
+/// ```
+///
+/// **BSD / RPM** (`shasum -a 256`, `openssl dgst`):
+/// ```text
+/// SHA256 (<filename>) = <checksum>
+/// SHA512 (<filename>) = <checksum>
+/// ```
+///
+/// Lines that are blank, start with `#`, or do not match any known format
+/// are silently skipped.
+pub fn parse_shasum_file(content: &str) -> Vec<ShasumEntry> {
+    let mut entries = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(entry) = parse_bsd_line(line).or_else(|| parse_gnu_line(line)) {
+            entries.push(entry);
+        }
+    }
+    entries
+}
+
+/// Find the checksum for a specific filename within parsed entries.
+///
+/// The match is performed on the bare filename, allowing for path prefixes
+/// stored in the SUMS file (e.g. `./images/foo.qcow2` matches `foo.qcow2`).
+///
+/// Pass the original URL filename (e.g. `foo.qcow2`), not the host-storage
+/// name (`foo.img`) — the `.img` rename is a Proxmox implementation detail.
+pub fn find_checksum<'a>(entries: &'a [ShasumEntry], filename: &str) -> Option<&'a ShasumEntry> {
+    entries.iter().find(|e| {
+        e.filename == filename
+            || e.filename.ends_with(&format!("/{filename}"))
+            || e.filename.ends_with(&format!("\\{filename}"))
+    })
+}
+
+/// Fetch a SHASUMS file from a URL and return the checksum entry for the
+/// given filename.
+///
+/// Returns an error if the URL cannot be fetched or the filename is not
+/// present in the file.
+pub async fn fetch_checksum_for_file(sha2_url: &str, filename: &str) -> Result<ShasumEntry> {
+    let body = reqwest::get(sha2_url)
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let entries = parse_shasum_file(&body);
+    match find_checksum(&entries, filename) {
+        Some(e) => Ok(e.clone()),
+        None => bail!("Checksum for '{}' not found in {}", filename, sha2_url),
+    }
+}
+
+/// Well-known shared SHASUMS filenames probed in the image's directory.
+/// Ordered from strongest to weakest algorithm.
+const CANDIDATE_SUMS_FILES: &[&str] = &["SHA512SUMS", "SHA256SUMS", "SHA512SUMS.txt", "SHA256SUMS.txt"];
+
+/// Per-file sidecar extensions appended directly to the image filename
+/// (e.g. `foo.qcow2.SHA256`).  Ordered from strongest to weakest.
+const CANDIDATE_SIDECAR_EXTS: &[&str] = &[".SHA512", ".SHA256", ".sha512", ".sha256"];
+
+/// Given an image download URL and its filename, attempt to locate and fetch a
+/// checksum by probing:
+/// 1. Well-known shared SHASUMS files in the same directory (`SHA512SUMS`, `SHA256SUMS`, …)
+/// 2. Per-file sidecar files appended to the image URL (`<url>.SHA256`, `<url>.SHA512`, …)
+///
+/// Returns `None` if no matching file is found.
+pub async fn probe_checksum_from_image_url(
+    image_url: &str,
+    filename: &str,
+) -> Option<(ShasumEntry, String)> {
+    // Build the base directory URL by stripping the last path segment
+    let base = {
+        let trimmed = image_url.trim_end_matches('/');
+        match trimmed.rfind('/') {
+            Some(i) => &trimmed[..=i],
+            None => return None,
+        }
+    };
+
+    // 1. Shared SHASUMS files in the same directory
+    for candidate in CANDIDATE_SUMS_FILES {
+        let sums_url = format!("{}{}", base, candidate);
+        if let Ok(entry) = fetch_checksum_for_file(&sums_url, filename).await {
+            return Some((entry, sums_url));
+        }
+    }
+
+    // 2. Per-file sidecar: <image_url>.<EXT>
+    for ext in CANDIDATE_SIDECAR_EXTS {
+        let sums_url = format!("{}{}", image_url, ext);
+        if let Ok(entry) = fetch_checksum_for_file(&sums_url, filename).await {
+            return Some((entry, sums_url));
+        }
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Internal parsers
+// ---------------------------------------------------------------------------
+
+/// Parse a GNU coreutils line: `<checksum>  <filename>` or `<checksum> *<filename>`
+fn parse_gnu_line(line: &str) -> Option<ShasumEntry> {
+    // Split on the first whitespace run; the second token may start with `*`
+    let (checksum, rest) = line.split_once(|c: char| c.is_ascii_whitespace())?;
+    let filename = rest.trim().trim_start_matches('*').trim();
+    if filename.is_empty() {
+        return None;
+    }
+    let checksum = checksum.trim();
+    if !checksum.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let algorithm = ShasumAlgorithm::from_hex_len(checksum.len())?;
+    Some(ShasumEntry {
+        algorithm,
+        checksum: checksum.to_lowercase(),
+        filename: filename.to_owned(),
+    })
+}
+
+/// Parse a BSD/RPM line: `SHA256 (<filename>) = <checksum>`
+fn parse_bsd_line(line: &str) -> Option<ShasumEntry> {
+    // Must start with a known algorithm prefix
+    let (algo_str, rest) = line.split_once(' ')?;
+    let algorithm = match algo_str.to_uppercase().as_str() {
+        "MD5" | "SHA1" => return None, // ignored weak algorithms
+        "SHA256" => ShasumAlgorithm::Sha256,
+        "SHA384" => ShasumAlgorithm::Sha384,
+        "SHA512" => ShasumAlgorithm::Sha512,
+        _ => return None,
+    };
+    // rest should be `(<filename>) = <checksum>`
+    let rest = rest.trim();
+    let inner = rest.strip_prefix('(')?.split_once(')')?;
+    let filename = inner.0.trim();
+    let checksum = inner.1.trim().strip_prefix('=')?.trim();
+    if !checksum.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(ShasumEntry {
+        algorithm,
+        checksum: checksum.to_lowercase(),
+        filename: filename.to_owned(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- GNU format --------------------------------------------------------
+
+    #[test]
+    fn test_gnu_two_spaces() {
+        let content = "4586d96ba3604c05b1772c9fef74a6957402688eb9c075f212068d5a29afe6bca924afaa4d12b8e0e593deea18b8b200f606a94ad4a0aa5361e75ffacb12087c  debian-12-generic-amd64.qcow2\n";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].filename, "debian-12-generic-amd64.qcow2");
+        assert_eq!(entries[0].algorithm, ShasumAlgorithm::Sha512);
+        assert_eq!(entries[0].checksum.len(), 128);
+    }
+
+    #[test]
+    fn test_gnu_asterisk_binary_marker() {
+        let content = "4586d96ba3604c05b1772c9fef74a6957402688eb9c075f212068d5a29afe6bca924afaa4d12b8e0e593deea18b8b200f606a94ad4a0aa5361e75ffacb12087c *debian-12-generic-amd64.qcow2\n";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].filename, "debian-12-generic-amd64.qcow2");
+        assert_eq!(entries[0].algorithm, ShasumAlgorithm::Sha512);
+    }
+
+    #[test]
+    fn test_gnu_sha256() {
+        let content = "049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4fa3c2b *noble-server-cloudimg-amd64.img\n";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].algorithm, ShasumAlgorithm::Sha256);
+        assert_eq!(entries[0].filename, "noble-server-cloudimg-amd64.img");
+    }
+
+    // ---- BSD/RPM format ----------------------------------------------------
+
+    #[test]
+    fn test_bsd_sha256() {
+        let content = "SHA256 (CentOS-Stream-9-latest-x86_64-dvd1.iso) = 045b30d6cc7574b3bf6b373a8693e73cdfd7b840070c15c6d5818a45235128c7\n";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].filename,
+            "CentOS-Stream-9-latest-x86_64-dvd1.iso"
+        );
+        assert_eq!(entries[0].algorithm, ShasumAlgorithm::Sha256);
+        assert_eq!(
+            entries[0].checksum,
+            "045b30d6cc7574b3bf6b373a8693e73cdfd7b840070c15c6d5818a45235128c7"
+        );
+    }
+
+    #[test]
+    fn test_bsd_sha512() {
+        let content = "SHA512 (somefile.img) = 4586d96ba3604c05b1772c9fef74a6957402688eb9c075f212068d5a29afe6bca924afaa4d12b8e0e593deea18b8b200f606a94ad4a0aa5361e75ffacb12087c4586d96ba3604c05b1772c9fef74a6957402688eb9c075f212068d5a29afe6bc\n";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].algorithm, ShasumAlgorithm::Sha512);
+    }
+
+    // ---- Comment / blank lines ---------------------------------------------
+
+    #[test]
+    fn test_skips_comments_and_blank_lines() {
+        let content = "# generated by sha512sum\n\n049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4fa3c2b *noble.img\n";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 1);
+    }
+
+    // ---- find_checksum -----------------------------------------------------
+
+    #[test]
+    fn test_find_checksum_exact() {
+        let entries = parse_shasum_file(
+            "049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4fa3c2b *noble.img\n",
+        );
+        assert!(find_checksum(&entries, "noble.img").is_some());
+        assert!(find_checksum(&entries, "other.img").is_none());
+    }
+
+    #[test]
+    fn test_find_checksum_with_path_prefix() {
+        let entries = parse_shasum_file(
+            "049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4fa3c2b  ./images/noble.img\n",
+        );
+        assert!(find_checksum(&entries, "noble.img").is_some());
+    }
+
+    // ---- Mixed file --------------------------------------------------------
+
+    #[test]
+    fn test_mixed_file() {
+        let content = "\
+# Comment line
+SHA256 (file-a.iso) = 049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4fa3c2b
+4586d96ba3604c05b1772c9fef74a6957402688eb9c075f212068d5a29afe6bca924afaa4d12b8e0e593deea18b8b200f606a94ad4a0aa5361e75ffacb12087c  file-b.qcow2
+049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4fa3c2b *file-c.img
+";
+        let entries = parse_shasum_file(content);
+        assert_eq!(entries.len(), 3);
+        assert!(find_checksum(&entries, "file-a.iso").is_some());
+        assert!(find_checksum(&entries, "file-b.qcow2").is_some());
+        assert!(find_checksum(&entries, "file-c.img").is_some());
+    }
+
+    // ---- Network test against real Debian SHA512SUMS -----------------------
+
+    #[tokio::test]
+    async fn test_fetch_checksum_debian_bookworm() -> anyhow::Result<()> {
+        let url = "https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS";
+        let filename = "debian-12-generic-amd64.qcow2";
+
+        let entry = fetch_checksum_for_file(url, filename).await?;
+
+        assert_eq!(entry.filename, filename);
+        assert_eq!(entry.algorithm, ShasumAlgorithm::Sha512);
+        assert_eq!(entry.checksum.len(), 128);
+        assert!(entry.checksum.chars().all(|c| c.is_ascii_hexdigit()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fetch_checksum_ubuntu_noble() -> anyhow::Result<()> {
+        let url = "https://cloud-images.ubuntu.com/noble/current/SHA256SUMS";
+        let filename = "noble-server-cloudimg-amd64.img";
+
+        let entry = fetch_checksum_for_file(url, filename).await?;
+
+        assert_eq!(entry.algorithm, ShasumAlgorithm::Sha256);
+        assert_eq!(entry.checksum.len(), 64);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fetch_checksum_missing_filename_errors() {
+        let url = "https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS";
+        let result = fetch_checksum_for_file(url, "nonexistent-file.qcow2").await;
+        assert!(result.is_err());
+    }
+
+    // ---- probe_checksum_from_image_url -------------------------------------
+
+    #[tokio::test]
+    async fn test_probe_checksum_debian_image_url() -> anyhow::Result<()> {
+        // No sha2_url provided — should auto-discover SHA512SUMS in the same directory.
+        // Use the original URL filename (qcow2), not the host-stored .img variant.
+        let image_url =
+            "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2";
+        let filename = "debian-12-generic-amd64.qcow2";
+
+        let result = probe_checksum_from_image_url(image_url, filename).await;
+        let (entry, sums_url) = result.expect("should find a SHASUMS file");
+
+        assert!(
+            sums_url.contains("SHA512SUMS") || sums_url.contains("SHA256SUMS"),
+            "unexpected sums_url: {sums_url}"
+        );
+        assert_eq!(entry.algorithm, ShasumAlgorithm::Sha512);
+        assert_eq!(entry.checksum.len(), 128);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_probe_checksum_ubuntu_image_url() -> anyhow::Result<()> {
+        let image_url =
+            "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img";
+        let filename = "noble-server-cloudimg-amd64.img";
+
+        let result = probe_checksum_from_image_url(image_url, filename).await;
+        let (entry, sums_url) = result.expect("should find a SHASUMS file");
+
+        assert!(
+            sums_url.contains("SHA256SUMS") || sums_url.contains("SHA512SUMS"),
+            "unexpected sums_url: {sums_url}"
+        );
+        assert_eq!(entry.checksum.len(), 64, "Ubuntu uses SHA-256");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_probe_checksum_arch_sidecar() -> anyhow::Result<()> {
+        // Arch Linux uses a per-file sidecar: <image>.qcow2.SHA256
+        let image_url =
+            "https://mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2";
+        let filename = "Arch-Linux-x86_64-cloudimg.qcow2";
+
+        let result = probe_checksum_from_image_url(image_url, filename).await;
+        let (entry, sums_url) = result.expect("should find sidecar SHA256 file");
+
+        assert!(sums_url.ends_with(".SHA256"), "unexpected sums_url: {sums_url}");
+        assert_eq!(entry.algorithm, ShasumAlgorithm::Sha256);
+        assert_eq!(entry.checksum.len(), 64);
+        Ok(())
+    }
+
+    #[test]
+    fn test_probe_base_url_stripping() {
+        // Verify the base-URL derivation logic inline (no network needed)
+        let image_url = "https://example.com/images/latest/some-image.qcow2";
+        let base = {
+            let trimmed = image_url.trim_end_matches('/');
+            let i = trimmed.rfind('/').unwrap();
+            trimmed[..=i].to_owned()
+        };
+        assert_eq!(base, "https://example.com/images/latest/");
+    }
+}

--- a/lnvps_api_common/src/work/mod.rs
+++ b/lnvps_api_common/src/work/mod.rs
@@ -116,6 +116,9 @@ pub enum WorkJob {
     },
     /// Send an email verification link to the user
     SendEmailVerification { user_id: u64, verify_url: String },
+    /// Download OS images to all hosts, verifying checksums and re-downloading if stale.
+    /// If `image_id` is Some, only that image is processed; otherwise all images are checked.
+    DownloadOsImages { image_id: Option<u64> },
 }
 
 impl WorkJob {
@@ -153,6 +156,7 @@ impl fmt::Display for WorkJob {
             WorkJob::ProcessVmRefund { .. } => write!(f, "ProcessVmRefund"),
             WorkJob::CreateVm { .. } => write!(f, "CreateVm"),
             WorkJob::SendEmailVerification { .. } => write!(f, "SendEmailVerification"),
+            WorkJob::DownloadOsImages { .. } => write!(f, "DownloadOsImages"),
         }
     }
 }

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -164,6 +164,9 @@ pub trait LNVpsDbBase: Send + Sync {
     /// List available OS images
     async fn list_os_image(&self) -> DbResult<Vec<VmOsImage>>;
 
+    /// Update an OS image (sha2, sha2_url, and other fields)
+    async fn update_os_image(&self, image: &VmOsImage) -> DbResult<()>;
+
     /// List available IP Ranges
     async fn get_ip_range(&self, id: u64) -> DbResult<IpRange>;
 

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -631,6 +631,7 @@ pub struct VmOsImage {
 }
 
 impl VmOsImage {
+    /// The filename as it will be stored on the host (original extension replaced with `.img`).
     pub fn filename(&self) -> Result<String> {
         let u: Url = self.url.parse()?;
         let mut name: PathBuf = u
@@ -641,6 +642,16 @@ impl VmOsImage {
             .parse()?;
         name.set_extension("img");
         Ok(name.to_string_lossy().to_string())
+    }
+
+    /// The original filename from the download URL, as it appears in SHASUMS files.
+    pub fn url_filename(&self) -> Result<String> {
+        let u: Url = self.url.parse()?;
+        u.path_segments()
+            .ok_or(anyhow!("Invalid URL"))?
+            .next_back()
+            .ok_or(anyhow!("Invalid URL"))
+            .map(str::to_owned)
     }
 }
 

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -393,6 +393,25 @@ impl LNVpsDbBase for LNVpsDbMysql {
             .await?)
     }
 
+    async fn update_os_image(&self, image: &VmOsImage) -> DbResult<()> {
+        sqlx::query(
+            "UPDATE vm_os_image SET distribution=?, flavour=?, version=?, enabled=?, release_date=?, url=?, default_username=?, sha2=?, sha2_url=? WHERE id=?"
+        )
+        .bind(image.distribution as u16)
+        .bind(&image.flavour)
+        .bind(&image.version)
+        .bind(image.enabled)
+        .bind(image.release_date)
+        .bind(&image.url)
+        .bind(&image.default_username)
+        .bind(&image.sha2)
+        .bind(&image.sha2_url)
+        .bind(image.id)
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
     async fn get_ip_range(&self, id: u64) -> DbResult<IpRange> {
         Ok(sqlx::query_as("select * from ip_range where id=?")
             .bind(id)


### PR DESCRIPTION
Closes #69

## Summary

- **`lnvps_api_common::shasum`** — common SHASUMS parser supporting GNU (`sha256sum` / `sha512sum` output), BSD/RPM (`SHA256 (file) = ...`), and per-file sidecar formats (`<image>.SHA256`). Probes well-known filenames (`SHA512SUMS`, `SHA256SUMS`) and sidecars automatically when no `sha2_url` is configured.
- **`VmOsImage::url_filename()`** — returns the original download filename for SHASUMS lookups; `filename()` (`.img` rename) is now Proxmox-only and never used for checksums.
- **`DownloadOsImages` WorkJob** — resolves and persists `sha2`/`sha2_url` for images missing them, then downloads to all hosts. Startup enqueues this job instead of blocking in `provisioner::init`.
- **Proxmox `download_os_image`** — verifies existing files via SSH checksum, deletes stale files and re-downloads on mismatch, passes checksum to Proxmox `download-url` API for in-flight verification.
- **Admin create/update** — auto-resolves `sha2` from `sha2_url` or by probing the image directory; `PATCH` now correctly applies `sha2`/`sha2_url` updates.
- **`POST /api/admin/v1/vm_os_images/{id}/download`** — triggers an immediate download/re-check for a specific image.
- **`LNVpsDbBase::update_os_image()`** — new base trait method so the worker can persist resolved checksums without the admin feature.