### PR TITLE
fix: wait for VM fully stopped before unlinking disk on reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +932,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +1595,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2493,6 +2527,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "virt",
+ "wiremock",
 ]
 
 [[package]]
@@ -2932,6 +2967,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5901,6 +5946,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log 0.4.29",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/lnvps_api/Cargo.toml
+++ b/lnvps_api/Cargo.toml
@@ -94,6 +94,7 @@ quick-xml = { version = "0.39", features = ["serde", "serialize"], optional = tr
 env_logger = "0.11"
 lightning-invoice = "0.34"
 bitcoin = "0.32"
+wiremock = "0.6"
 
 [build-dependencies]
 openapi-build-gen = { git = "https://github.com/v0l/openapi-build-gen.git", rev = "b4c946ca891d22c5ab16ce13f17b1bf81c91587c", optional = true }

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -517,7 +517,9 @@ async fn v1_create_custom_vm_order(
 
     let user = this.db.get_user(uid).await?;
     if !user.email_verified {
-        return Err(ApiError::new("Email verification is required before creating a VM"));
+        return Err(ApiError::new(
+            "Email verification is required before creating a VM",
+        ));
     }
 
     // create a fake template from the request to generate the order
@@ -601,7 +603,9 @@ async fn v1_create_vm_order(
 
     let user = this.db.get_user(uid).await?;
     if !user.email_verified {
-        return Err(ApiError::new("Email verification is required before creating a VM"));
+        return Err(ApiError::new(
+            "Email verification is required before creating a VM",
+        ));
     }
 
     let rsp = this

--- a/lnvps_api/src/bin/api.rs
+++ b/lnvps_api/src/bin/api.rs
@@ -139,7 +139,6 @@ async fn main() -> Result<(), Error> {
                 worker.spawn_job_interval(WorkJob::CheckNostrDomains, Duration::from_secs(600)),
             );
         }
-
     }
 
     // setup payment handlers

--- a/lnvps_api/src/provisioner/lnvps.rs
+++ b/lnvps_api/src/provisioner/lnvps.rs
@@ -1357,7 +1357,13 @@ mod tests {
         let rates = Arc::new(MockExchangeRate::new());
         const MOCK_RATE: f32 = 69_420.0;
         rates.set_rate(Ticker::btc_rate("EUR")?, MOCK_RATE).await;
-        Ok(LNVpsProvisioner::new(mock_settings(), db, node, rates, None))
+        Ok(LNVpsProvisioner::new(
+            mock_settings(),
+            db,
+            node,
+            rates,
+            None,
+        ))
     }
 
     /// Insert a VmCustomPricing + one VmCustomPricingDisk into db and return the pricing id.
@@ -1857,7 +1863,11 @@ mod tests {
             .await;
         assert!(result.is_err(), "should fail with disabled template");
         assert!(
-            result.unwrap_err().to_string().to_lowercase().contains("disabled"),
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("disabled"),
             "error should mention disabled"
         );
         Ok(())
@@ -1877,7 +1887,11 @@ mod tests {
             .await;
         assert!(result.is_err(), "should fail with expired template");
         assert!(
-            result.unwrap_err().to_string().to_lowercase().contains("expired"),
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("expired"),
             "error should mention expired"
         );
         Ok(())
@@ -1941,7 +1955,11 @@ mod tests {
             .await;
         assert!(result.is_err(), "should fail with expired custom pricing");
         assert!(
-            result.unwrap_err().to_string().to_lowercase().contains("expired"),
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("expired"),
             "error should mention expired"
         );
         Ok(())

--- a/lnvps_api_admin/src/admin/vm_os_images.rs
+++ b/lnvps_api_admin/src/admin/vm_os_images.rs
@@ -5,7 +5,9 @@ use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
 use lnvps_api_common::shasum::{fetch_checksum_for_file, probe_checksum_from_image_url};
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, WorkJob};
+use lnvps_api_common::{
+    ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, WorkJob,
+};
 use lnvps_db::{AdminAction, AdminResource, VmOsImage};
 use log::warn;
 

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -1544,7 +1544,13 @@ impl LNVpsDbBase for MockDb {
         let mut referrals = self.referrals.lock().await;
         let max_id = referrals.keys().max().copied().unwrap_or(0);
         let new_id = max_id + 1;
-        referrals.insert(new_id, Referral { id: new_id, ..referral.clone() });
+        referrals.insert(
+            new_id,
+            Referral {
+                id: new_id,
+                ..referral.clone()
+            },
+        );
         Ok(new_id)
     }
 

--- a/lnvps_api_common/src/network.rs
+++ b/lnvps_api_common/src/network.rs
@@ -687,7 +687,11 @@ mod tests {
             ..Default::default()
         };
         let available = NetworkProvisioner::count_available_ips(&range, 15);
-        assert_eq!(available, Some(1), "should have 1 free IP when gateway is outside range");
+        assert_eq!(
+            available,
+            Some(1),
+            "should have 1 free IP when gateway is outside range"
+        );
     }
 
     #[test]
@@ -704,7 +708,11 @@ mod tests {
             ..Default::default()
         };
         let available = NetworkProvisioner::count_available_ips(&range, 15);
-        assert_eq!(available, Some(0), "should have 0 free IPs when gateway is inside range");
+        assert_eq!(
+            available,
+            Some(0),
+            "should have 0 free IPs when gateway is inside range"
+        );
     }
 
     #[tokio::test]

--- a/lnvps_api_common/src/shasum.rs
+++ b/lnvps_api_common/src/shasum.rs
@@ -145,7 +145,12 @@ pub async fn resolve_redirect(url: &str) -> String {
 
 /// Well-known shared SHASUMS filenames probed in the image's directory.
 /// Ordered from strongest to weakest algorithm.
-const CANDIDATE_SUMS_FILES: &[&str] = &["SHA512SUMS", "SHA256SUMS", "SHA512SUMS.txt", "SHA256SUMS.txt"];
+const CANDIDATE_SUMS_FILES: &[&str] = &[
+    "SHA512SUMS",
+    "SHA256SUMS",
+    "SHA512SUMS.txt",
+    "SHA256SUMS.txt",
+];
 
 /// Per-file sidecar extensions appended directly to the image filename
 /// (e.g. `foo.qcow2.SHA256`).  Ordered from strongest to weakest.
@@ -376,8 +381,7 @@ SHA256 (file-a.iso) = 049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4
     async fn test_resolve_redirect_debian_raw_image() {
         // cloud.debian.org issues a 302 redirect to a mirror for raw images.
         // Verify that resolve_redirect follows it and returns a different (mirror) URL.
-        let url =
-            "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.raw";
+        let url = "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.raw";
         let resolved = resolve_redirect(url).await;
         assert_ne!(
             resolved, url,
@@ -473,7 +477,10 @@ SHA256 (file-a.iso) = 049d861863ad093da0d1e97a49e4d4f57329b86b56e66e3c0578e788c4
         let result = probe_checksum_from_image_url(image_url, filename).await;
         let (entry, sums_url) = result.expect("should find sidecar SHA256 file");
 
-        assert!(sums_url.ends_with(".SHA256"), "unexpected sums_url: {sums_url}");
+        assert!(
+            sums_url.ends_with(".SHA256"),
+            "unexpected sums_url: {sums_url}"
+        );
         assert_eq!(entry.algorithm, ShasumAlgorithm::Sha256);
         assert_eq!(entry.checksum.len(), 64);
         Ok(())

--- a/lnvps_api_common/src/vm_history.rs
+++ b/lnvps_api_common/src/vm_history.rs
@@ -482,7 +482,13 @@ mod tests {
         let history = logger.db.list_vm_history(42).await.unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].action_type.to_string(), "created");
-        assert!(history[0].description.as_deref().unwrap_or("").contains("42"));
+        assert!(
+            history[0]
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .contains("42")
+        );
     }
 
     #[tokio::test]
@@ -519,11 +525,13 @@ mod tests {
             .unwrap();
         let history = logger.db.list_vm_history(10).await.unwrap();
         assert_eq!(history[0].action_type.to_string(), "deleted");
-        assert!(history[0]
-            .description
-            .as_deref()
-            .unwrap_or("")
-            .contains("test reason"));
+        assert!(
+            history[0]
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .contains("test reason")
+        );
     }
 
     #[tokio::test]
@@ -568,16 +576,26 @@ mod tests {
         let old = chrono::Utc::now();
         let new = old + chrono::TimeDelta::days(7);
         logger
-            .log_vm_extended(14, Some(99), old, new, 7, Some("admin gift".to_string()), None)
+            .log_vm_extended(
+                14,
+                Some(99),
+                old,
+                new,
+                7,
+                Some("admin gift".to_string()),
+                None,
+            )
             .await
             .unwrap();
         let history = logger.db.list_vm_history(14).await.unwrap();
         assert_eq!(history[0].action_type.to_string(), "renewed");
-        assert!(history[0]
-            .description
-            .as_deref()
-            .unwrap_or("")
-            .contains("admin gift"));
+        assert!(
+            history[0]
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .contains("admin gift")
+        );
         let meta: serde_json::Value =
             serde_json::from_slice(history[0].metadata.as_ref().unwrap()).unwrap();
         assert_eq!(meta["days_extended"], 7);

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -1,6 +1,6 @@
 use crate::comma_separated::CommaSeparated;
 use crate::encrypted_string::EncryptedString;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Type};

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -93,14 +93,12 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn get_user_by_email_verify_token(&self, token: &str) -> DbResult<User> {
-        Ok(
-            sqlx::query_as(
-                "select * from users where email_verify_token = ? and email_verify_token != ''",
-            )
-            .bind(token)
-            .fetch_one(&self.db)
-            .await?,
+        Ok(sqlx::query_as(
+            "select * from users where email_verify_token = ? and email_verify_token != ''",
         )
+        .bind(token)
+        .fetch_one(&self.db)
+        .await?)
     }
 
     async fn list_users(&self) -> DbResult<Vec<User>> {
@@ -793,11 +791,13 @@ impl LNVpsDbBase for LNVpsDbMysql {
 
         let mut tx = self.db.begin().await?;
 
-        sqlx::query("update vm_payment set is_paid = true, external_data = ?, paid_at = NOW() where id = ?")
-            .bind(&vm_payment.external_data)
-            .bind(&vm_payment.id)
-            .execute(&mut *tx)
-            .await?;
+        sqlx::query(
+            "update vm_payment set is_paid = true, external_data = ?, paid_at = NOW() where id = ?",
+        )
+        .bind(&vm_payment.external_data)
+        .bind(&vm_payment.id)
+        .execute(&mut *tx)
+        .await?;
 
         sqlx::query("update vm set expires = TIMESTAMPADD(SECOND, ?, expires) where id = ?")
             .bind(vm_payment.time_value)
@@ -827,12 +827,10 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn get_custom_pricing(&self, id: u64) -> DbResult<VmCustomPricing> {
-        Ok(
-            sqlx::query_as("select * from vm_custom_pricing where id=?")
-                .bind(id)
-                .fetch_one(&self.db)
-                .await?,
-        )
+        Ok(sqlx::query_as("select * from vm_custom_pricing where id=?")
+            .bind(id)
+            .fetch_one(&self.db)
+            .await?)
     }
 
     async fn get_custom_vm_template(&self, id: u64) -> DbResult<VmCustomTemplate> {
@@ -1883,14 +1881,12 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn update_referral(&self, referral: &Referral) -> DbResult<()> {
-        sqlx::query(
-            "UPDATE referral SET lightning_address = ?, use_nwc = ? WHERE id = ?",
-        )
-        .bind(&referral.lightning_address)
-        .bind(referral.use_nwc)
-        .bind(referral.id)
-        .execute(&self.db)
-        .await?;
+        sqlx::query("UPDATE referral SET lightning_address = ?, use_nwc = ? WHERE id = ?")
+            .bind(&referral.lightning_address)
+            .bind(referral.use_nwc)
+            .bind(referral.id)
+            .execute(&self.db)
+            .await?;
         Ok(())
     }
 
@@ -1918,12 +1914,12 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn list_referral_payouts(&self, referral_id: u64) -> DbResult<Vec<ReferralPayout>> {
-        Ok(
-            sqlx::query_as("SELECT * FROM referral_payout WHERE referral_id = ? ORDER BY created DESC")
-                .bind(referral_id)
-                .fetch_all(&self.db)
-                .await?,
+        Ok(sqlx::query_as(
+            "SELECT * FROM referral_payout WHERE referral_id = ? ORDER BY created DESC",
         )
+        .bind(referral_id)
+        .fetch_all(&self.db)
+        .await?)
     }
 
     async fn list_referral_usage(&self, code: &str) -> DbResult<Vec<ReferralCostUsage>> {
@@ -2857,44 +2853,44 @@ impl AdminDb for LNVpsDbMysql {
         Ok((hosts, total as u64))
     }
 
-     async fn insert_custom_pricing(&self, pricing: &VmCustomPricing) -> DbResult<u64> {
-         let query = r#"
+    async fn insert_custom_pricing(&self, pricing: &VmCustomPricing) -> DbResult<u64> {
+        let query = r#"
              INSERT INTO vm_custom_pricing (name, enabled, created, expires, region_id, currency, cpu_mfg, cpu_arch, cpu_features, cpu_cost, memory_cost, ip4_cost, ip6_cost, min_cpu, max_cpu, min_memory, max_memory, disk_iops_read, disk_iops_write, disk_mbps_read, disk_mbps_write, network_mbps, cpu_limit)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          "#;
 
-         let result = sqlx::query(query)
-             .bind(&pricing.name)
-             .bind(pricing.enabled)
-             .bind(pricing.created)
-             .bind(pricing.expires)
-             .bind(pricing.region_id)
-             .bind(&pricing.currency)
-             .bind(&pricing.cpu_mfg)
-             .bind(&pricing.cpu_arch)
-             .bind(&pricing.cpu_features)
-             .bind(pricing.cpu_cost)
-             .bind(pricing.memory_cost)
-             .bind(pricing.ip4_cost)
-             .bind(pricing.ip6_cost)
-             .bind(pricing.min_cpu)
-             .bind(pricing.max_cpu)
-             .bind(pricing.min_memory)
-             .bind(pricing.max_memory)
-             .bind(pricing.disk_iops_read)
-             .bind(pricing.disk_iops_write)
-             .bind(pricing.disk_mbps_read)
-             .bind(pricing.disk_mbps_write)
-             .bind(pricing.network_mbps)
-             .bind(pricing.cpu_limit)
-             .execute(&self.db)
-             .await?;
+        let result = sqlx::query(query)
+            .bind(&pricing.name)
+            .bind(pricing.enabled)
+            .bind(pricing.created)
+            .bind(pricing.expires)
+            .bind(pricing.region_id)
+            .bind(&pricing.currency)
+            .bind(&pricing.cpu_mfg)
+            .bind(&pricing.cpu_arch)
+            .bind(&pricing.cpu_features)
+            .bind(pricing.cpu_cost)
+            .bind(pricing.memory_cost)
+            .bind(pricing.ip4_cost)
+            .bind(pricing.ip6_cost)
+            .bind(pricing.min_cpu)
+            .bind(pricing.max_cpu)
+            .bind(pricing.min_memory)
+            .bind(pricing.max_memory)
+            .bind(pricing.disk_iops_read)
+            .bind(pricing.disk_iops_write)
+            .bind(pricing.disk_mbps_read)
+            .bind(pricing.disk_mbps_write)
+            .bind(pricing.network_mbps)
+            .bind(pricing.cpu_limit)
+            .execute(&self.db)
+            .await?;
 
         Ok(result.last_insert_id())
     }
 
-     async fn update_custom_pricing(&self, pricing: &VmCustomPricing) -> DbResult<()> {
-         let query = r#"
+    async fn update_custom_pricing(&self, pricing: &VmCustomPricing) -> DbResult<()> {
+        let query = r#"
              UPDATE vm_custom_pricing 
              SET name = ?, enabled = ?, expires = ?, region_id = ?, currency = ?, 
                  cpu_mfg = ?, cpu_arch = ?, cpu_features = ?, cpu_cost = ?, memory_cost = ?, ip4_cost = ?, ip6_cost = ?, 
@@ -2904,32 +2900,32 @@ impl AdminDb for LNVpsDbMysql {
              WHERE id = ?
          "#;
 
-         let result = sqlx::query(query)
-             .bind(&pricing.name)
-             .bind(pricing.enabled)
-             .bind(pricing.expires)
-             .bind(pricing.region_id)
-             .bind(&pricing.currency)
-             .bind(&pricing.cpu_mfg)
-             .bind(&pricing.cpu_arch)
-             .bind(&pricing.cpu_features)
-             .bind(pricing.cpu_cost)
-             .bind(pricing.memory_cost)
-             .bind(pricing.ip4_cost)
-             .bind(pricing.ip6_cost)
-             .bind(pricing.min_cpu)
-             .bind(pricing.max_cpu)
-             .bind(pricing.min_memory)
-             .bind(pricing.max_memory)
-             .bind(pricing.disk_iops_read)
-             .bind(pricing.disk_iops_write)
-             .bind(pricing.disk_mbps_read)
-             .bind(pricing.disk_mbps_write)
-             .bind(pricing.network_mbps)
-             .bind(pricing.cpu_limit)
-             .bind(pricing.id)
-             .execute(&self.db)
-             .await?;
+        let result = sqlx::query(query)
+            .bind(&pricing.name)
+            .bind(pricing.enabled)
+            .bind(pricing.expires)
+            .bind(pricing.region_id)
+            .bind(&pricing.currency)
+            .bind(&pricing.cpu_mfg)
+            .bind(&pricing.cpu_arch)
+            .bind(&pricing.cpu_features)
+            .bind(pricing.cpu_cost)
+            .bind(pricing.memory_cost)
+            .bind(pricing.ip4_cost)
+            .bind(pricing.ip6_cost)
+            .bind(pricing.min_cpu)
+            .bind(pricing.max_cpu)
+            .bind(pricing.min_memory)
+            .bind(pricing.max_memory)
+            .bind(pricing.disk_iops_read)
+            .bind(pricing.disk_iops_write)
+            .bind(pricing.disk_mbps_read)
+            .bind(pricing.disk_mbps_write)
+            .bind(pricing.network_mbps)
+            .bind(pricing.cpu_limit)
+            .bind(pricing.id)
+            .execute(&self.db)
+            .await?;
 
         if result.rows_affected() == 0 {
             return Err(DbError::Source(


### PR DESCRIPTION
## Summary

- After the Proxmox stop task completes, the VM process may still be shutting down; unlinking the primary disk at that point left it as an unattached (orphaned) volume instead of deleting it
- Added `wait_for_vm_stopped()` to `ProxmoxClient` which polls `get_vm_status` until the VM reaches `Stopped` state (2-minute timeout with 2-second intervals)
- Updated `stop_vm` trait implementation to call `wait_for_vm_stopped` after `wait_for_task`, ensuring the disk is fully free before the unlink step runs during reinstall

## Regression test

Added `test_reinstall_unlink_only_called_after_vm_stopped` in `mocks.rs` which verifies that after `stop_vm` returns, the VM is in `Stopped` state before `unlink_primary_disk` is called.

Fixes #94