### PR TITLE
chore: prepare v0.3.0 release notes and docs

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -61,6 +61,20 @@ Query Parameters:
 
 Required Permission: `users::view`
 
+#### Find User by Email
+
+```
+GET /api/admin/v1/users/by-email?email={email}
+```
+
+Query Parameters:
+
+- `email`: string (required) - the user's email address (case-insensitive; matched via an indexed SHA-256 hash)
+
+Required Permission: `users::view`
+
+Returns the matching `AdminUserInfo`, or a `"User not found"` error if no user has that email.
+
 #### Get User Details
 
 ```

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [v0.3.0] - 2026-06-17
+
+### Added
+
+- **2026-06-15** - `GET /api/admin/v1/users/by-email` — find a user by email address
+  - Looks up a user via an indexed SHA-256 hash of the (lowercased, trimmed) email and returns the full `AdminUserInfo`, or a `"User not found"` error if no match.
+  - Query parameter: `email` (required). Requires the `users::view` permission.
+  - Backed by a new `email_hash` column on the users table, backfilled for existing users at startup.
+
+- **2026-04-03** - LNURL-pay endpoints for VM renewal restored
+  - `GET /.well-known/lnurlp/{id}` — LNURL PayResponse for a VM. These endpoints were lost during the Rocket→Axum migration and are now working again (the path-parameter syntax was corrected for Axum).
+  - `GET /api/v1/vm/{id}/renew-lnurlp?amount={millisats}` — returns an invoice to extend the VM via LNURL pay.
+
+### Changed
+
+- **2026-04-03** - Unpaid VMs with a non-expired pending payment are no longer auto-deleted
+  - The worker cleanup loop now skips deletion of unpaid VMs that still have a pending (non-expired) payment, giving slower payment methods (e.g. Revolut) time to settle before the VM is removed.
+
+### Fixed
+
+- **2026-06-16** - VM→subscription backfill now runs reliably at startup
+  - The backfill is executed during app startup, after schema migrations and before any VM read, and preserves each VM's existing expiry and auto-renewal preference. The legacy `vm.expires` / `vm.created` columns are no longer dropped before the backfill runs, which previously caused the backfill to fail for every VM and break all VM reads. (No external API surface change — listed for operator awareness.)
+
+- **2026-04-26** - Region capacity no longer reports IP ranges as full incorrectly
+  - `GET /api/v1/vm/templates` and region availability — the gateway IP is now only counted as a used address when it actually falls within the allocation CIDR. Previously a gateway outside the range inflated the used-IP count and could falsely report a region/range as full while free IPs remained.
+
+- **2026-04-02** - Payments for already-deleted VMs are handled gracefully
+  - `POST /api/v1/vm/{id}/renew` and payment confirmation — a payment that arrives for a VM auto-deleted before the (slow) payment settled now un-deletes the VM and applies the payment instead of erroring; the VM is then re-provisioned by the next check. Renewal/invoice creation for VMs that remain deleted is rejected with `"VM not found"`.
+  - A race where a VM paid between the cleanup snapshot and the deletion step could be deleted is fixed by re-reading VM state immediately before deletion.
+
 ### Added
 
 - **2026-03-10** - `"creating"` VM state for cleaner first-provision UX (closes #119)

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -19,8 +19,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `GET /.well-known/lnurlp/{id}` — LNURL PayResponse for a VM. These endpoints were lost during the Rocket→Axum migration and are now working again (the path-parameter syntax was corrected for Axum).
   - `GET /api/v1/vm/{id}/renew-lnurlp?amount={millisats}` — returns an invoice to extend the VM via LNURL pay.
 
+- **2026-02-25** - Resource limits on custom pricing plans, propagated to custom templates
+  - `POST /api/admin/v1/custom_pricing` — Accepts new optional fields: `disk_iops_read`, `disk_iops_write`, `disk_mbps_read`, `disk_mbps_write`, `network_mbps`, `cpu_limit`
+  - `PATCH /api/admin/v1/custom_pricing/{id}` — Accepts the same limit fields; send `null` to remove a limit
+  - `GET /api/admin/v1/custom_pricing` / `GET /api/admin/v1/custom_pricing/{id}` — Response now includes limit fields (omitted when uncapped)
+  - Limits are copied from the pricing plan into each `VmCustomTemplate` at VM provisioning time (new VMs and template upgrades)
+  - `None` / omitted = uncapped
+- **2026-02-25** - Template resource limits for fair-use and SLA enforcement (closes #26)
+  - `POST /api/admin/v1/vm_templates` — Accepts new optional fields: `disk_iops_read`, `disk_iops_write`, `disk_mbps_read`, `disk_mbps_write`, `network_mbps`, `cpu_limit`
+  - `PATCH /api/admin/v1/vm_templates/{id}` — Accepts the same limit fields; send `null` to remove a limit
+  - `GET /api/admin/v1/vm_templates` / `GET /api/admin/v1/vm_templates/{id}` — Response now includes limit fields (omitted when uncapped)
+  - Limits are applied at VM create time and on any VM configure/upgrade:
+    - **Disk IO**: `mbps_rd`/`mbps_wr`/`iops_rd`/`iops_wr` on the primary disk via Proxmox API
+    - **Network bandwidth**: `rate=N` on `net0` interface
+    - **CPU limit**: `cpulimit` VM config option (fraction of allocated cores)
+  - `None` / omitted = uncapped (preserves existing behaviour for all current VMs)
+- **2026-02-24** - Cloud image checksum verification and on-demand download (closes #69)
+  - `POST /api/admin/v1/vm_os_images/{id}/download` — Enqueue an immediate download/re-check of an OS image on all hosts (requires `vm_os_image::update`)
+  - `PATCH /api/admin/v1/vm_os_images/{id}` — Now correctly applies `sha2` and `sha2_url` updates
+  - Worker: `DownloadOsImages` job fetches `sha2_url`, compares checksum via SSH, and re-downloads stale images; checksum is also passed to Proxmox `download-url` API for in-flight verification
+- **2026-02-24** - Added `company_base_currency` field to `AdminVmPaymentInfo`
+  - `GET /api/admin/v1/vms/{id}/payments` — Response now includes `company_base_currency`
+  - `GET /api/admin/v1/vms/{id}/payments/{payment_id}` — Response now includes `company_base_currency`
+  - `POST /api/admin/v1/vms/{id}/payments/{payment_id}/complete` — Response now includes `company_base_currency`
+- **2026-02-23** - Sponsoring LIR Agreement generation (User API)
+  - `GET /api/v1/legal/sponsoring-lir-agreement?data={base64url_json}` — Renders an unsigned LIR agreement HTML document from base64url-encoded JSON agreement data. Rejects data that carries a cryptographic proof.
+  - `GET /api/v1/legal/sponsoring-lir-agreement/from-subscription/{subscription_id}` (NIP-98 auth) — Generates a cryptographically signed LIR agreement for one of the caller's own subscriptions, populating provider/end-user details from company and billing data. Returns a `SignedAgreementUrlResponse`.
+- **2026-02-23** - Admin endpoints to manually complete payments
+  - `POST /api/admin/v1/vms/{id}/payments/{payment_id}/complete` — Mark a VM payment as paid, extend VM expiry, and dispatch provisioning (requires `payments::update`)
+  - `POST /api/admin/v1/subscription_payments/{id}/complete` — Mark a subscription payment as paid, extend subscription by 30 days, and activate it (requires `subscription_payments::update`)
+
 ### Changed
 
+- **2026-02-25** - Email verification is now required before creating a VM (closes #92)
+  - `POST /api/v1/vm` — Returns `400` with error message if the user's email is not verified
+  - `POST /api/v1/vm/custom-template` — Same gate applied
 - **2026-04-03** - Unpaid VMs with a non-expired pending payment are no longer auto-deleted
   - The worker cleanup loop now skips deletion of unpaid VMs that still have a pending (non-expired) payment, giving slower payment methods (e.g. Revolut) time to settle before the VM is removed.
 
@@ -35,6 +68,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **2026-04-02** - Payments for already-deleted VMs are handled gracefully
   - `POST /api/v1/vm/{id}/renew` and payment confirmation — a payment that arrives for a VM auto-deleted before the (slow) payment settled now un-deletes the VM and applies the payment instead of erroring; the VM is then re-provisioned by the next check. Renewal/invoice creation for VMs that remain deleted is rejected with `"VM not found"`.
   - A race where a VM paid between the cleanup snapshot and the deletion step could be deleted is fixed by re-reading VM state immediately before deletion.
+
+- **2026-02-23** - Fixed inability to unset `cpu_mfg`, `cpu_arch`, `cpu_features` fields via PATCH endpoints
+  - `PATCH /api/admin/v1/vm_templates/{id}` — Now supports setting `cpu_mfg`, `cpu_arch`, `cpu_features` to `null` to clear values
+  - `PATCH /api/admin/v1/custom_pricing/{id}` — Now supports setting `cpu_mfg`, `cpu_arch`, `cpu_features` to `null` to clear values
+  - `PATCH /api/admin/v1/hosts/{id}` — Now supports setting `cpu_mfg`, `cpu_arch`, `cpu_features` to `null` to clear values
+  - Previously, sending `null` for these fields was treated the same as omitting them (no change)
 
 ### Added
 
@@ -141,46 +180,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `POST /api/admin/v1/vms/{id}/renew` — Same `intervals` support in admin renewal endpoint
 
 ## [v0.2.0] - 2026-02-22
-
-### Changed
-- **2026-02-25** - Email verification is now required before creating a VM (closes #92)
-  - `POST /api/v1/vm` — Returns `400` with error message if the user's email is not verified
-  - `POST /api/v1/vm/custom-template` — Same gate applied
-
-### Added
-- **2026-02-25** - Resource limits on custom pricing plans, propagated to custom templates
-  - `POST /api/admin/v1/custom_pricing` — Accepts new optional fields: `disk_iops_read`, `disk_iops_write`, `disk_mbps_read`, `disk_mbps_write`, `network_mbps`, `cpu_limit`
-  - `PATCH /api/admin/v1/custom_pricing/{id}` — Accepts the same limit fields; send `null` to remove a limit
-  - `GET /api/admin/v1/custom_pricing` / `GET /api/admin/v1/custom_pricing/{id}` — Response now includes limit fields (omitted when uncapped)
-  - Limits are copied from the pricing plan into each `VmCustomTemplate` at VM provisioning time (new VMs and template upgrades)
-  - `None` / omitted = uncapped
-- **2026-02-25** - Template resource limits for fair-use and SLA enforcement (closes #26)
-  - `POST /api/admin/v1/vm_templates` — Accepts new optional fields: `disk_iops_read`, `disk_iops_write`, `disk_mbps_read`, `disk_mbps_write`, `network_mbps`, `cpu_limit`
-  - `PATCH /api/admin/v1/vm_templates/{id}` — Accepts the same limit fields; send `null` to remove a limit
-  - `GET /api/admin/v1/vm_templates` / `GET /api/admin/v1/vm_templates/{id}` — Response now includes limit fields (omitted when uncapped)
-  - Limits are applied at VM create time and on any VM configure/upgrade:
-    - **Disk IO**: `mbps_rd`/`mbps_wr`/`iops_rd`/`iops_wr` on the primary disk via Proxmox API
-    - **Network bandwidth**: `rate=N` on `net0` interface
-    - **CPU limit**: `cpulimit` VM config option (fraction of allocated cores)
-  - `None` / omitted = uncapped (preserves existing behaviour for all current VMs)
-- **2026-02-24** - Cloud image checksum verification and on-demand download (closes #69)
-  - `POST /api/admin/v1/vm_os_images/{id}/download` — Enqueue an immediate download/re-check of an OS image on all hosts (requires `vm_os_image::update`)
-  - `PATCH /api/admin/v1/vm_os_images/{id}` — Now correctly applies `sha2` and `sha2_url` updates
-  - Worker: `DownloadOsImages` job fetches `sha2_url`, compares checksum via SSH, and re-downloads stale images; checksum is also passed to Proxmox `download-url` API for in-flight verification
-- **2026-02-24** - Added `company_base_currency` field to `AdminVmPaymentInfo`
-  - `GET /api/admin/v1/vms/{id}/payments` — Response now includes `company_base_currency`
-  - `GET /api/admin/v1/vms/{id}/payments/{payment_id}` — Response now includes `company_base_currency`
-  - `POST /api/admin/v1/vms/{id}/payments/{payment_id}/complete` — Response now includes `company_base_currency`
-- **2026-02-23** - Admin endpoints to manually complete payments
-  - `POST /api/admin/v1/vms/{id}/payments/{payment_id}/complete` — Mark a VM payment as paid, extend VM expiry, and dispatch provisioning (requires `payments::update`)
-  - `POST /api/admin/v1/subscription_payments/{id}/complete` — Mark a subscription payment as paid, extend subscription by 30 days, and activate it (requires `subscription_payments::update`)
-
-### Fixed
-- **2026-02-23** - Fixed inability to unset `cpu_mfg`, `cpu_arch`, `cpu_features` fields via PATCH endpoints
-  - `PATCH /api/admin/v1/vm_templates/{id}` — Now supports setting `cpu_mfg`, `cpu_arch`, `cpu_features` to `null` to clear values
-  - `PATCH /api/admin/v1/custom_pricing/{id}` — Now supports setting `cpu_mfg`, `cpu_arch`, `cpu_features` to `null` to clear values
-  - `PATCH /api/admin/v1/hosts/{id}` — Now supports setting `cpu_mfg`, `cpu_arch`, `cpu_features` to `null` to clear values
-  - Previously, sending `null` for these fields was treated the same as omitting them (no change)
 
 ### Changed
 - **2026-02-22** - Reduced unpaid VM deletion time from 24 hours to 1 hour

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -760,6 +760,21 @@ interface ReferralState extends Referral {
   - `amount`: Amount in millisatoshis (minimum 1000)
 - **Response**: Lightning Network invoice
 
+### Legal Documents
+
+#### Generate Unsigned Sponsoring LIR Agreement
+- **GET** `/api/v1/legal/sponsoring-lir-agreement?data={base64url_json}`
+- **Auth**: None
+- **Query Params**:
+  - `data`: base64url-encoded JSON of the agreement data
+- **Response**: Rendered HTML agreement document
+- **Notes**: Rejects data that includes a cryptographic proof (use the signed endpoint for that)
+
+#### Generate Signed Sponsoring LIR Agreement from Subscription
+- **GET** `/api/v1/legal/sponsoring-lir-agreement/from-subscription/{subscription_id}`
+- **Auth**: NIP-98
+- **Response**: `SignedAgreementUrlResponse` — a cryptographically signed LIR agreement for one of the caller's own subscriptions. Provider/end-user details are populated from company and user billing data. Returns an error if the subscription does not belong to the caller.
+
 ## Error Handling
 
 All endpoints return errors in the following format:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_agent"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_api_admin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_api_common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_db"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_e2e"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_health"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_nostr"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_operator"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5505,7 +5505,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "try-procedure"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "log 0.4.29",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ A Bitcoin-powered VPS platform. Customers pay with Bitcoin Lightning (or optiona
   - NIP-05 identity server (`lnvps_nostr`)
   - NIP-47 Nostr Wallet Connect for auto-renewal
   - NIP-90 Data Vending Machine (DVM) for provisioning via Nostr
+- **AI support agent** (`lnvps_agent`)
+  - Handles customer support requests with an OpenAI-compatible LLM and API-calling tools
+  - Email channel (IMAP IDLE inbox watching + SMTP replies) and Nostr kind-1 mention channel
 - **Security**
   - XDP eBPF SYN-flood rate limiter (`lnvps_ebpf` + `lnvps_fw_service`)
   - Database field-level AES-GCM encryption for sensitive columns
@@ -47,8 +50,11 @@ A Bitcoin-powered VPS platform. Customers pay with Bitcoin Lightning (or optiona
 | `lnvps_api_common` | — | Shared types, pricing engine, exchange rates, Redis queue, NIP-98 auth |
 | `lnvps_db` | — | Database abstraction (MySQL/SQLx), migrations, field-level encryption |
 | `lnvps_nostr` | `lnvps_nostr` | Standalone NIP-05 identity server (`/.well-known/nostr.json`) |
+| `lnvps_agent` | `lnvps_agent` | AI support agent — answers support requests via email (IMAP/SMTP) and Nostr kind-1 mentions using an OpenAI-compatible LLM with API-calling tools |
 | `lnvps_operator` | `lnvps_operator` | Kubernetes operator — reconciles Nostr domain Ingress objects |
 | `lnvps_health` | `lnvps_health` | Network health monitor — TCP MSS/PMTU checks, DNS, Prometheus metrics |
+| `lnvps_host_util` | — | Host-side helper utilities packaged for isolated Docker builds |
+| `lnvps_e2e` | — | End-to-end integration test suite (spins up API + worker against a real DB/LND) |
 | `lnvps_ebpf` | — | XDP eBPF SYN-flood rate limiter (kernel program) |
 | `lnvps_fw_service` | `lnvps_fw_service` | Userspace loader for the eBPF firewall |
 
@@ -58,6 +64,7 @@ A Bitcoin-powered VPS platform. Customers pay with Bitcoin Lightning (or optiona
 cargo build --release -p lnvps_api
 cargo build --release -p lnvps_api_admin
 cargo build --release -p lnvps_nostr
+cargo build --release -p lnvps_agent
 cargo build --release -p lnvps_operator
 cargo build --release -p lnvps_health
 ```
