### PR TITLE
feat: require email verification before creating a VM

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [v0.2.0] - 2026-02-22
 
+### Changed
+- **2026-02-25** - Email verification is now required before creating a VM (closes #92)
+  - `POST /api/v1/vm` — Returns `400` with error message if the user's email is not verified
+  - `POST /api/v1/vm/custom-template` — Same gate applied
+
 ### Added
 - **2026-02-25** - Resource limits on custom pricing plans, propagated to custom templates
   - `POST /api/admin/v1/custom_pricing` — Accepts new optional fields: `disk_iops_read`, `disk_iops_write`, `disk_mbps_read`, `disk_mbps_write`, `network_mbps`, `cpu_limit`

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -515,6 +515,11 @@ async fn v1_create_custom_vm_order(
     let pubkey = auth.event.pubkey.to_bytes();
     let uid = this.db.upsert_user(&pubkey).await?;
 
+    let user = this.db.get_user(uid).await?;
+    if !user.email_verified {
+        return Err(ApiError::new("Email verification is required before creating a VM"));
+    }
+
     // create a fake template from the request to generate the order
     let template = req.spec.clone().into();
 
@@ -593,6 +598,11 @@ async fn v1_create_vm_order(
 ) -> ApiResult<ApiVmStatus> {
     let pubkey = auth.event.pubkey.to_bytes();
     let uid = this.db.upsert_user(&pubkey).await?;
+
+    let user = this.db.get_user(uid).await?;
+    if !user.email_verified {
+        return Err(ApiError::new("Email verification is required before creating a VM"));
+    }
 
     let rsp = this
         .provisioner


### PR DESCRIPTION
## Summary

- Gate `POST /api/v1/vm` and `POST /api/v1/vm/custom-template` behind email verification
- Returns a `400` error with message `"Email verification is required before creating a VM"` if the user's `email_verified` flag is `false`
- All infrastructure (the `email_verified` field, verification token, send-verification job, and verify endpoint) was already in place — this just enforces the gate at provisioning time

Closes #92