### PR TITLE
fix: remove ssh_genkeytypes from cloud-init vendor snippet

### DIFF
--- a/lnvps_api/src/host/proxmox.rs
+++ b/lnvps_api/src/host/proxmox.rs
@@ -340,7 +340,7 @@ impl ProxmoxClient {
         };
 
         let snippet_filename = "lnvps-vendor.yaml";
-        let snippet_content = "#cloud-config\nssh_deletekeys: false\nssh_genkeytypes: []\n";
+        let snippet_content = "#cloud-config\nssh_deletekeys: false\n";
 
         // Snippet storage path depends on the storage type; for the default
         // `local` storage this is `/var/lib/vz/snippets/`.  For other directory-


### PR DESCRIPTION
## Summary

- Remove `ssh_genkeytypes: []` from the cloud-init vendor-data snippet, which was preventing SSH host key generation on first boot
- Keep `ssh_deletekeys: false` to preserve existing host keys on cloud-init reconfiguration

## Root Cause

The vendor snippet introduced in #98 included `ssh_genkeytypes: []`, which tells cloud-init to generate zero host key types. This applies on first boot too, so new VMs never got any SSH host keys generated. The snippet only needs `ssh_deletekeys: false` — cloud-init already skips key generation for types that already exist on disk, so reconfiguration won't cause host-key mismatch warnings.