@@ -301,4 +308,45 @@ mss-checks:
 ```bash
 ./lnvps_health --config config.yaml         # run continuously
 ./lnvps_health --config config.yaml --once  # run once and exit
+```
+
+---
+
+### `lnvps_agent` config
+
+AI support agent. Watches an email inbox (IMAP IDLE) and/or Nostr kind-1 mentions, and answers
+support requests using an OpenAI-compatible LLM with tools that call the LNVPS APIs. Config path is
+passed via the `LNVPS_AGENT_CONFIG` environment variable; all keys can also be overridden with
+`LNVPS_AGENT__*` environment variables.
+
+```yaml
+listen: "0.0.0.0:8080"                       # agent HTTP server (default)
+admin-api-url: "https://api.example.com"     # LNVPS admin API base URL (required)
+user-api-url: "https://api.example.com"      # LNVPS user API base URL (required)
+nsec: "nsec1234xxx"                           # signs NIP-98 auth events / Nostr ops (required)
+system-prompt: "You are LNVPS support..."    # optional system prompt override
+conversation-history-path: "/var/lib/lnvps-agent"  # optional history store dir
+
+openai:                                       # OpenAI-compatible LLM (required)
+  base-url: "http://localhost:11434/v1"      # e.g. Ollama, or https://api.openai.com/v1
+  api-key: "sk-..."                          # optional (not needed for Ollama)
+  model: "gpt-4o"
+  max-tokens: 2048
+
+email:                                        # email channel (optional)
+  imap-server: "imap.gmail.com:993"
+  imap-username: "support@example.com"
+  imap-password: "app-password"
+  imap-mailbox: "INBOX"                       # optional
+  smtp-server: "smtp.gmail.com:587"
+  smtp-username: "support@example.com"
+  smtp-password: "app-password"
+  smtp-from: "support@example.com"
+  smtp-from-name: "LNVPS Support"            # optional
+
+kind1:                                        # Nostr kind-1 mention channel (optional)
+  relays:
+    - "wss://relay.damus.io"
+  mention-pubkeys: []                          # hex pubkeys to watch; defaults to the bot's own
+  poll-interval-secs: 30
 ```

