### PR TITLE
fix(reinstall): remove redundant disk resize causing 500

### DIFF
--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -857,14 +857,12 @@ async fn v1_reinstall_vm(
         })
         .step("import_template_disk", |ctx| {
             Box::pin(async move {
+                // import_template_disk already imports AND resizes the primary
+                // disk to the template size; a separate resize step here would
+                // ask Proxmox to resize to the same size, which it rejects as a
+                // disallowed shrink and surfaces as a 500 (see issue #142).
                 info!("Importing template disk for VM {}", ctx.vm_id);
                 ctx.client.import_template_disk(&ctx.info).await
-            })
-        })
-        .step("resize_disk", |ctx| {
-            Box::pin(async move {
-                info!("Resizing disk for VM {}", ctx.vm_id);
-                ctx.client.resize_disk(&ctx.info).await
             })
         })
         .step("start_vm", |ctx| {


### PR DESCRIPTION
## Summary

`/api/v1/vm/{id}/re-install` returned `500 InternalServerError`.

## Root cause

The reinstall pipeline (introduced in "feat: pipeline reinstall") ran two disk steps:

1. `import_template_disk` — which already does `import_disk` **+** `resize_main_disk`, resizing the primary disk to the full template size.
2. A redundant `resize_disk` step — asking Proxmox to resize the disk to that **same** size.

Proxmox only permits growing a disk; resizing to a size that isn't strictly larger is rejected as a disallowed shrink, which surfaces as a generic 500. The original pre-pipeline `reinstall_vm` never had this extra resize, so this was a regression.

## Fix

Removed the redundant `resize_disk` step. The pipeline is now: stop → unlink → import+resize → start, matching the original behaviour.

Fixes #142