--- a/lnvps_api/src/data_migration/vm_subscription_backfill.rs
+++ b/lnvps_api/src/data_migration/vm_subscription_backfill.rs
@@ -14,7 +14,7 @@
 //!
 //! Both phases are idempotent: VMs already linked and payments already copied are skipped.
 use anyhow::{Context, Result, bail};
-use chrono::Utc;
+use lnvps_api_common::PricingEngine;
 use lnvps_db::{
     IntervalType, LNVpsDb, LNVpsDbMysql, Subscription, SubscriptionLineItem,
     SubscriptionPaymentType, SubscriptionType, VmForMigration, VmPaymentRaw,
@@ -32,9 +32,91 @@ fn interval_to_seconds(interval_type: IntervalType, interval_amount: u64) -> i64
     base * interval_amount as i64
 }
 
+/// Billing details resolved for a VM from its template or custom pricing.
+struct VmBilling {
+    currency: String,
+    interval_amount: u64,
+    interval_type: IntervalType,
+    line_item_amount: u64,
+    description: String,
+}
+
+/// Resolve a VM's billing details (currency, interval, recurring amount, description) so they
+/// match what the live provisioning paths set, ensuring the admin UI shows the correct cost:
+///   - standard template: subscription.currency = cost_plan.currency, amount = cost_plan.amount
+///   - custom template:   subscription.currency = pricing.currency,   amount = computed cost
+///
+/// Shared by the initial backfill and the one-time repair pass so both produce identical values.
+async fn resolve_vm_billing(db: &Arc<dyn LNVpsDb>, vm: &VmForMigration) -> Result<VmBilling> {
+    if let Some(template_id) = vm.template_id {
+        let template = db
+            .get_vm_template(template_id)
+            .await
+            .context("Failed to get VM template")?;
+        let cost_plan = db
+            .get_cost_plan(template.cost_plan_id)
+            .await
+            .context("Failed to get cost plan")?;
+        Ok(VmBilling {
+            currency: cost_plan.currency,
+            interval_amount: cost_plan.interval_amount,
+            interval_type: cost_plan.interval_type,
+            line_item_amount: cost_plan.amount,
+            description: format!("{} (VM {})", template.name, vm.id),
+        })
+    } else if let Some(custom_template_id) = vm.custom_template_id {
+        // Custom VMs are always billed monthly; the amount is computed from the custom
+        // pricing (CPU/memory/disk/IPs) just like update_line_item_cost_for_custom_vm.
+        let custom_template = db
+            .get_custom_vm_template(custom_template_id)
+            .await
+            .context("Failed to get custom VM template")?;
+        let price = PricingEngine::get_custom_vm_cost_amount(db, vm.id, &custom_template)
+            .await
+            .context("Failed to compute custom VM cost")?;
+        Ok(VmBilling {
+            currency: price.currency.to_string(),
+            interval_amount: 1,
+            interval_type: IntervalType::Month,
+            line_item_amount: price.total(),
+            description: format!("Custom VM {}", vm.id),
+        })
+    } else {
+        bail!(
+            "VM {} has neither template_id nor custom_template_id",
+            vm.id
+        );
+    }
+}
+
 /// Run the VM → subscription backfill. Safe to call on every startup (idempotent).
 pub async fn run_vm_subscription_backfill(db_impl: Arc<LNVpsDbMysql>) -> Result<()> {
     let db: Arc<dyn LNVpsDb> = db_impl.clone();
+
+    // Phase 0: repair subscriptions written by earlier (buggy) backfill revisions.
+    // Idempotent — performs no writes once every already-migrated row is correct.
+    let linked_vm_ids = db_impl
+        .list_vm_ids_with_subscription()
+        .await
+        .context("Failed to list VMs with subscription for repair")?;
+    let mut repaired = 0usize;
+    let mut repair_errored = 0usize;
+    for vm_id in &linked_vm_ids {
+        match repair_migrated_vm_subscription(db_impl.clone(), db.clone(), *vm_id).await {
+            Ok(true) => repaired += 1,
+            Ok(false) => {}
+            Err(e) => {
+                warn!("Phase 0: Failed to repair VM {}: {:#}", vm_id, e);
+                repair_errored += 1;
+            }
+        }
+    }
+    if repaired > 0 || repair_errored > 0 {
+        info!(
+            "VM subscription backfill — Phase 0 complete: {} subscriptions repaired, {} errors",
+            repaired, repair_errored
+        );
+    }
 
     // Phase 1: create subscriptions for all VMs (including deleted)
     let vm_ids = db_impl
@@ -86,7 +168,10 @@ pub async fn run_vm_subscription_backfill(db_impl: Arc<LNVpsDbMysql>) -> Result<
         match migrate_vm_payments(db_impl.clone(), db.clone(), *vm_id).await {
             Ok(n) => pay_migrated += n,
             Err(e) => {
-                warn!("Phase 2: Failed to migrate payments for VM {}: {:#}", vm_id, e);
+                warn!(
+                    "Phase 2: Failed to migrate payments for VM {}: {:#}",
+                    vm_id, e
+                );
                 pay_errored += 1;
             }
         }
@@ -98,9 +183,10 @@ pub async fn run_vm_subscription_backfill(db_impl: Arc<LNVpsDbMysql>) -> Result<
         );
     }
 
-    if sub_errored > 0 || pay_errored > 0 {
+    if repair_errored > 0 || sub_errored > 0 || pay_errored > 0 {
         bail!(
-            "VM subscription backfill incomplete: {} subscription errors, {} payment VM errors (see warnings above)",
+            "VM subscription backfill incomplete: {} repair errors, {} subscription errors, {} payment VM errors (see warnings above)",
+            repair_errored,
             sub_errored,
             pay_errored
         );
@@ -125,35 +211,15 @@ async fn migrate_vm_subscription(
         .get_vm_company_id(vm_id)
         .await
         .context("Failed to get company id for VM")?;
-    let company = db
-        .get_company(company_id)
-        .await
-        .context("Failed to get company")?;
-    let currency = company.base_currency.clone();
 
-    let (interval_amount, interval_type, line_item_amount, description) =
-        if let Some(template_id) = vm.template_id {
-            let template = db
-                .get_vm_template(template_id)
-                .await
-                .context("Failed to get VM template")?;
-            let cost_plan = db
-                .get_cost_plan(template.cost_plan_id)
-                .await
-                .context("Failed to get cost plan")?;
-            let desc = format!("{} (VM {})", template.name, vm_id);
-            (
-                cost_plan.interval_amount,
-                cost_plan.interval_type,
-                cost_plan.amount,
-                desc,
-            )
-        } else if vm.custom_template_id.is_some() {
-            let desc = format!("Custom VM {}", vm_id);
-            (1u64, IntervalType::Month, 0u64, desc)
-        } else {
-            bail!("VM {} has neither template_id nor custom_template_id", vm_id);
-        };
+    let billing = resolve_vm_billing(&db, &vm).await?;
+    let VmBilling {
+        currency,
+        interval_amount,
+        interval_type,
+        line_item_amount,
+        description,
+    } = billing;
 
     let time_value = interval_to_seconds(interval_type, interval_amount);
     info!(
@@ -170,29 +236,14 @@ async fn migrate_vm_subscription(
     );
 
     // Deleted VMs should have inactive subscriptions — they are no longer running.
-    let is_active = !vm.deleted;
-
-    let subscription = Subscription {
-        id: 0,
-        user_id: vm.user_id,
+    let subscription = build_subscription_for_vm(
+        &vm,
         company_id,
-        name: format!("VM {} Subscription", vm_id),
-        description: Some(description.clone()),
-        created: Utc::now(),
-        // Preserve the VM's existing billing expiry so renewal/suspension/auto-renewal
-        // enforcement continues seamlessly. The legacy vm.expires column is the source
-        // of truth pre-migration and is dropped only at finalization.
-        expires: Some(vm.expires),
-        is_active,
-        is_setup: true,
         currency,
         interval_amount,
         interval_type,
-        setup_fee: 0,
-        // Preserve the VM's auto-renewal preference so NWC auto-renewal keeps working.
-        auto_renewal_enabled: vm.auto_renewal_enabled,
-        external_id: None,
-    };
+        &description,
+    );
     let line_item = SubscriptionLineItem {
         id: 0,
         subscription_id: 0,
@@ -216,6 +267,149 @@ async fn migrate_vm_subscription(
         .context("Failed to link VM to subscription")?;
 
     Ok(())
+}
+
+/// Build the `Subscription` row for a VM during backfill.
+///
+/// Pure mapping (no DB access) so it can be unit-tested. The key invariants:
+/// - `created` is copied from the VM's original creation date (NOT `Utc::now()`), because the
+///   subscription is now the source of truth for the VM's "created" timestamp in the API.
+/// - `expires` and `auto_renewal_enabled` are copied from the VM so billing/renewal continue.
+/// - `is_setup` mirrors the legacy "has this VM ever been paid" signal: pre-migration, a
+///   never-paid VM had `expires == created` and `check_vms` deleted it after 1h. The new
+///   `check_vms` uses `subscription.is_setup` for that decision, so we must NOT blindly set
+///   `is_setup = true` — a VM that was still unpaid at migration time would then look paid and
+///   never be cleaned up. `expires > created` means at least one payment advanced the expiry.
+/// - Deleted VMs get an inactive subscription — they are no longer running.
+fn build_subscription_for_vm(
+    vm: &VmForMigration,
+    company_id: u64,
+    currency: String,
+    interval_amount: u64,
+    interval_type: IntervalType,
+    description: &str,
+) -> Subscription {
+    // A pre-migration VM was "set up" (paid at least once) iff its expiry was advanced past
+    // its creation time. Never-paid VMs had expires == created and must stay !is_setup so the
+    // worker's unpaid-VM cleanup continues to apply to them after migration.
+    let is_setup = vm.expires > vm.created;
+    Subscription {
+        id: 0,
+        user_id: vm.user_id,
+        company_id,
+        name: format!("VM {} Subscription", vm.id),
+        description: Some(description.to_string()),
+        // Preserve the VM's original creation date so the subscription (now the source of
+        // truth for the VM's "created" timestamp in the API) reflects when the VM was
+        // actually ordered, not when the migration ran.
+        created: vm.created,
+        // Preserve the VM's existing billing expiry so renewal/suspension/auto-renewal
+        // enforcement continues seamlessly. The legacy vm.expires column is the source of
+        // truth pre-migration and is dropped only at finalization.
+        expires: Some(vm.expires),
+        // An unpaid VM (never set up) must not be marked active.
+        is_active: !vm.deleted && is_setup,
+        is_setup,
+        currency,
+        interval_amount,
+        interval_type,
+        setup_fee: 0,
+        // Preserve the VM's auto-renewal preference so NWC auto-renewal keeps working.
+        auto_renewal_enabled: vm.auto_renewal_enabled,
+        external_id: None,
+    }
+}
+
+// ─── Phase 0: repair already-migrated subscriptions ──────────────────────────
+
+/// Repair subscriptions created by earlier (buggy) backfill revisions.
+///
+/// Earlier revisions wrote several fields incorrectly for already-linked VMs:
+///   - `subscription.created` was stamped with the migration time instead of `vm.created`
+///   - custom-VM line items got `amount = 0` (showing $0 in the admin UI)
+///   - `subscription.currency` used the company base currency instead of the cost-plan /
+///     pricing currency
+///   - `is_setup`/`is_active` were forced true even for never-paid VMs
+///
+/// This pass re-derives the correct values and updates the subscription + line item only when
+/// they actually differ. It is idempotent: once every row is correct it performs no writes.
+async fn repair_migrated_vm_subscription(
+    db_impl: Arc<LNVpsDbMysql>,
+    db: Arc<dyn LNVpsDb>,
+    vm_id: u64,
+) -> Result<bool> {
+    let vm: VmForMigration = db_impl
+        .get_vm_for_migration(vm_id)
+        .await
+        .context("Failed to get VM")?;
+
+    let line_item_id = match vm.subscription_line_item_id.filter(|&id| id != 0) {
+        Some(id) => id,
+        None => return Ok(false), // not migrated yet; Phase 1 will handle it
+    };
+
+    let mut subscription = db
+        .get_subscription_by_line_item_id(line_item_id)
+        .await
+        .context("Failed to get subscription for VM")?;
+    let mut line_item = db
+        .get_subscription_line_item(line_item_id)
+        .await
+        .context("Failed to get subscription line item")?;
+
+    let billing = resolve_vm_billing(&db, &vm).await?;
+    let is_setup = vm.expires > vm.created;
+    let want_created = vm.created;
+    let want_active = !vm.deleted && is_setup;
+
+    let mut changed = false;
+    if subscription.created != want_created {
+        subscription.created = want_created;
+        changed = true;
+    }
+    if subscription.currency != billing.currency {
+        subscription.currency = billing.currency.clone();
+        changed = true;
+    }
+    if subscription.interval_amount != billing.interval_amount {
+        subscription.interval_amount = billing.interval_amount;
+        changed = true;
+    }
+    if subscription.interval_type != billing.interval_type {
+        subscription.interval_type = billing.interval_type;
+        changed = true;
+    }
+    if subscription.is_setup != is_setup {
+        subscription.is_setup = is_setup;
+        changed = true;
+    }
+    if subscription.is_active != want_active {
+        subscription.is_active = want_active;
+        changed = true;
+    }
+
+    if changed {
+        db.update_subscription(&subscription)
+            .await
+            .context("Failed to update subscription during repair")?;
+    }
+
+    if line_item.amount != billing.line_item_amount {
+        line_item.amount = billing.line_item_amount;
+        db.update_subscription_line_item(&line_item)
+            .await
+            .context("Failed to update line item during repair")?;
+        changed = true;
+    }
+
+    if changed {
+        info!(
+            "Phase 0: repaired VM {} subscription (created={}, currency={}, amount={}, is_setup={})",
+            vm_id, want_created, billing.currency, billing.line_item_amount, is_setup
+        );
+    }
+
+    Ok(changed)
 }
 
 // ─── Phase 2: payment backfill ───────────────────────────────────────────────
@@ -304,4 +498,105 @@ async fn migrate_vm_payments(
     }
 
     Ok(copied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn vm_for_migration(created: chrono::DateTime<Utc>, deleted: bool) -> VmForMigration {
+        // Paid VM: expiry advanced well past creation.
+        vm_with_expires(
+            created,
+            Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap(),
+            deleted,
+        )
+    }
+
+    fn vm_with_expires(
+        created: chrono::DateTime<Utc>,
+        expires: chrono::DateTime<Utc>,
+        deleted: bool,
+    ) -> VmForMigration {
+        VmForMigration {
+            id: 42,
+            user_id: 7,
+            template_id: Some(1),
+            custom_template_id: None,
+            created,
+            expires,
+            auto_renewal_enabled: true,
+            subscription_line_item_id: None,
+            deleted,
+        }
+    }
+
+    /// Regression: the backfill must preserve the VM's original creation date on the
+    /// subscription, not stamp it with the migration time (was `Utc::now()`).
+    #[test]
+    fn build_subscription_preserves_vm_created() {
+        let vm_created = Utc.with_ymd_and_hms(2025, 1, 15, 12, 30, 0).unwrap();
+        let vm = vm_for_migration(vm_created, false);
+
+        let sub = build_subscription_for_vm(
+            &vm,
+            3,
+            "EUR".to_string(),
+            1,
+            IntervalType::Month,
+            "Test (VM 42)",
+        );
+
+        assert_eq!(
+            sub.created, vm_created,
+            "subscription.created must equal vm.created"
+        );
+        assert_ne!(sub.created, Utc::now());
+        // Other preserved fields
+        assert_eq!(sub.expires, Some(vm.expires));
+        assert_eq!(sub.auto_renewal_enabled, vm.auto_renewal_enabled);
+        assert_eq!(sub.user_id, vm.user_id);
+        assert_eq!(sub.company_id, 3);
+        assert_eq!(sub.currency, "EUR");
+        assert!(
+            sub.is_active,
+            "non-deleted VM must have an active subscription"
+        );
+        assert!(sub.is_setup);
+    }
+
+    /// Deleted VMs must map to inactive subscriptions.
+    #[test]
+    fn build_subscription_deleted_vm_is_inactive() {
+        let vm = vm_for_migration(Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(), true);
+        let sub = build_subscription_for_vm(&vm, 1, "USD".to_string(), 1, IntervalType::Month, "x");
+        assert!(
+            !sub.is_active,
+            "deleted VM must have an inactive subscription"
+        );
+    }
+
+    /// Regression: a VM that was still unpaid at migration time (legacy `expires == created`)
+    /// must NOT be marked `is_setup`/`is_active`, otherwise the worker's unpaid-VM cleanup
+    /// (which now keys off `subscription.is_setup`) would never delete it.
+    #[test]
+    fn build_subscription_unpaid_vm_is_not_setup() {
+        let t = Utc.with_ymd_and_hms(2026, 6, 17, 10, 0, 0).unwrap();
+        let vm = vm_with_expires(t, t, false); // expires == created => never paid
+        let sub = build_subscription_for_vm(&vm, 1, "EUR".to_string(), 1, IntervalType::Month, "x");
+        assert!(!sub.is_setup, "never-paid VM must not be is_setup");
+        assert!(!sub.is_active, "never-paid VM must not be active");
+    }
+
+    /// A paid VM (expiry advanced past creation) must be `is_setup` and active.
+    #[test]
+    fn build_subscription_paid_vm_is_setup() {
+        let created = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let expires = Utc.with_ymd_and_hms(2025, 2, 1, 0, 0, 0).unwrap();
+        let vm = vm_with_expires(created, expires, false);
+        let sub = build_subscription_for_vm(&vm, 1, "EUR".to_string(), 1, IntervalType::Month, "x");
+        assert!(sub.is_setup, "paid VM must be is_setup");
+        assert!(sub.is_active, "paid non-deleted VM must be active");
+    }
 }

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -733,7 +733,7 @@ pub enum NetworkAccessPolicy {
     StaticArp = 0,
 }
 
-#[derive(Clone, Copy, Debug, sqlx::Type, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum IntervalType {
     Day = 0,
@@ -933,6 +933,7 @@ pub struct VmForMigration {
     pub user_id: u64,
     pub template_id: Option<u64>,
     pub custom_template_id: Option<u64>,
+    pub created: DateTime<Utc>,
     pub expires: DateTime<Utc>,
     pub auto_renewal_enabled: bool,
     pub subscription_line_item_id: Option<u64>,

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -49,6 +49,19 @@ impl LNVpsDbMysql {
         Ok(rows.iter().map(|r| r.get::<u32, _>("id") as u64).collect())
     }
 
+    /// List ids of all VMs that already have a subscription linked. Used by the one-time
+    /// repair pass that corrects fields written incorrectly by earlier backfill revisions
+    /// (subscription.created/currency/is_setup and the custom-VM line-item amount).
+    pub async fn list_vm_ids_with_subscription(&self) -> DbResult<Vec<u64>> {
+        let rows = sqlx::query(
+            "SELECT id FROM vm \
+             WHERE subscription_line_item_id IS NOT NULL AND subscription_line_item_id != 0",
+        )
+        .fetch_all(&self.db)
+        .await?;
+        Ok(rows.iter().map(|r| r.get::<u32, _>("id") as u64).collect())
+    }
+
     /// Insert a subscription_payment row by copying a vm_payment row verbatim,
     /// writing external_data as raw bytes (no encrypt/decrypt round-trip).
     pub async fn insert_subscription_payment_raw(
@@ -153,7 +166,7 @@ impl LNVpsDbMysql {
     /// Used by the data migration tool where the column may still be NULL.
     pub async fn get_vm_for_migration(&self, vm_id: u64) -> DbResult<VmForMigration> {
         Ok(sqlx::query_as(
-            "SELECT id, user_id, template_id, custom_template_id, expires, \
+            "SELECT id, user_id, template_id, custom_template_id, created, expires, \
              auto_renewal_enabled, subscription_line_item_id, deleted \
              FROM vm WHERE id = ?",
         )


### PR DESCRIPTION
Prepares the v0.3.0 release metadata (no functional code changes).

- Bump workspace version 0.2.0 → 0.3.0
- Add `v0.3.0` changelog section covering changes merged since v0.2.0 that were not yet documented: `GET /api/admin/v1/users/by-email`, restored LNURLp endpoints, pending-payment auto-delete guard, startup VM→subscription backfill, gateway-outside-CIDR capacity fix, deleted-VM payment handling
- Document `GET /api/admin/v1/users/by-email` in ADMIN_API_ENDPOINTS.md

No tag is created yet — will tag after deploy/test verification.