### PR TITLE
feat(firewall): basic per-VM firewall rules (#36)

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -14,9 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **2026-06-24** - Basic per-VM firewall rules (user API)
   - `GET /api/v1/vm/{id}/firewall` — list a VM's firewall rules (ordered by `priority`).
-  - `POST /api/v1/vm/{id}/firewall` — create a rule. Body: `{ priority?, direction: "inbound"|"outbound", protocol: "any"|"tcp"|"udp"|"icmp", action: "accept"|"drop", src_cidr?, dst_port_start?, dst_port_end?, enabled? }`. Returns the created `FirewallRule`. Enforces a per-VM rule limit (configurable per template, default 20) and validates `src_cidr` (CIDR) and the port range (1–65535, start ≤ end).
+  - `POST /api/v1/vm/{id}/firewall` — create a rule. Body: `{ priority?, direction: "inbound"|"outbound", protocol: "any"|"tcp"|"udp"|"icmp", action: "accept"|"drop"|"reject", src_cidr?, dst_port_start?, dst_port_end?, enabled? }`. Returns the created `FirewallRule`. Enforces a per-VM rule limit (configurable per template, default 20) and validates `src_cidr` (CIDR) and the port range (1–65535, start ≤ end).
   - `PATCH /api/v1/vm/{id}/firewall/{rule_id}` — update a rule; all fields optional. Send `src_cidr: null` / `dst_port_*: null` to clear a field to "any".
   - `DELETE /api/v1/vm/{id}/firewall/{rule_id}` — delete a rule.
+  - `GET /api/v1/vm/{id}/firewall/policy` — get the per-VM default firewall policy. Returns `{ policy_in, policy_out }` where each is `"accept"|"drop"|"reject"` or `null` (inherit the host default, i.e. allow-all).
+  - `PATCH /api/v1/vm/{id}/firewall/policy` — set the per-VM default inbound/outbound policy. Body: `{ policy_in?, policy_out? }`; omit a field to leave it unchanged, send `null` to reset it to the host default, or a value (`"accept"|"drop"|"reject"`) to set it explicitly.
   - Any change queues an asynchronous re-apply (`ApplyVmFirewall`) of the full ruleset on the host. Default policy remains allow-all inbound/outbound; host anti-spoof (IP filter) protection is always enforced regardless of user rules. Backend rule application on the host is implemented separately.
 
 - **2026-06-23** - Enable/disable a tunnel on a router (admin)

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **2026-06-24** - Basic per-VM firewall rules (user API)
+  - `GET /api/v1/vm/{id}/firewall` — list a VM's firewall rules (ordered by `priority`).
+  - `POST /api/v1/vm/{id}/firewall` — create a rule. Body: `{ priority?, direction: "inbound"|"outbound", protocol: "any"|"tcp"|"udp"|"icmp", action: "accept"|"drop", src_cidr?, dst_port_start?, dst_port_end?, enabled? }`. Returns the created `FirewallRule`. Enforces a per-VM rule limit (configurable per template, default 20) and validates `src_cidr` (CIDR) and the port range (1–65535, start ≤ end).
+  - `PATCH /api/v1/vm/{id}/firewall/{rule_id}` — update a rule; all fields optional. Send `src_cidr: null` / `dst_port_*: null` to clear a field to "any".
+  - `DELETE /api/v1/vm/{id}/firewall/{rule_id}` — delete a rule.
+  - Any change queues an asynchronous re-apply (`ApplyVmFirewall`) of the full ruleset on the host. Default policy remains allow-all inbound/outbound; host anti-spoof (IP filter) protection is always enforced regardless of user rules. Backend rule application on the host is implemented separately.
+
 - **2026-06-23** - Enable/disable a tunnel on a router (admin)
   - `POST /api/admin/v1/routers/{id}/tunnels/{name}/toggle` — enable or disable a tunnel interface. Body: `{ "enabled": boolean }`. Returns a `JobResponse` (`{ "job_id": string }`); applied asynchronously by the worker (Linux `ip link set <iface> up|down`, RouterOS `disabled` flag), which then refreshes the tunnel cache. Requires `router::update`.
 

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -517,10 +517,12 @@ console.log('Auto-renewal enabled:', vmStatus.data.auto_renewal_enabled);
 
 ### VM Firewall
 
-Basic per-VM firewall rules. User-defined ACCEPT/DROP rules are evaluated in
-`priority` order (lower first) before the default policy. The default policy is
-allow-all inbound and outbound (no change from prior behaviour). Anti-spoofing
-(IP filter) protection is always enforced by the host regardless of user rules.
+Basic per-VM firewall rules. User-defined ACCEPT/DROP/REJECT rules are evaluated
+in `priority` order (lower first) before the default policy. The default policy
+per direction is configurable per-VM (`accept`/`drop`/`reject`); when unset it
+inherits the host default, which is allow-all inbound and outbound (no change
+from prior behaviour). Anti-spoofing (IP filter) protection is always enforced
+by the host regardless of user rules.
 
 The maximum number of rules per VM is configurable at the template level and
 defaults to **20**. Any change to the rules queues an asynchronous re-apply of
@@ -533,7 +535,7 @@ the full firewall ruleset on the host.
   priority: number;                       // evaluation order, lower first
   direction: "inbound" | "outbound";
   protocol: "any" | "tcp" | "udp" | "icmp";
-  action: "accept" | "drop";
+  action: "accept" | "drop" | "reject";
   src_cidr?: string | null;               // optional source CIDR, null = any
   dst_port_start?: number | null;         // optional inclusive port range start, null = any
   dst_port_end?: number | null;           // optional inclusive port range end, null = single port
@@ -563,6 +565,26 @@ the full firewall ruleset on the host.
 - **DELETE** `/api/v1/vm/{id}/firewall/{rule_id}`
 - **Auth**: Required
 - **Response**: `null`
+
+**`FirewallPolicy` type**
+```typescript
+{
+  policy_in?: "accept" | "drop" | "reject" | null;   // null = inherit host default (allow-all)
+  policy_out?: "accept" | "drop" | "reject" | null;  // null = inherit host default (allow-all)
+}
+```
+
+#### Get Firewall Policy
+- **GET** `/api/v1/vm/{id}/firewall/policy`
+- **Auth**: Required
+- **Response**: `FirewallPolicy`
+
+#### Update Firewall Policy
+- **PATCH** `/api/v1/vm/{id}/firewall/policy`
+- **Auth**: Required
+- **Body**: `{ policy_in?, policy_out? }`. Omit a field to leave it unchanged, send `null` to reset it to the host default, or a value (`"accept"|"drop"|"reject"`) to set it explicitly.
+- **Response**: `FirewallPolicy`
+- **Description**: Sets the VM's default inbound/outbound policy and queues a firewall re-apply.
 
 ### Templates and Images
 

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -515,6 +515,55 @@ console.log('Auto-renewal enabled:', vmStatus.data.auto_renewal_enabled);
 - **Protocol**: WebSocket upgrade — bidirectional relay between the client and the VM's serial console
 - **Description**: Opens a WebSocket connection to the VM's serial terminal. Raw bytes in either direction are forwarded to/from the VM's serial port on the host. The connection is closed when either side disconnects or an error occurs.
 
+### VM Firewall
+
+Basic per-VM firewall rules. User-defined ACCEPT/DROP rules are evaluated in
+`priority` order (lower first) before the default policy. The default policy is
+allow-all inbound and outbound (no change from prior behaviour). Anti-spoofing
+(IP filter) protection is always enforced by the host regardless of user rules.
+
+The maximum number of rules per VM is configurable at the template level and
+defaults to **20**. Any change to the rules queues an asynchronous re-apply of
+the full firewall ruleset on the host.
+
+**`FirewallRule` type**
+```typescript
+{
+  id: number;
+  priority: number;                       // evaluation order, lower first
+  direction: "inbound" | "outbound";
+  protocol: "any" | "tcp" | "udp" | "icmp";
+  action: "accept" | "drop";
+  src_cidr?: string | null;               // optional source CIDR, null = any
+  dst_port_start?: number | null;         // optional inclusive port range start, null = any
+  dst_port_end?: number | null;           // optional inclusive port range end, null = single port
+  enabled: boolean;
+}
+```
+
+#### List Firewall Rules
+- **GET** `/api/v1/vm/{id}/firewall`
+- **Auth**: Required
+- **Response**: `FirewallRule[]`
+
+#### Create Firewall Rule
+- **POST** `/api/v1/vm/{id}/firewall`
+- **Auth**: Required
+- **Body**: `{ priority?: number, direction, protocol, action, src_cidr?, dst_port_start?, dst_port_end?, enabled? }`
+- **Response**: `FirewallRule`
+- **Description**: Creates a rule and queues a firewall re-apply. Fails if the per-VM rule limit is reached, or if `src_cidr`/port range are invalid (ports 1–65535, `dst_port_start <= dst_port_end`).
+
+#### Update Firewall Rule
+- **PATCH** `/api/v1/vm/{id}/firewall/{rule_id}`
+- **Auth**: Required
+- **Body**: Partial `FirewallRule` fields (all optional). Send `src_cidr: null` / `dst_port_*: null` to clear a field to "any".
+- **Response**: `FirewallRule`
+
+#### Delete Firewall Rule
+- **DELETE** `/api/v1/vm/{id}/firewall/{rule_id}`
+- **Auth**: Required
+- **Response**: `null`
+
 ### Templates and Images
 
 #### List VM Templates

--- a/lnvps_api/src/api/model.rs
+++ b/lnvps_api/src/api/model.rs
@@ -598,6 +598,210 @@ pub struct ApiVmUpgradeQuote {
 }
 
 // ============================================================================
+// Firewall Models (#36)
+// ============================================================================
+
+/// Direction a firewall rule applies to
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiFirewallDirection {
+    Inbound,
+    Outbound,
+}
+
+impl From<lnvps_db::VmFirewallDirection> for ApiFirewallDirection {
+    fn from(v: lnvps_db::VmFirewallDirection) -> Self {
+        match v {
+            lnvps_db::VmFirewallDirection::Inbound => ApiFirewallDirection::Inbound,
+            lnvps_db::VmFirewallDirection::Outbound => ApiFirewallDirection::Outbound,
+        }
+    }
+}
+
+impl From<ApiFirewallDirection> for lnvps_db::VmFirewallDirection {
+    fn from(v: ApiFirewallDirection) -> Self {
+        match v {
+            ApiFirewallDirection::Inbound => lnvps_db::VmFirewallDirection::Inbound,
+            ApiFirewallDirection::Outbound => lnvps_db::VmFirewallDirection::Outbound,
+        }
+    }
+}
+
+/// Protocol a firewall rule matches
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiFirewallProtocol {
+    Any,
+    Tcp,
+    Udp,
+    Icmp,
+}
+
+impl From<lnvps_db::VmFirewallProtocol> for ApiFirewallProtocol {
+    fn from(v: lnvps_db::VmFirewallProtocol) -> Self {
+        match v {
+            lnvps_db::VmFirewallProtocol::Any => ApiFirewallProtocol::Any,
+            lnvps_db::VmFirewallProtocol::Tcp => ApiFirewallProtocol::Tcp,
+            lnvps_db::VmFirewallProtocol::Udp => ApiFirewallProtocol::Udp,
+            lnvps_db::VmFirewallProtocol::Icmp => ApiFirewallProtocol::Icmp,
+        }
+    }
+}
+
+impl From<ApiFirewallProtocol> for lnvps_db::VmFirewallProtocol {
+    fn from(v: ApiFirewallProtocol) -> Self {
+        match v {
+            ApiFirewallProtocol::Any => lnvps_db::VmFirewallProtocol::Any,
+            ApiFirewallProtocol::Tcp => lnvps_db::VmFirewallProtocol::Tcp,
+            ApiFirewallProtocol::Udp => lnvps_db::VmFirewallProtocol::Udp,
+            ApiFirewallProtocol::Icmp => lnvps_db::VmFirewallProtocol::Icmp,
+        }
+    }
+}
+
+/// Action taken when a firewall rule matches
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiFirewallAction {
+    Drop,
+    Accept,
+}
+
+impl From<lnvps_db::VmFirewallRuleAction> for ApiFirewallAction {
+    fn from(v: lnvps_db::VmFirewallRuleAction) -> Self {
+        match v {
+            lnvps_db::VmFirewallRuleAction::Drop => ApiFirewallAction::Drop,
+            lnvps_db::VmFirewallRuleAction::Accept => ApiFirewallAction::Accept,
+        }
+    }
+}
+
+impl From<ApiFirewallAction> for lnvps_db::VmFirewallRuleAction {
+    fn from(v: ApiFirewallAction) -> Self {
+        match v {
+            ApiFirewallAction::Drop => lnvps_db::VmFirewallRuleAction::Drop,
+            ApiFirewallAction::Accept => lnvps_db::VmFirewallRuleAction::Accept,
+        }
+    }
+}
+
+/// A user-configurable per-VM firewall rule
+#[derive(Serialize, Deserialize)]
+pub struct ApiVmFirewallRule {
+    pub id: u64,
+    /// Evaluation order; lower priority is evaluated first
+    pub priority: u16,
+    pub direction: ApiFirewallDirection,
+    pub protocol: ApiFirewallProtocol,
+    pub action: ApiFirewallAction,
+    /// Optional source CIDR (None = any)
+    pub src_cidr: Option<String>,
+    /// Optional inclusive destination port range start (None = any)
+    pub dst_port_start: Option<u32>,
+    /// Optional inclusive destination port range end (None = single port / any)
+    pub dst_port_end: Option<u32>,
+    pub enabled: bool,
+}
+
+impl From<lnvps_db::VmFirewallRule> for ApiVmFirewallRule {
+    fn from(r: lnvps_db::VmFirewallRule) -> Self {
+        ApiVmFirewallRule {
+            id: r.id,
+            priority: r.priority,
+            direction: r.direction.into(),
+            protocol: r.protocol.into(),
+            action: r.action.into(),
+            src_cidr: r.src_cidr,
+            dst_port_start: r.dst_port_start,
+            dst_port_end: r.dst_port_end,
+            enabled: r.enabled,
+        }
+    }
+}
+
+/// Request body to create a firewall rule
+#[derive(Serialize, Deserialize)]
+pub struct CreateVmFirewallRule {
+    #[serde(default)]
+    pub priority: u16,
+    pub direction: ApiFirewallDirection,
+    pub protocol: ApiFirewallProtocol,
+    pub action: ApiFirewallAction,
+    pub src_cidr: Option<String>,
+    pub dst_port_start: Option<u32>,
+    pub dst_port_end: Option<u32>,
+    /// Whether the rule is active (defaults to true)
+    pub enabled: Option<bool>,
+}
+
+/// Request body to update a firewall rule (all fields optional)
+#[derive(Serialize, Deserialize)]
+pub struct PatchVmFirewallRule {
+    pub priority: Option<u16>,
+    pub direction: Option<ApiFirewallDirection>,
+    pub protocol: Option<ApiFirewallProtocol>,
+    pub action: Option<ApiFirewallAction>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "lnvps_api_common::deserialize_nullable_option"
+    )]
+    pub src_cidr: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "lnvps_api_common::deserialize_nullable_option"
+    )]
+    pub dst_port_start: Option<Option<u32>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "lnvps_api_common::deserialize_nullable_option"
+    )]
+    pub dst_port_end: Option<Option<u32>>,
+    pub enabled: Option<bool>,
+}
+
+/// Validate a source CIDR string, returning a normalised error message on failure.
+pub fn validate_firewall_cidr(cidr: &str) -> Result<(), String> {
+    use std::str::FromStr;
+    ipnetwork::IpNetwork::from_str(cidr)
+        .map(|_| ())
+        .map_err(|_| format!("Invalid src_cidr: {}", cidr))
+}
+
+/// Validate a destination port range. Returns the normalised (start, end) where
+/// end defaults to start when only a single port is supplied.
+pub fn validate_firewall_ports(
+    start: Option<u32>,
+    end: Option<u32>,
+) -> Result<(Option<u32>, Option<u32>), String> {
+    let check = |p: u32| -> Result<(), String> {
+        if p == 0 || p > 65535 {
+            Err(format!("Port out of range (1-65535): {}", p))
+        } else {
+            Ok(())
+        }
+    };
+    match (start, end) {
+        (None, None) => Ok((None, None)),
+        (Some(s), None) => {
+            check(s)?;
+            Ok((Some(s), None))
+        }
+        (None, Some(_)) => Err("dst_port_end set without dst_port_start".to_string()),
+        (Some(s), Some(e)) => {
+            check(s)?;
+            check(e)?;
+            if s > e {
+                return Err("dst_port_start must be <= dst_port_end".to_string());
+            }
+            Ok((Some(s), Some(e)))
+        }
+    }
+}
+
+// ============================================================================
 // Subscription Models
 // ============================================================================
 
@@ -1016,5 +1220,88 @@ mod tests {
         assert_eq!(item.formatted_amount, "EUR 5.00");
         assert_eq!(item.formatted_tax, "EUR 1.15");
         assert!(!item.formatted_duration.is_empty());
+    }
+
+    #[test]
+    fn test_validate_firewall_cidr() {
+        assert!(validate_firewall_cidr("1.2.3.0/24").is_ok());
+        assert!(validate_firewall_cidr("2001:db8::/32").is_ok());
+        assert!(validate_firewall_cidr("10.0.0.1").is_ok());
+        assert!(validate_firewall_cidr("not-a-cidr").is_err());
+        assert!(validate_firewall_cidr("1.2.3.4/99").is_err());
+    }
+
+    #[test]
+    fn test_validate_firewall_ports() {
+        assert_eq!(validate_firewall_ports(None, None), Ok((None, None)));
+        assert_eq!(
+            validate_firewall_ports(Some(80), None),
+            Ok((Some(80), None))
+        );
+        assert_eq!(
+            validate_firewall_ports(Some(80), Some(443)),
+            Ok((Some(80), Some(443)))
+        );
+        // end without start
+        assert!(validate_firewall_ports(None, Some(80)).is_err());
+        // start > end
+        assert!(validate_firewall_ports(Some(443), Some(80)).is_err());
+        // out of range
+        assert!(validate_firewall_ports(Some(0), None).is_err());
+        assert!(validate_firewall_ports(Some(70000), None).is_err());
+        assert!(validate_firewall_ports(Some(1), Some(70000)).is_err());
+    }
+
+    #[test]
+    fn test_firewall_enum_roundtrip() {
+        use lnvps_db::{VmFirewallDirection, VmFirewallProtocol, VmFirewallRuleAction};
+
+        for d in [VmFirewallDirection::Inbound, VmFirewallDirection::Outbound] {
+            let api: ApiFirewallDirection = d.into();
+            let back: VmFirewallDirection = api.into();
+            assert_eq!(d, back);
+        }
+        for p in [
+            VmFirewallProtocol::Any,
+            VmFirewallProtocol::Tcp,
+            VmFirewallProtocol::Udp,
+            VmFirewallProtocol::Icmp,
+        ] {
+            let api: ApiFirewallProtocol = p.into();
+            let back: VmFirewallProtocol = api.into();
+            assert_eq!(p, back);
+        }
+        for a in [VmFirewallRuleAction::Drop, VmFirewallRuleAction::Accept] {
+            let api: ApiFirewallAction = a.into();
+            let back: VmFirewallRuleAction = api.into();
+            assert_eq!(a, back);
+        }
+    }
+
+    #[test]
+    fn test_api_firewall_rule_from_db() {
+        let rule = lnvps_db::VmFirewallRule {
+            id: 7,
+            vm_id: 3,
+            priority: 5,
+            direction: lnvps_db::VmFirewallDirection::Inbound,
+            protocol: lnvps_db::VmFirewallProtocol::Tcp,
+            action: lnvps_db::VmFirewallRuleAction::Accept,
+            src_cidr: Some("1.2.3.0/24".to_string()),
+            dst_port_start: Some(22),
+            dst_port_end: None,
+            enabled: true,
+            created: Utc::now(),
+            updated: Utc::now(),
+        };
+        let api = ApiVmFirewallRule::from(rule);
+        assert_eq!(api.id, 7);
+        assert_eq!(api.priority, 5);
+        assert_eq!(api.direction, ApiFirewallDirection::Inbound);
+        assert_eq!(api.protocol, ApiFirewallProtocol::Tcp);
+        assert_eq!(api.action, ApiFirewallAction::Accept);
+        assert_eq!(api.src_cidr.as_deref(), Some("1.2.3.0/24"));
+        assert_eq!(api.dst_port_start, Some(22));
+        assert!(api.enabled);
     }
 }

--- a/lnvps_api/src/api/model.rs
+++ b/lnvps_api/src/api/model.rs
@@ -665,6 +665,7 @@ impl From<ApiFirewallProtocol> for lnvps_db::VmFirewallProtocol {
 pub enum ApiFirewallAction {
     Drop,
     Accept,
+    Reject,
 }
 
 impl From<lnvps_db::VmFirewallRuleAction> for ApiFirewallAction {
@@ -672,6 +673,7 @@ impl From<lnvps_db::VmFirewallRuleAction> for ApiFirewallAction {
         match v {
             lnvps_db::VmFirewallRuleAction::Drop => ApiFirewallAction::Drop,
             lnvps_db::VmFirewallRuleAction::Accept => ApiFirewallAction::Accept,
+            lnvps_db::VmFirewallRuleAction::Reject => ApiFirewallAction::Reject,
         }
     }
 }
@@ -681,8 +683,67 @@ impl From<ApiFirewallAction> for lnvps_db::VmFirewallRuleAction {
         match v {
             ApiFirewallAction::Drop => lnvps_db::VmFirewallRuleAction::Drop,
             ApiFirewallAction::Accept => lnvps_db::VmFirewallRuleAction::Accept,
+            ApiFirewallAction::Reject => lnvps_db::VmFirewallRuleAction::Reject,
         }
     }
+}
+
+/// Default policy applied to a traffic direction when no rule matches
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiFirewallPolicy {
+    Accept,
+    Drop,
+    Reject,
+}
+
+impl From<lnvps_db::VmFirewallPolicy> for ApiFirewallPolicy {
+    fn from(v: lnvps_db::VmFirewallPolicy) -> Self {
+        match v {
+            lnvps_db::VmFirewallPolicy::Accept => ApiFirewallPolicy::Accept,
+            lnvps_db::VmFirewallPolicy::Drop => ApiFirewallPolicy::Drop,
+            lnvps_db::VmFirewallPolicy::Reject => ApiFirewallPolicy::Reject,
+        }
+    }
+}
+
+impl From<ApiFirewallPolicy> for lnvps_db::VmFirewallPolicy {
+    fn from(v: ApiFirewallPolicy) -> Self {
+        match v {
+            ApiFirewallPolicy::Accept => lnvps_db::VmFirewallPolicy::Accept,
+            ApiFirewallPolicy::Drop => lnvps_db::VmFirewallPolicy::Drop,
+            ApiFirewallPolicy::Reject => lnvps_db::VmFirewallPolicy::Reject,
+        }
+    }
+}
+
+/// Per-VM default firewall policy (None = inherit host default / accept)
+#[derive(Serialize, Deserialize)]
+pub struct ApiVmFirewallPolicy {
+    /// Inbound default policy (None = inherit host default / accept)
+    pub policy_in: Option<ApiFirewallPolicy>,
+    /// Outbound default policy (None = inherit host default / accept)
+    pub policy_out: Option<ApiFirewallPolicy>,
+}
+
+/// Request body to update the per-VM default firewall policy.
+///
+/// Each field is a nullable-option: omit to leave unchanged, `null` to reset to
+/// the host default (accept), or a value to set explicitly.
+#[derive(Serialize, Deserialize)]
+pub struct PatchVmFirewallPolicy {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "lnvps_api_common::deserialize_nullable_option"
+    )]
+    pub policy_in: Option<Option<ApiFirewallPolicy>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "lnvps_api_common::deserialize_nullable_option"
+    )]
+    pub policy_out: Option<Option<ApiFirewallPolicy>>,
 }
 
 /// A user-configurable per-VM firewall rule
@@ -1271,10 +1332,29 @@ mod tests {
             let back: VmFirewallProtocol = api.into();
             assert_eq!(p, back);
         }
-        for a in [VmFirewallRuleAction::Drop, VmFirewallRuleAction::Accept] {
+        for a in [
+            VmFirewallRuleAction::Drop,
+            VmFirewallRuleAction::Accept,
+            VmFirewallRuleAction::Reject,
+        ] {
             let api: ApiFirewallAction = a.into();
             let back: VmFirewallRuleAction = api.into();
             assert_eq!(a, back);
+        }
+    }
+
+    #[test]
+    fn test_firewall_policy_enum_roundtrip() {
+        use lnvps_db::VmFirewallPolicy;
+
+        for p in [
+            VmFirewallPolicy::Accept,
+            VmFirewallPolicy::Drop,
+            VmFirewallPolicy::Reject,
+        ] {
+            let api: ApiFirewallPolicy = p.into();
+            let back: VmFirewallPolicy = api.into();
+            assert_eq!(p, back);
         }
     }
 

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -29,10 +29,11 @@ use lnvps_db::{
 
 use crate::api::model::{
     AccountPatchRequest, ApiCompany, ApiCustomTemplateParams, ApiCustomVmOrder, ApiCustomVmRequest,
-    ApiInvoiceItem, ApiPaymentInfo, ApiPaymentMethod, ApiTemplatesResponse, ApiVmFirewallRule,
-    ApiVmHistory, ApiVmPayment, ApiVmStatus, ApiVmUpgradeQuote, ApiVmUpgradeRequest, CreateSshKey,
-    CreateVmFirewallRule, CreateVmRequest, PatchVmFirewallRule, VMPatchRequest,
-    validate_firewall_cidr, validate_firewall_ports, vm_to_status,
+    ApiInvoiceItem, ApiPaymentInfo, ApiPaymentMethod, ApiTemplatesResponse, ApiVmFirewallPolicy,
+    ApiVmFirewallRule, ApiVmHistory, ApiVmPayment, ApiVmStatus, ApiVmUpgradeQuote,
+    ApiVmUpgradeRequest, CreateSshKey, CreateVmFirewallRule, CreateVmRequest,
+    PatchVmFirewallPolicy, PatchVmFirewallRule, VMPatchRequest, validate_firewall_cidr,
+    validate_firewall_ports, vm_to_status,
 };
 use crate::api::{AmountQuery, AuthQuery, PaymentMethodQuery, RouterState};
 use crate::host::{FullVmInfo, TimeSeries, TimeSeriesData, get_host_client};
@@ -95,6 +96,10 @@ pub fn routes() -> Router<RouterState> {
         .route(
             "/api/v1/vm/{id}/firewall",
             get(v1_list_firewall_rules).post(v1_create_firewall_rule),
+        )
+        .route(
+            "/api/v1/vm/{id}/firewall/policy",
+            get(v1_get_firewall_policy).patch(v1_patch_firewall_policy),
         )
         .route(
             "/api/v1/vm/{id}/firewall/{rule_id}",
@@ -1390,6 +1395,48 @@ async fn v1_list_firewall_rules(
     let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
     let rules = this.db.list_vm_firewall_rules(vm.id).await?;
     ApiData::ok(rules.into_iter().map(ApiVmFirewallRule::from).collect())
+}
+
+/// Get the per-VM default firewall policy
+async fn v1_get_firewall_policy(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+) -> ApiResult<ApiVmFirewallPolicy> {
+    let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
+    ApiData::ok(ApiVmFirewallPolicy {
+        policy_in: vm.fw_policy_in.map(Into::into),
+        policy_out: vm.fw_policy_out.map(Into::into),
+    })
+}
+
+/// Update the per-VM default firewall policy
+async fn v1_patch_firewall_policy(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+    Json(req): Json<PatchVmFirewallPolicy>,
+) -> ApiResult<ApiVmFirewallPolicy> {
+    let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
+
+    let policy_in = match req.policy_in {
+        Some(v) => v.map(Into::into),
+        None => vm.fw_policy_in,
+    };
+    let policy_out = match req.policy_out {
+        Some(v) => v.map(Into::into),
+        None => vm.fw_policy_out,
+    };
+
+    this.db
+        .update_vm_firewall_policy(vm.id, policy_in, policy_out)
+        .await?;
+    apply_firewall(&this, vm.id).await?;
+
+    ApiData::ok(ApiVmFirewallPolicy {
+        policy_in: policy_in.map(Into::into),
+        policy_out: policy_out.map(Into::into),
+    })
 }
 
 /// Create a firewall rule for a VM

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -29,9 +29,10 @@ use lnvps_db::{
 
 use crate::api::model::{
     AccountPatchRequest, ApiCompany, ApiCustomTemplateParams, ApiCustomVmOrder, ApiCustomVmRequest,
-    ApiInvoiceItem, ApiPaymentInfo, ApiPaymentMethod, ApiTemplatesResponse, ApiVmHistory,
-    ApiVmPayment, ApiVmStatus, ApiVmUpgradeQuote, ApiVmUpgradeRequest, CreateSshKey,
-    CreateVmRequest, VMPatchRequest, vm_to_status,
+    ApiInvoiceItem, ApiPaymentInfo, ApiPaymentMethod, ApiTemplatesResponse, ApiVmFirewallRule,
+    ApiVmHistory, ApiVmPayment, ApiVmStatus, ApiVmUpgradeQuote, ApiVmUpgradeRequest, CreateSshKey,
+    CreateVmFirewallRule, CreateVmRequest, PatchVmFirewallRule, VMPatchRequest,
+    validate_firewall_cidr, validate_firewall_ports, vm_to_status,
 };
 use crate::api::{AmountQuery, AuthQuery, PaymentMethodQuery, RouterState};
 use crate::host::{FullVmInfo, TimeSeries, TimeSeriesData, get_host_client};
@@ -91,6 +92,14 @@ pub fn routes() -> Router<RouterState> {
         .route("/api/v1/vm/{id}/history", get(v1_get_vm_history))
         .route("/api/v1/vm/{id}/upgrade/quote", post(v1_vm_upgrade_quote))
         .route("/api/v1/vm/{id}/upgrade", post(v1_vm_upgrade))
+        .route(
+            "/api/v1/vm/{id}/firewall",
+            get(v1_list_firewall_rules).post(v1_create_firewall_rule),
+        )
+        .route(
+            "/api/v1/vm/{id}/firewall/{rule_id}",
+            patch(v1_patch_firewall_rule).delete(v1_delete_firewall_rule),
+        )
 }
 
 /// Update user account
@@ -1354,6 +1363,168 @@ async fn v1_vm_upgrade(
 
     // Note: The actual upgrade happens after payment is confirmed
     ApiData::ok(ApiVmPayment::from_subscription_payment(payment, id)?)
+}
+
+/// Default maximum number of user firewall rules per VM when no template limit is set.
+const DEFAULT_FIREWALL_RULE_LIMIT: u16 = 20;
+
+/// Resolve the firewall rule limit for a VM from its (custom) template,
+/// falling back to the global default.
+async fn vm_firewall_rule_limit(this: &RouterState, vm: &Vm) -> Result<u16, ApiError> {
+    let limit = if let Some(t) = vm.template_id {
+        this.db.get_vm_template(t).await?.firewall_rule_limit
+    } else if let Some(t) = vm.custom_template_id {
+        this.db.get_custom_vm_template(t).await?.firewall_rule_limit
+    } else {
+        None
+    };
+    Ok(limit.unwrap_or(DEFAULT_FIREWALL_RULE_LIMIT))
+}
+
+/// List firewall rules for a VM
+async fn v1_list_firewall_rules(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+) -> ApiResult<Vec<ApiVmFirewallRule>> {
+    let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
+    let rules = this.db.list_vm_firewall_rules(vm.id).await?;
+    ApiData::ok(rules.into_iter().map(ApiVmFirewallRule::from).collect())
+}
+
+/// Create a firewall rule for a VM
+async fn v1_create_firewall_rule(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+    Json(req): Json<CreateVmFirewallRule>,
+) -> ApiResult<ApiVmFirewallRule> {
+    let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
+
+    // Enforce the per-VM rule limit
+    let limit = vm_firewall_rule_limit(&this, &vm).await?;
+    let existing = this.db.list_vm_firewall_rules(vm.id).await?;
+    if existing.len() as u16 >= limit {
+        return ApiData::err(&format!("Firewall rule limit reached ({})", limit));
+    }
+
+    // Validate inputs
+    if let Some(cidr) = &req.src_cidr {
+        if let Err(e) = validate_firewall_cidr(cidr) {
+            return ApiData::err(&e);
+        }
+    }
+    let (dst_port_start, dst_port_end) =
+        match validate_firewall_ports(req.dst_port_start, req.dst_port_end) {
+            Ok(v) => v,
+            Err(e) => return ApiData::err(&e),
+        };
+
+    let rule = lnvps_db::VmFirewallRule {
+        id: 0,
+        vm_id: vm.id,
+        priority: req.priority,
+        direction: req.direction.into(),
+        protocol: req.protocol.into(),
+        action: req.action.into(),
+        src_cidr: req.src_cidr,
+        dst_port_start,
+        dst_port_end,
+        enabled: req.enabled.unwrap_or(true),
+        created: Utc::now(),
+        updated: Utc::now(),
+    };
+    let rule_id = this.db.insert_vm_firewall_rule(&rule).await?;
+
+    apply_firewall(&this, vm.id).await?;
+
+    let created = this.db.get_vm_firewall_rule(rule_id).await?;
+    ApiData::ok(ApiVmFirewallRule::from(created))
+}
+
+/// Update a firewall rule
+async fn v1_patch_firewall_rule(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path((id, rule_id)): Path<(u64, u64)>,
+    Json(req): Json<PatchVmFirewallRule>,
+) -> ApiResult<ApiVmFirewallRule> {
+    let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
+
+    let mut rule = this.db.get_vm_firewall_rule(rule_id).await?;
+    if rule.vm_id != vm.id {
+        return ApiData::err("Firewall rule does not belong to this VM");
+    }
+
+    if let Some(p) = req.priority {
+        rule.priority = p;
+    }
+    if let Some(d) = req.direction {
+        rule.direction = d.into();
+    }
+    if let Some(p) = req.protocol {
+        rule.protocol = p.into();
+    }
+    if let Some(a) = req.action {
+        rule.action = a.into();
+    }
+    if let Some(c) = req.src_cidr {
+        if let Some(cidr) = &c {
+            if let Err(e) = validate_firewall_cidr(cidr) {
+                return ApiData::err(&e);
+            }
+        }
+        rule.src_cidr = c;
+    }
+    if let Some(s) = req.dst_port_start {
+        rule.dst_port_start = s;
+    }
+    if let Some(e) = req.dst_port_end {
+        rule.dst_port_end = e;
+    }
+    match validate_firewall_ports(rule.dst_port_start, rule.dst_port_end) {
+        Ok((s, e)) => {
+            rule.dst_port_start = s;
+            rule.dst_port_end = e;
+        }
+        Err(e) => return ApiData::err(&e),
+    }
+    if let Some(en) = req.enabled {
+        rule.enabled = en;
+    }
+
+    this.db.update_vm_firewall_rule(&rule).await?;
+    apply_firewall(&this, vm.id).await?;
+
+    let updated = this.db.get_vm_firewall_rule(rule_id).await?;
+    ApiData::ok(ApiVmFirewallRule::from(updated))
+}
+
+/// Delete a firewall rule
+async fn v1_delete_firewall_rule(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path((id, rule_id)): Path<(u64, u64)>,
+) -> ApiResult<()> {
+    let (_uid, vm) = get_user_vm(&auth, &this, id).await?;
+
+    let rule = this.db.get_vm_firewall_rule(rule_id).await?;
+    if rule.vm_id != vm.id {
+        return ApiData::err("Firewall rule does not belong to this VM");
+    }
+
+    this.db.delete_vm_firewall_rule(rule_id).await?;
+    apply_firewall(&this, vm.id).await?;
+    ApiData::ok(())
+}
+
+/// Queue a firewall re-apply job for the VM.
+async fn apply_firewall(this: &RouterState, vm_id: u64) -> Result<(), ApiError> {
+    this.work_sender
+        .send(WorkJob::ApplyVmFirewall { vm_id })
+        .await
+        .map_err(|e| ApiError::new(&format!("Failed to queue firewall update: {}", e)))?;
+    Ok(())
 }
 
 async fn get_user_vm(auth: &Nip98Auth, this: &RouterState, id: u64) -> Result<(u64, Vm), ApiError> {

--- a/lnvps_api/src/host/mod.rs
+++ b/lnvps_api/src/host/mod.rs
@@ -371,6 +371,8 @@ mod tests {
                 deleted: false,
                 ref_code: None,
                 disabled: false,
+                fw_policy_in: None,
+                fw_policy_out: None,
             },
             host: VmHost {
                 id: 1,

--- a/lnvps_api/src/host/mod.rs
+++ b/lnvps_api/src/host/mod.rs
@@ -5,8 +5,8 @@ use futures::future::join_all;
 use lnvps_api_common::VmRunningState;
 use lnvps_api_common::retry::OpResult;
 use lnvps_db::{
-    IpRange, LNVpsDb, UserSshKey, Vm, VmCustomTemplate, VmHost, VmHostDisk, VmHostKind,
-    VmIpAssignment, VmOsImage, VmTemplate,
+    IpRange, LNVpsDb, UserSshKey, Vm, VmCustomTemplate, VmFirewallRule, VmHost, VmHostDisk,
+    VmHostKind, VmIpAssignment, VmOsImage, VmTemplate,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -154,6 +154,8 @@ pub struct FullVmInfo {
     pub ranges: Vec<IpRange>,
     /// SSH key to access the VM
     pub ssh_key: UserSshKey,
+    /// User-configured firewall rules for this VM (ordered by priority)
+    pub firewall_rules: Vec<VmFirewallRule>,
 }
 
 impl FullVmInfo {
@@ -183,6 +185,7 @@ impl FullVmInfo {
         } else {
             None
         };
+        let firewall_rules = db.list_vm_firewall_rules(vm_id).await?;
         // create VM
         Ok(FullVmInfo {
             vm,
@@ -194,6 +197,7 @@ impl FullVmInfo {
             disk,
             ranges,
             ssh_key,
+            firewall_rules,
         })
     }
 
@@ -484,6 +488,7 @@ mod tests {
                 created: Default::default(),
                 key_data: "ssh-ed25519 AAA=".into(),
             },
+            firewall_rules: vec![],
         }
     }
 }

--- a/lnvps_api/src/host/proxmox.rs
+++ b/lnvps_api/src/host/proxmox.rs
@@ -905,6 +905,16 @@ impl ProxmoxClient {
         }
     }
 
+    /// Translate a user-defined per-VM default firewall policy into a Proxmox
+    /// policy value.
+    fn convert_vm_firewall_policy(policy: lnvps_db::VmFirewallPolicy) -> VmFirewallPolicy {
+        match policy {
+            lnvps_db::VmFirewallPolicy::Accept => VmFirewallPolicy::ACCEPT,
+            lnvps_db::VmFirewallPolicy::Drop => VmFirewallPolicy::DROP,
+            lnvps_db::VmFirewallPolicy::Reject => VmFirewallPolicy::REJECT,
+        }
+    }
+
     /// Translate a user-defined DB firewall rule into a Proxmox PVE firewall rule.
     ///
     /// The rule is tagged with a [`USER_FW_MARKER`]-prefixed comment so it can be
@@ -916,6 +926,7 @@ impl ProxmoxClient {
         let action = match rule.action {
             VmFirewallRuleAction::Accept => VmFirewallAction::ACCEPT,
             VmFirewallRuleAction::Drop => VmFirewallAction::DROP,
+            VmFirewallRuleAction::Reject => VmFirewallAction::REJECT,
         };
         let rule_type = match rule.direction {
             VmFirewallDirection::Inbound => VmFirewallRuleType::In,
@@ -1623,6 +1634,23 @@ impl VmHostClient for ProxmoxClient {
         }
 
         let fw_cfg = self.config.firewall_config.as_ref().unwrap();
+        // Per-VM default policy (user-configured) overrides the host default when
+        // set; otherwise fall back to the host-level configured policy.
+        let policy_in = cfg
+            .vm
+            .fw_policy_in
+            .map(Self::convert_vm_firewall_policy)
+            .or_else(|| fw_cfg.policy_in.as_ref().map(Self::convert_firewall_policy));
+        let policy_out = cfg
+            .vm
+            .fw_policy_out
+            .map(Self::convert_vm_firewall_policy)
+            .or_else(|| {
+                fw_cfg
+                    .policy_out
+                    .as_ref()
+                    .map(Self::convert_firewall_policy)
+            });
         // Use configured firewall options or disable firewall if no config
         let firewall_config = VmFirewallConfig {
             dhcp: fw_cfg.dhcp,
@@ -1630,11 +1658,8 @@ impl VmHostClient for ProxmoxClient {
             ip_filter: fw_cfg.ip_filter,
             mac_filter: fw_cfg.mac_filter,
             ndp: fw_cfg.ndp,
-            policy_in: fw_cfg.policy_in.as_ref().map(Self::convert_firewall_policy),
-            policy_out: fw_cfg
-                .policy_out
-                .as_ref()
-                .map(Self::convert_firewall_policy),
+            policy_in,
+            policy_out,
         };
 
         // Re-apply firewall configuration
@@ -2768,6 +2793,42 @@ mod tests {
         assert_eq!(pve.dport.as_deref(), Some("53"));
         assert_eq!(pve.source, None);
         assert_eq!(pve.enable, Some(0));
+    }
+
+    #[test]
+    fn test_to_pve_firewall_rule_reject_action() {
+        let rule = lnvps_db::VmFirewallRule {
+            id: 9,
+            vm_id: 1,
+            priority: 0,
+            direction: lnvps_db::VmFirewallDirection::Inbound,
+            protocol: lnvps_db::VmFirewallProtocol::Tcp,
+            action: lnvps_db::VmFirewallRuleAction::Reject,
+            src_cidr: None,
+            dst_port_start: Some(25),
+            dst_port_end: None,
+            enabled: true,
+            created: Default::default(),
+            updated: Default::default(),
+        };
+        let pve = ProxmoxClient::to_pve_firewall_rule(&rule);
+        assert_eq!(pve.action, VmFirewallAction::REJECT);
+    }
+
+    #[test]
+    fn test_convert_vm_firewall_policy() {
+        assert!(matches!(
+            ProxmoxClient::convert_vm_firewall_policy(lnvps_db::VmFirewallPolicy::Accept),
+            VmFirewallPolicy::ACCEPT
+        ));
+        assert!(matches!(
+            ProxmoxClient::convert_vm_firewall_policy(lnvps_db::VmFirewallPolicy::Drop),
+            VmFirewallPolicy::DROP
+        ));
+        assert!(matches!(
+            ProxmoxClient::convert_vm_firewall_policy(lnvps_db::VmFirewallPolicy::Reject),
+            VmFirewallPolicy::REJECT
+        ));
     }
 
     #[test]

--- a/lnvps_api/src/host/proxmox.rs
+++ b/lnvps_api/src/host/proxmox.rs
@@ -23,6 +23,10 @@ use std::str::FromStr;
 use std::time::Duration;
 use tokio::time::sleep;
 
+/// Comment prefix used to tag user-defined firewall rules (#36) on Proxmox so
+/// they can be identified and re-synced without disturbing system rules.
+const USER_FW_MARKER: &str = "lnvps-fw";
+
 #[derive(Clone)]
 pub struct ProxmoxClient {
     api: JsonApi,
@@ -868,6 +872,28 @@ impl ProxmoxClient {
             .await?;
         Ok(())
     }
+
+    /// Delete a VM firewall rule by its position
+    ///
+    /// https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/firewall/rules/{pos}
+    pub async fn delete_vm_firewall_rule(
+        &self,
+        node: &str,
+        vm_id: ProxmoxVmId,
+        pos: i32,
+    ) -> OpResult<()> {
+        self.api
+            .req_status::<()>(
+                Method::DELETE,
+                &format!(
+                    "/api2/json/nodes/{}/qemu/{}/firewall/rules/{}",
+                    node, vm_id, pos
+                ),
+                None,
+            )
+            .await?;
+        Ok(())
+    }
 }
 
 impl ProxmoxClient {
@@ -876,6 +902,46 @@ impl ProxmoxClient {
             crate::settings::FirewallPolicy::Accept => VmFirewallPolicy::ACCEPT,
             crate::settings::FirewallPolicy::Reject => VmFirewallPolicy::REJECT,
             crate::settings::FirewallPolicy::Drop => VmFirewallPolicy::DROP,
+        }
+    }
+
+    /// Translate a user-defined DB firewall rule into a Proxmox PVE firewall rule.
+    ///
+    /// The rule is tagged with a [`USER_FW_MARKER`]-prefixed comment so it can be
+    /// identified and re-synced on subsequent applies without disturbing the
+    /// always-enforced ipfilter (anti-spoof) rule.
+    fn to_pve_firewall_rule(rule: &lnvps_db::VmFirewallRule) -> VmFirewallRule {
+        use lnvps_db::{VmFirewallDirection, VmFirewallProtocol, VmFirewallRuleAction};
+
+        let action = match rule.action {
+            VmFirewallRuleAction::Accept => VmFirewallAction::ACCEPT,
+            VmFirewallRuleAction::Drop => VmFirewallAction::DROP,
+        };
+        let rule_type = match rule.direction {
+            VmFirewallDirection::Inbound => VmFirewallRuleType::In,
+            VmFirewallDirection::Outbound => VmFirewallRuleType::Out,
+        };
+        let proto = match rule.protocol {
+            VmFirewallProtocol::Any => None,
+            VmFirewallProtocol::Tcp => Some("tcp".to_string()),
+            VmFirewallProtocol::Udp => Some("udp".to_string()),
+            VmFirewallProtocol::Icmp => Some("icmp".to_string()),
+        };
+        let dport = match (rule.dst_port_start, rule.dst_port_end) {
+            (Some(s), Some(e)) if e != s => Some(format!("{}:{}", s, e)),
+            (Some(s), _) => Some(s.to_string()),
+            (None, _) => None,
+        };
+
+        VmFirewallRule {
+            action,
+            rule_type,
+            proto,
+            dport,
+            source: rule.src_cidr.clone(),
+            enable: Some(if rule.enabled { 1 } else { 0 }),
+            comment: Some(format!("{}:{}", USER_FW_MARKER, rule.id)),
+            ..Default::default()
         }
     }
 
@@ -1663,6 +1729,33 @@ impl VmHostClient for ProxmoxClient {
 
         if !rule_exists {
             self.add_vm_firewall_rule(&self.node, vm_id, allow_rule)
+                .await?;
+        }
+
+        // Sync user-defined firewall rules (#36).
+        // Remove any previously-applied user rules (tagged with USER_FW_MARKER),
+        // then re-add the current set. Deletion is done by position in
+        // descending order so positions don't shift mid-loop. PVE inserts new
+        // rules at the top, so we add in reverse priority order to preserve the
+        // intended top-to-bottom (priority ascending) evaluation order.
+        let current_rules = self.list_vm_firewall_rules(&self.node, vm_id).await?;
+        let mut stale_positions: Vec<i32> = current_rules
+            .iter()
+            .filter(|r| {
+                r.comment
+                    .as_deref()
+                    .map(|c| c.starts_with(USER_FW_MARKER))
+                    .unwrap_or(false)
+            })
+            .filter_map(|r| r.pos)
+            .collect();
+        stale_positions.sort_unstable_by(|a, b| b.cmp(a));
+        for pos in stale_positions {
+            self.delete_vm_firewall_rule(&self.node, vm_id, pos).await?;
+        }
+
+        for rule in cfg.firewall_rules.iter().rev() {
+            self.add_vm_firewall_rule(&self.node, vm_id, Self::to_pve_firewall_rule(rule))
                 .await?;
         }
 
@@ -2624,6 +2717,57 @@ mod tests {
         let vm = p.make_config(&cfg, None)?;
         assert_eq!(vm.cpu_limit, Some(0.5));
         Ok(())
+    }
+
+    #[test]
+    fn test_to_pve_firewall_rule_inbound_tcp_port_range() {
+        let rule = lnvps_db::VmFirewallRule {
+            id: 42,
+            vm_id: 1,
+            priority: 0,
+            direction: lnvps_db::VmFirewallDirection::Inbound,
+            protocol: lnvps_db::VmFirewallProtocol::Tcp,
+            action: lnvps_db::VmFirewallRuleAction::Accept,
+            src_cidr: Some("1.2.3.0/24".to_string()),
+            dst_port_start: Some(80),
+            dst_port_end: Some(443),
+            enabled: true,
+            created: Default::default(),
+            updated: Default::default(),
+        };
+        let pve = ProxmoxClient::to_pve_firewall_rule(&rule);
+        assert_eq!(pve.action, VmFirewallAction::ACCEPT);
+        assert_eq!(pve.rule_type, VmFirewallRuleType::In);
+        assert_eq!(pve.proto.as_deref(), Some("tcp"));
+        assert_eq!(pve.dport.as_deref(), Some("80:443"));
+        assert_eq!(pve.source.as_deref(), Some("1.2.3.0/24"));
+        assert_eq!(pve.enable, Some(1));
+        assert_eq!(pve.comment.as_deref(), Some("lnvps-fw:42"));
+    }
+
+    #[test]
+    fn test_to_pve_firewall_rule_outbound_any_single_port_disabled() {
+        let rule = lnvps_db::VmFirewallRule {
+            id: 7,
+            vm_id: 1,
+            priority: 3,
+            direction: lnvps_db::VmFirewallDirection::Outbound,
+            protocol: lnvps_db::VmFirewallProtocol::Any,
+            action: lnvps_db::VmFirewallRuleAction::Drop,
+            src_cidr: None,
+            dst_port_start: Some(53),
+            dst_port_end: None,
+            enabled: false,
+            created: Default::default(),
+            updated: Default::default(),
+        };
+        let pve = ProxmoxClient::to_pve_firewall_rule(&rule);
+        assert_eq!(pve.action, VmFirewallAction::DROP);
+        assert_eq!(pve.rule_type, VmFirewallRuleType::Out);
+        assert_eq!(pve.proto, None);
+        assert_eq!(pve.dport.as_deref(), Some("53"));
+        assert_eq!(pve.source, None);
+        assert_eq!(pve.enable, Some(0));
     }
 
     #[test]

--- a/lnvps_api/src/provisioner/integration_retry_tests.rs
+++ b/lnvps_api/src/provisioner/integration_retry_tests.rs
@@ -201,6 +201,8 @@ mod tests {
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         assert_eq!(failing_host.start_failures_remaining(), 2);
@@ -245,6 +247,8 @@ mod tests {
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         assert_eq!(failing_host.stop_failures_remaining(), 1);
@@ -284,6 +288,8 @@ mod tests {
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         assert_eq!(failing_host.delete_failures_remaining(), 1);

--- a/lnvps_api/src/provisioner/retry_tests.rs
+++ b/lnvps_api/src/provisioner/retry_tests.rs
@@ -216,6 +216,8 @@ mod tests {
                 deleted: false,
                 ref_code: None,
                 disabled: false,
+                fw_policy_in: None,
+                fw_policy_out: None,
             })
             .await?;
 

--- a/lnvps_api/src/provisioner/rollback_tests.rs
+++ b/lnvps_api/src/provisioner/rollback_tests.rs
@@ -553,6 +553,8 @@ mod tests {
             ref_code: None,
             deleted: false,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
         let vm_id = db.insert_vm(&vm).await?;
         vm.id = vm_id;

--- a/lnvps_api/src/provisioner/vm.rs
+++ b/lnvps_api/src/provisioner/vm.rs
@@ -166,6 +166,8 @@ impl VmProvisioner {
             deleted: false,
             ref_code,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         let new_id = self.db.insert_vm(&new_vm).await?;
@@ -290,6 +292,8 @@ impl VmProvisioner {
             deleted: false,
             ref_code,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         let new_id = self.db.insert_vm(&new_vm).await?;

--- a/lnvps_api/src/worker.rs
+++ b/lnvps_api/src/worker.rs
@@ -2160,6 +2160,9 @@ impl Worker {
             } => {
                 self.configure_vm(*vm_id, *admin_user_id).await?;
             }
+            WorkJob::ApplyVmFirewall { vm_id } => {
+                self.apply_vm_firewall(*vm_id).await?;
+            }
             WorkJob::CheckNostrDomains => {
                 self.check_nostr_domains().await?;
             }
@@ -2606,6 +2609,25 @@ impl Worker {
             "Successfully re-configured VM {} using current database settings",
             vm_id
         );
+        Ok(())
+    }
+
+    /// Re-apply the firewall ruleset for a VM using current database configuration.
+    async fn apply_vm_firewall(&self, vm_id: u64) -> Result<()> {
+        info!("Re-applying firewall for VM {}", vm_id);
+
+        let vm = self.db.get_vm(vm_id).await?;
+        if vm.deleted {
+            bail!("Cannot apply firewall to deleted VM {}", vm_id);
+        }
+
+        let full_info = FullVmInfo::load(vm_id, self.db.clone()).await?;
+        let host = self.db.get_host(full_info.host.id).await?;
+        let client = get_host_client(&host, &self.settings.provisioner_config)?;
+
+        client.patch_firewall(&full_info).await?;
+
+        info!("Successfully re-applied firewall for VM {}", vm_id);
         Ok(())
     }
 

--- a/lnvps_api_admin/src/admin/vm_templates.rs
+++ b/lnvps_api_admin/src/admin/vm_templates.rs
@@ -201,6 +201,7 @@ async fn admin_create_vm_template(
         disk_mbps_write: req.disk_mbps_write,
         network_mbps: req.network_mbps,
         cpu_limit: req.cpu_limit,
+        firewall_rule_limit: None,
     };
 
     let template_id = this.db.insert_vm_template(&template).await?;

--- a/lnvps_api_admin/src/bin/generate_demo_data.rs
+++ b/lnvps_api_admin/src/bin/generate_demo_data.rs
@@ -1182,6 +1182,8 @@ async fn create_vms(
             deleted: false,
             ref_code: ref_code.clone(),
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         let id = db.insert_vm(&vm).await?;
@@ -1226,6 +1228,8 @@ async fn create_vms(
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
 
         let id = db.insert_vm(&vm).await?;

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -9,8 +9,9 @@ use lnvps_db::{
     PaymentMethodConfig, Referral, ReferralCostUsage, ReferralPayout, Router, RouterBgpRoute,
     RouterBgpSession, RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem,
     SubscriptionPayment, SubscriptionPaymentWithCompany, User, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallRule, VmHistory, VmHost,
-    VmHostDisk, VmHostKind, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment, VmTemplate,
+    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallPolicy, VmFirewallRule,
+    VmHistory, VmHost, VmHostDisk, VmHostKind, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment,
+    VmTemplate,
 };
 
 use async_trait::async_trait;
@@ -118,6 +119,8 @@ impl MockDb {
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         }
     }
 }
@@ -976,6 +979,20 @@ impl LNVpsDbBase for MockDb {
     async fn delete_vm_firewall_rule(&self, rule_id: u64) -> DbResult<()> {
         let mut rules = self.firewall_rules.lock().await;
         rules.remove(&rule_id);
+        Ok(())
+    }
+
+    async fn update_vm_firewall_policy(
+        &self,
+        vm_id: u64,
+        policy_in: Option<VmFirewallPolicy>,
+        policy_out: Option<VmFirewallPolicy>,
+    ) -> DbResult<()> {
+        let mut vms = self.vms.lock().await;
+        if let Some(vm) = vms.get_mut(&vm_id) {
+            vm.fw_policy_in = policy_in;
+            vm.fw_policy_out = policy_out;
+        }
         Ok(())
     }
 
@@ -3332,6 +3349,44 @@ mod tests {
         db.delete_vm_firewall_rule(id_a).await.unwrap();
         assert!(db.get_vm_firewall_rule(id_a).await.is_err());
         assert_eq!(db.list_vm_firewall_rules(1).await.unwrap().len(), 1);
+    }
+
+    /// Per-VM firewall policy update via the mock DB.
+    #[tokio::test]
+    async fn test_firewall_policy_update() {
+        use lnvps_db::{Vm, VmFirewallPolicy};
+
+        let db = MockDb::default();
+        db.vms.lock().await.insert(
+            1,
+            Vm {
+                id: 1,
+                ..Default::default()
+            },
+        );
+
+        // default is inherit (None)
+        let vm = db.get_vm(1).await.unwrap();
+        assert_eq!(vm.fw_policy_in, None);
+        assert_eq!(vm.fw_policy_out, None);
+
+        // set policies
+        db.update_vm_firewall_policy(
+            1,
+            Some(VmFirewallPolicy::Drop),
+            Some(VmFirewallPolicy::Reject),
+        )
+        .await
+        .unwrap();
+        let vm = db.get_vm(1).await.unwrap();
+        assert_eq!(vm.fw_policy_in, Some(VmFirewallPolicy::Drop));
+        assert_eq!(vm.fw_policy_out, Some(VmFirewallPolicy::Reject));
+
+        // reset to inherit
+        db.update_vm_firewall_policy(1, None, None).await.unwrap();
+        let vm = db.get_vm(1).await.unwrap();
+        assert_eq!(vm.fw_policy_in, None);
+        assert_eq!(vm.fw_policy_out, None);
     }
 
     /// subscription_payment_paid marks the payment as paid and sets paid_at.

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -9,8 +9,8 @@ use lnvps_db::{
     PaymentMethodConfig, Referral, ReferralCostUsage, ReferralPayout, Router, RouterBgpRoute,
     RouterBgpSession, RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem,
     SubscriptionPayment, SubscriptionPaymentWithCompany, User, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmHistory, VmHost, VmHostDisk,
-    VmHostKind, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment, VmTemplate,
+    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallRule, VmHistory, VmHost,
+    VmHostDisk, VmHostKind, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment, VmTemplate,
 };
 
 use async_trait::async_trait;
@@ -53,6 +53,7 @@ pub struct MockDb {
     pub router_tunnel_traffic: Arc<Mutex<Vec<RouterTunnelTraffic>>>,
     pub router_bgp_sessions: Arc<Mutex<HashMap<u64, RouterBgpSession>>>,
     pub router_bgp_routes: Arc<Mutex<HashMap<u64, RouterBgpRoute>>>,
+    pub firewall_rules: Arc<Mutex<HashMap<u64, VmFirewallRule>>>,
 }
 
 impl MockDb {
@@ -97,6 +98,7 @@ impl MockDb {
             disk_mbps_write: None,
             network_mbps: None,
             cpu_limit: None,
+            firewall_rule_limit: None,
         }
     }
 
@@ -306,6 +308,7 @@ impl Default for MockDb {
             router_tunnel_traffic: Arc::new(Default::default()),
             router_bgp_sessions: Arc::new(Default::default()),
             router_bgp_routes: Arc::new(Default::default()),
+            firewall_rules: Arc::new(Default::default()),
         }
     }
 }
@@ -925,6 +928,54 @@ impl LNVpsDbBase for MockDb {
                 ip_assignment.deleted = true;
             }
         }
+        Ok(())
+    }
+
+    async fn insert_vm_firewall_rule(&self, rule: &VmFirewallRule) -> DbResult<u64> {
+        let mut rules = self.firewall_rules.lock().await;
+        let max = *rules.keys().max().unwrap_or(&0);
+        let id = max + 1;
+        rules.insert(id, VmFirewallRule { id, ..rule.clone() });
+        Ok(id)
+    }
+
+    async fn get_vm_firewall_rule(&self, rule_id: u64) -> DbResult<VmFirewallRule> {
+        let rules = self.firewall_rules.lock().await;
+        rules
+            .get(&rule_id)
+            .cloned()
+            .ok_or_else(|| DbError::Other(anyhow!("Firewall rule not found")))
+    }
+
+    async fn list_vm_firewall_rules(&self, vm_id: u64) -> DbResult<Vec<VmFirewallRule>> {
+        let rules = self.firewall_rules.lock().await;
+        let mut out: Vec<VmFirewallRule> = rules
+            .values()
+            .filter(|r| r.vm_id == vm_id)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.id.cmp(&b.id)));
+        Ok(out)
+    }
+
+    async fn update_vm_firewall_rule(&self, rule: &VmFirewallRule) -> DbResult<()> {
+        let mut rules = self.firewall_rules.lock().await;
+        if let Some(r) = rules.get_mut(&rule.id) {
+            r.priority = rule.priority;
+            r.direction = rule.direction;
+            r.protocol = rule.protocol;
+            r.action = rule.action;
+            r.src_cidr = rule.src_cidr.clone();
+            r.dst_port_start = rule.dst_port_start;
+            r.dst_port_end = rule.dst_port_end;
+            r.enabled = rule.enabled;
+        }
+        Ok(())
+    }
+
+    async fn delete_vm_firewall_rule(&self, rule_id: u64) -> DbResult<()> {
+        let mut rules = self.firewall_rules.lock().await;
+        rules.remove(&rule_id);
         Ok(())
     }
 
@@ -3228,6 +3279,59 @@ mod tests {
             processing_fee: 0,
             paid_at: None,
         }
+    }
+
+    /// Firewall rule CRUD via the mock DB.
+    #[tokio::test]
+    async fn test_firewall_rule_crud() {
+        use lnvps_db::{
+            VmFirewallDirection, VmFirewallProtocol, VmFirewallRule, VmFirewallRuleAction,
+        };
+
+        let db = MockDb::default();
+        let mk = |vm_id: u64, priority: u16| VmFirewallRule {
+            id: 0,
+            vm_id,
+            priority,
+            direction: VmFirewallDirection::Inbound,
+            protocol: VmFirewallProtocol::Tcp,
+            action: VmFirewallRuleAction::Accept,
+            src_cidr: None,
+            dst_port_start: Some(22),
+            dst_port_end: None,
+            enabled: true,
+            created: Utc::now(),
+            updated: Utc::now(),
+        };
+
+        // insert two rules for vm 1 (out of order priority) and one for vm 2
+        let id_a = db.insert_vm_firewall_rule(&mk(1, 10)).await.unwrap();
+        let _id_b = db.insert_vm_firewall_rule(&mk(1, 1)).await.unwrap();
+        let _id_c = db.insert_vm_firewall_rule(&mk(2, 5)).await.unwrap();
+
+        // list returns only vm 1 rules ordered by priority
+        let rules = db.list_vm_firewall_rules(1).await.unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].priority, 1);
+        assert_eq!(rules[1].priority, 10);
+
+        // get
+        let got = db.get_vm_firewall_rule(id_a).await.unwrap();
+        assert_eq!(got.vm_id, 1);
+
+        // update
+        let mut upd = got.clone();
+        upd.action = VmFirewallRuleAction::Drop;
+        upd.dst_port_end = Some(80);
+        db.update_vm_firewall_rule(&upd).await.unwrap();
+        let got = db.get_vm_firewall_rule(id_a).await.unwrap();
+        assert_eq!(got.action, VmFirewallRuleAction::Drop);
+        assert_eq!(got.dst_port_end, Some(80));
+
+        // delete
+        db.delete_vm_firewall_rule(id_a).await.unwrap();
+        assert!(db.get_vm_firewall_rule(id_a).await.is_err());
+        assert_eq!(db.list_vm_firewall_rules(1).await.unwrap().len(), 1);
     }
 
     /// subscription_payment_paid marks the payment as paid and sets paid_at.

--- a/lnvps_api_common/src/pricing.rs
+++ b/lnvps_api_common/src/pricing.rs
@@ -617,6 +617,7 @@ impl PricingEngine {
             disk_mbps_write: pricing.disk_mbps_write,
             network_mbps: pricing.network_mbps,
             cpu_limit: pricing.cpu_limit,
+            firewall_rule_limit: None,
         };
         Ok(new_custom_template)
     }

--- a/lnvps_api_common/src/vm_history.rs
+++ b/lnvps_api_common/src/vm_history.rs
@@ -471,6 +471,8 @@ mod tests {
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
         logger.log_vm_created(&vm, Some(1), None).await.unwrap();
         let history = logger.db.list_vm_history(42).await.unwrap();
@@ -656,6 +658,8 @@ mod tests {
             deleted: false,
             ref_code: None,
             disabled: false,
+            fw_policy_in: None,
+            fw_policy_out: None,
         };
         let mut new_vm = old_vm.clone();
         new_vm.image_id = 2;

--- a/lnvps_api_common/src/work/mod.rs
+++ b/lnvps_api_common/src/work/mod.rs
@@ -83,6 +83,8 @@ pub enum WorkJob {
         vm_id: u64,
         admin_user_id: Option<u64>,
     },
+    /// Re-apply the firewall ruleset for a VM (after firewall rule changes)
+    ApplyVmFirewall { vm_id: u64 },
     /// Assign an IP to a VM using the provisioner (handles all additional steps)
     AssignVmIp {
         vm_id: u64,
@@ -180,6 +182,7 @@ impl fmt::Display for WorkJob {
             WorkJob::CheckNostrDomains => write!(f, "CheckNostrDomains"),
             WorkJob::ProcessVmUpgrade { .. } => write!(f, "ProcessVmUpgrade"),
             WorkJob::ConfigureVm { .. } => write!(f, "ConfigureVm"),
+            WorkJob::ApplyVmFirewall { .. } => write!(f, "ApplyVmFirewall"),
             WorkJob::AssignVmIp { .. } => write!(f, "AssignVmIp"),
             WorkJob::UnassignVmIp { .. } => write!(f, "UnassignVmIp"),
             WorkJob::UpdateVmIp { .. } => write!(f, "UpdateVmIp"),

--- a/lnvps_db/migrations/20260624123544_vm_firewall_rule.sql
+++ b/lnvps_db/migrations/20260624123544_vm_firewall_rule.sql
@@ -1,0 +1,33 @@
+-- Basic per-VM firewall rules (#36)
+-- User-configurable ACCEPT/DROP rules applied on top of the always-enforced
+-- ipfilter (anti-spoof) rules. Default policy remains allow-all (no regression).
+
+create table vm_firewall_rule
+(
+    id             integer unsigned not null auto_increment primary key,
+    vm_id          integer unsigned not null,
+    -- Evaluation order; lower priority evaluated first
+    priority       smallint unsigned not null default 0,
+    -- 0 = inbound, 1 = outbound
+    direction      smallint unsigned not null default 0,
+    -- 0 = any, 1 = tcp, 2 = udp, 3 = icmp
+    protocol       smallint unsigned not null default 0,
+    -- 0 = drop, 1 = accept
+    action         smallint unsigned not null default 1,
+    -- Optional source CIDR (e.g. 1.2.3.0/24 or ::/0); NULL = any
+    src_cidr       varchar(64)      null     default null,
+    -- Optional destination port range (inclusive); NULL = any
+    dst_port_start integer unsigned null     default null,
+    dst_port_end   integer unsigned null     default null,
+    -- Whether this rule is active
+    enabled        bit(1)           not null default 1,
+    created        timestamp        not null default current_timestamp,
+    updated        timestamp        not null default current_timestamp on update current_timestamp,
+    constraint fk_vm_firewall_rule_vm foreign key (vm_id) references vm (id)
+);
+
+create index ix_vm_firewall_rule_vm on vm_firewall_rule (vm_id);
+
+-- Per-template max firewall rule count (NULL = use global default)
+alter table vm_template        add column firewall_rule_limit smallint unsigned null default null;
+alter table vm_custom_template add column firewall_rule_limit smallint unsigned null default null;

--- a/lnvps_db/migrations/20260624123544_vm_firewall_rule.sql
+++ b/lnvps_db/migrations/20260624123544_vm_firewall_rule.sql
@@ -12,7 +12,7 @@ create table vm_firewall_rule
     direction      smallint unsigned not null default 0,
     -- 0 = any, 1 = tcp, 2 = udp, 3 = icmp
     protocol       smallint unsigned not null default 0,
-    -- 0 = drop, 1 = accept
+    -- 0 = drop, 1 = accept, 2 = reject
     action         smallint unsigned not null default 1,
     -- Optional source CIDR (e.g. 1.2.3.0/24 or ::/0); NULL = any
     src_cidr       varchar(64)      null     default null,
@@ -31,3 +31,8 @@ create index ix_vm_firewall_rule_vm on vm_firewall_rule (vm_id);
 -- Per-template max firewall rule count (NULL = use global default)
 alter table vm_template        add column firewall_rule_limit smallint unsigned null default null;
 alter table vm_custom_template add column firewall_rule_limit smallint unsigned null default null;
+
+-- Per-VM default firewall policy applied when no user rule matches.
+-- NULL = inherit host default (allow-all); 0 = accept, 1 = drop, 2 = reject.
+alter table vm add column fw_policy_in  smallint unsigned null default null;
+alter table vm add column fw_policy_out smallint unsigned null default null;

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -299,6 +299,21 @@ pub trait LNVpsDbBase: Send + Sync {
     /// Delete assigned VM ip
     async fn delete_vm_ip_assignment(&self, assignment_id: u64) -> DbResult<()>;
 
+    /// Create a firewall rule, returns the new rule id
+    async fn insert_vm_firewall_rule(&self, rule: &VmFirewallRule) -> DbResult<u64>;
+
+    /// Get a single firewall rule by id
+    async fn get_vm_firewall_rule(&self, rule_id: u64) -> DbResult<VmFirewallRule>;
+
+    /// List firewall rules for a VM, ordered by priority
+    async fn list_vm_firewall_rules(&self, vm_id: u64) -> DbResult<Vec<VmFirewallRule>>;
+
+    /// Update an existing firewall rule
+    async fn update_vm_firewall_rule(&self, rule: &VmFirewallRule) -> DbResult<()>;
+
+    /// Delete a firewall rule by id
+    async fn delete_vm_firewall_rule(&self, rule_id: u64) -> DbResult<()>;
+
     /// List payments by VM id
     async fn list_vm_payment(&self, vm_id: u64) -> DbResult<Vec<VmPayment>>;
 

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -314,6 +314,14 @@ pub trait LNVpsDbBase: Send + Sync {
     /// Delete a firewall rule by id
     async fn delete_vm_firewall_rule(&self, rule_id: u64) -> DbResult<()>;
 
+    /// Update the per-VM default firewall policy (None = inherit host default)
+    async fn update_vm_firewall_policy(
+        &self,
+        vm_id: u64,
+        policy_in: Option<VmFirewallPolicy>,
+        policy_out: Option<VmFirewallPolicy>,
+    ) -> DbResult<()>;
+
     /// List payments by VM id
     async fn list_vm_payment(&self, vm_id: u64) -> DbResult<Vec<VmPayment>>;
 

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -862,6 +862,8 @@ pub struct VmTemplate {
     pub network_mbps: Option<u32>,
     /// Maximum CPU usage as a fraction of allocated cores (e.g. 0.5 = 50%; None = uncapped)
     pub cpu_limit: Option<f32>,
+    /// Maximum number of user firewall rules per VM (None = use global default)
+    pub firewall_rule_limit: Option<u16>,
 }
 
 /// A custom pricing template, used for billing calculation of a specific VM
@@ -890,6 +892,8 @@ pub struct VmCustomTemplate {
     pub network_mbps: Option<u32>,
     /// Maximum CPU usage as a fraction of allocated cores (e.g. 0.5 = 50%; None = uncapped)
     pub cpu_limit: Option<f32>,
+    /// Maximum number of user firewall rules per VM (None = use global default)
+    pub firewall_rule_limit: Option<u16>,
 }
 
 /// Custom pricing template, usually 1 per region
@@ -1048,6 +1052,69 @@ impl Display for VmIpAssignment {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.ip)
     }
+}
+
+/// Direction a firewall rule applies to
+#[derive(Debug, Clone, Copy, sqlx::Type, PartialEq, Eq, Default)]
+#[repr(u16)]
+pub enum VmFirewallDirection {
+    /// Traffic arriving at the VM
+    #[default]
+    Inbound = 0,
+    /// Traffic leaving the VM
+    Outbound = 1,
+}
+
+/// Protocol a firewall rule matches
+#[derive(Debug, Clone, Copy, sqlx::Type, PartialEq, Eq, Default)]
+#[repr(u16)]
+pub enum VmFirewallProtocol {
+    /// Match any protocol
+    #[default]
+    Any = 0,
+    Tcp = 1,
+    Udp = 2,
+    Icmp = 3,
+}
+
+/// Action taken when a firewall rule matches
+#[derive(Debug, Clone, Copy, sqlx::Type, PartialEq, Eq, Default)]
+#[repr(u16)]
+pub enum VmFirewallRuleAction {
+    /// Silently drop the packet
+    Drop = 0,
+    /// Accept the packet
+    #[default]
+    Accept = 1,
+}
+
+/// A user-configurable per-VM firewall rule (#36)
+#[derive(FromRow, Clone, Debug, Default)]
+pub struct VmFirewallRule {
+    /// Unique id of this rule
+    pub id: u64,
+    /// VM this rule applies to
+    pub vm_id: u64,
+    /// Evaluation order; lower priority is evaluated first
+    pub priority: u16,
+    /// Direction this rule applies to
+    pub direction: VmFirewallDirection,
+    /// Protocol matched by this rule
+    pub protocol: VmFirewallProtocol,
+    /// Action taken when the rule matches
+    pub action: VmFirewallRuleAction,
+    /// Optional source CIDR (None = any)
+    pub src_cidr: Option<String>,
+    /// Optional inclusive destination port range start (None = any)
+    pub dst_port_start: Option<u32>,
+    /// Optional inclusive destination port range end (None = any)
+    pub dst_port_end: Option<u32>,
+    /// Whether this rule is active
+    pub enabled: bool,
+    /// When this rule was created
+    pub created: DateTime<Utc>,
+    /// When this rule was last updated
+    pub updated: DateTime<Utc>,
 }
 
 #[derive(FromRow, Clone, Debug, Default)]

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -982,6 +982,10 @@ pub struct Vm {
     pub ref_code: Option<String>,
     /// Whether the VM is disabled by admin
     pub disabled: bool,
+    /// Default inbound firewall policy (None = inherit host default / accept)
+    pub fw_policy_in: Option<VmFirewallPolicy>,
+    /// Default outbound firewall policy (None = inherit host default / accept)
+    pub fw_policy_out: Option<VmFirewallPolicy>,
 }
 
 /// Raw vm_payment row with external_data as a plain String (not decrypted).
@@ -1086,6 +1090,21 @@ pub enum VmFirewallRuleAction {
     /// Accept the packet
     #[default]
     Accept = 1,
+    /// Reject the packet (drop and send an ICMP/TCP-RST rejection)
+    Reject = 2,
+}
+
+/// Default policy applied to traffic in a given direction when no rule matches
+#[derive(Debug, Clone, Copy, sqlx::Type, PartialEq, Eq, Default)]
+#[repr(u16)]
+pub enum VmFirewallPolicy {
+    /// Accept the packet (allow-all default; current behaviour)
+    #[default]
+    Accept = 0,
+    /// Silently drop the packet
+    Drop = 1,
+    /// Reject the packet (drop and send an ICMP/TCP-RST rejection)
+    Reject = 2,
 }
 
 /// A user-configurable per-VM firewall rule (#36)

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -4,8 +4,9 @@ use crate::{
     PaymentType, Referral, ReferralCostUsage, ReferralPayout, RegionStats, Router, RouterBgpRoute,
     RouterBgpSession, RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem,
     SubscriptionPayment, SubscriptionPaymentWithCompany, User, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmForMigration, VmHistory, VmHost,
-    VmHostDisk, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment, VmPaymentRaw, VmTemplate,
+    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallRule, VmForMigration,
+    VmHistory, VmHost, VmHostDisk, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment,
+    VmPaymentRaw, VmTemplate,
 };
 #[cfg(feature = "admin")]
 use crate::{AdminDb, AdminRole, AdminRoleAssignment, AdminVmHost};
@@ -960,6 +961,68 @@ impl LNVpsDbBase for LNVpsDbMysql {
     async fn delete_vm_ip_assignment(&self, assignment_id: u64) -> DbResult<()> {
         sqlx::query("update vm_ip_assignment set deleted = 1 where id = ?")
             .bind(assignment_id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    async fn insert_vm_firewall_rule(&self, rule: &VmFirewallRule) -> DbResult<u64> {
+        Ok(sqlx::query(
+            "insert into vm_firewall_rule(vm_id,priority,direction,protocol,action,src_cidr,dst_port_start,dst_port_end,enabled) values(?,?,?,?,?,?,?,?,?) returning id",
+        )
+            .bind(rule.vm_id)
+            .bind(rule.priority)
+            .bind(rule.direction)
+            .bind(rule.protocol)
+            .bind(rule.action)
+            .bind(&rule.src_cidr)
+            .bind(rule.dst_port_start)
+            .bind(rule.dst_port_end)
+            .bind(rule.enabled)
+            .fetch_one(&self.db)
+            .await?
+            .try_get(0)?)
+    }
+
+    async fn get_vm_firewall_rule(&self, rule_id: u64) -> DbResult<VmFirewallRule> {
+        Ok(
+            sqlx::query_as("select * from vm_firewall_rule where id = ?")
+                .bind(rule_id)
+                .fetch_one(&self.db)
+                .await?,
+        )
+    }
+
+    async fn list_vm_firewall_rules(&self, vm_id: u64) -> DbResult<Vec<VmFirewallRule>> {
+        Ok(sqlx::query_as(
+            "select * from vm_firewall_rule where vm_id = ? order by priority asc, id asc",
+        )
+        .bind(vm_id)
+        .fetch_all(&self.db)
+        .await?)
+    }
+
+    async fn update_vm_firewall_rule(&self, rule: &VmFirewallRule) -> DbResult<()> {
+        sqlx::query(
+            "update vm_firewall_rule set priority=?, direction=?, protocol=?, action=?, src_cidr=?, dst_port_start=?, dst_port_end=?, enabled=? where id=?",
+        )
+            .bind(rule.priority)
+            .bind(rule.direction)
+            .bind(rule.protocol)
+            .bind(rule.action)
+            .bind(&rule.src_cidr)
+            .bind(rule.dst_port_start)
+            .bind(rule.dst_port_end)
+            .bind(rule.enabled)
+            .bind(rule.id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_vm_firewall_rule(&self, rule_id: u64) -> DbResult<()> {
+        sqlx::query("delete from vm_firewall_rule where id = ?")
+            .bind(rule_id)
             .execute(&self.db)
             .await?;
         Ok(())

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -4,9 +4,9 @@ use crate::{
     PaymentType, Referral, ReferralCostUsage, ReferralPayout, RegionStats, Router, RouterBgpRoute,
     RouterBgpSession, RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem,
     SubscriptionPayment, SubscriptionPaymentWithCompany, User, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallRule, VmForMigration,
-    VmHistory, VmHost, VmHostDisk, VmHostRegion, VmIpAssignment, VmOsImage, VmPayment,
-    VmPaymentRaw, VmTemplate,
+    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallPolicy, VmFirewallRule,
+    VmForMigration, VmHistory, VmHost, VmHostDisk, VmHostRegion, VmIpAssignment, VmOsImage,
+    VmPayment, VmPaymentRaw, VmTemplate,
 };
 #[cfg(feature = "admin")]
 use crate::{AdminDb, AdminRole, AdminRoleAssignment, AdminVmHost};
@@ -785,7 +785,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
 
     async fn update_vm(&self, vm: &Vm) -> DbResult<()> {
         sqlx::query(
-            "update vm set image_id=?,template_id=?,custom_template_id=?,subscription_line_item_id=?,ssh_key_id=?,disk_id=?,mac_address=?,disabled=? where id=?",
+            "update vm set image_id=?,template_id=?,custom_template_id=?,subscription_line_item_id=?,ssh_key_id=?,disk_id=?,mac_address=?,disabled=?,fw_policy_in=?,fw_policy_out=? where id=?",
         )
             .bind(vm.image_id)
             .bind(vm.template_id)
@@ -795,6 +795,8 @@ impl LNVpsDbBase for LNVpsDbMysql {
             .bind(vm.disk_id)
             .bind(&vm.mac_address)
             .bind(vm.disabled)
+            .bind(vm.fw_policy_in)
+            .bind(vm.fw_policy_out)
             .bind(vm.id)
             .execute(&self.db)
             .await?;
@@ -1023,6 +1025,21 @@ impl LNVpsDbBase for LNVpsDbMysql {
     async fn delete_vm_firewall_rule(&self, rule_id: u64) -> DbResult<()> {
         sqlx::query("delete from vm_firewall_rule where id = ?")
             .bind(rule_id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    async fn update_vm_firewall_policy(
+        &self,
+        vm_id: u64,
+        policy_in: Option<VmFirewallPolicy>,
+        policy_out: Option<VmFirewallPolicy>,
+    ) -> DbResult<()> {
+        sqlx::query("update vm set fw_policy_in=?, fw_policy_out=? where id=?")
+            .bind(policy_in)
+            .bind(policy_out)
+            .bind(vm_id)
             .execute(&self.db)
             .await?;
         Ok(())

--- a/work/basic-firewall.md
+++ b/work/basic-firewall.md
@@ -1,0 +1,99 @@
+# Basic Firewall Support (#36)
+
+**Status:** complete
+**Started:** 2026-06-24
+**Last updated:** 2026-06-24 (All increments complete)
+
+## Goal
+
+Implement basic user-configurable per-VM firewall rules (issue #36): a data
+model for rules, user API endpoints to CRUD them, and a Proxmox PVE firewall
+backend that applies the user rules on top of the always-enforced ipfilter
+(anti-spoof) rules. Default policy stays allow-all (no regression).
+
+nftables backend (#33) and the `use_nftables` host flag (#34) are **out of
+scope** for this initial work — tracked separately.
+
+## Findings
+
+### Existing firewall infrastructure
+- `Host::patch_firewall(cfg: &FullVmInfo)` trait method: `lnvps_api/src/host/mod.rs:83`
+  - Proxmox impl: `lnvps_api/src/host/proxmox.rs:1514` — enables PVE fw on NIC,
+    manages `ipfilter-net0` IPset (anti-spoof), adds an ACCEPT rule for that set.
+  - libvirt impl: stub returning Ok (`lnvps_api/src/host/libvirt.rs:230`)
+  - dummy impl: stub (`lnvps_api/src/host/dummy_host.rs:271`)
+- Proxmox API client already has rule helpers: `list_vm_firewall_rules`,
+  `add_vm_firewall_rule` (proxmox.rs:835+). May need a delete helper.
+- `VmFirewallRule` (proxmox API type), `VmFirewallAction`, `VmFirewallRuleType`
+  already exist for the proxmox client — distinct from our new DB model type.
+- patch_firewall is invoked from worker: `lnvps_api/src/worker.rs:1255`.
+- NIC always has `firewall=1` (proxmox.rs:928).
+
+### DB patterns
+- Model structs in `lnvps_db/src/model.rs`; enums use
+  `#[derive(sqlx::Type)] #[repr(u16)]`. Trait in `lnvps_db/src/lib.rs`,
+  mysql impl in `lnvps_db/src/mysql.rs`. Mock in db trait area too.
+- Migrations: `lnvps_db/migrations/` timestamped `.sql`.
+- Template limit columns added via ALTER (see template_limits migration);
+  `VmTemplate` at model.rs:837.
+
+### API patterns
+- Routes registered in `lnvps_api/src/api/routes.rs` (axum `.route(...)`).
+- API DTO types in `lnvps_api/src/api/model.rs`.
+- VM ownership check pattern used across `v1_*` handlers.
+- `API_CHANGELOG.md` must be updated for user-facing API changes.
+
+## Tasks
+
+### Increment 1 — Data model + DB layer (M) ✅ DONE
+- [x] Migration: create `vm_firewall_rule` table
+      (`20260624123544_vm_firewall_rule.sql`)
+- [x] Migration: add `firewall_rule_limit` to `vm_template` + `vm_custom_template`
+- [x] Model: `VmFirewallRule` struct + `VmFirewallDirection`,
+      `VmFirewallProtocol`, `VmFirewallRuleAction` enums (model.rs)
+- [x] Add `firewall_rule_limit` field to `VmTemplate` / `VmCustomTemplate`
+- [x] DB trait methods (LNVpsDbBase): insert / get / list_by_vm / update / delete
+- [x] mysql impl of the above
+- [x] Update mock DB impl (`firewall_rules` map + 5 methods)
+- [x] cargo build --workspace + lnvps_api_common tests green
+
+### Increment 2 — User API (M) ✅ DONE
+- [x] API DTOs: `ApiVmFirewallRule` + `ApiFirewall{Direction,Protocol,Action}`,
+      `CreateVmFirewallRule`, `PatchVmFirewallRule` (api/model.rs)
+- [x] `GET /api/v1/vm/{id}/firewall`
+- [x] `POST /api/v1/vm/{id}/firewall`
+- [x] `PATCH /api/v1/vm/{id}/firewall/{rule_id}`
+- [x] `DELETE /api/v1/vm/{id}/firewall/{rule_id}`
+- [x] Validation: ownership (`get_user_vm`), max-rule limit
+      (`vm_firewall_rule_limit`, default 20), CIDR + port-range parsing
+- [x] Trigger firewall re-apply: new `WorkJob::ApplyVmFirewall { vm_id }` +
+      worker `apply_vm_firewall` handler; queued on every change
+- [x] `FullVmInfo` now loads `firewall_rules` (for Increment 3 backend)
+- [x] API_CHANGELOG.md + API_DOCUMENTATION.md entries
+- [x] OpenAPI auto-generated from handlers (`cargo build --features openapi` ok)
+- [x] Unit tests: validators, enum round-trips, ApiVmFirewallRule::from,
+      mock DB firewall CRUD
+
+### Increment 3 — Proxmox backend (M-L) ✅ DONE
+- [x] Translate DB rules → Proxmox PVE firewall rules
+      (`ProxmoxClient::to_pve_firewall_rule`, tagged with `lnvps-fw:{id}` comment)
+- [x] Sync semantics in `patch_firewall`: delete stale user rules (by pos, desc)
+      then re-add current set in reverse priority order (PVE inserts at top);
+      ipfilter anti-spoof ACCEPT rule always preserved
+- [x] Added `ProxmoxClient::delete_vm_firewall_rule` (DELETE by pos)
+- [x] Unit tests: inbound tcp port-range + outbound any single-port disabled
+- [x] Full workspace tests green (`--test-threads=1`)
+
+## Summary
+
+All three increments complete. nftables backend (#33) + `use_nftables` host
+flag (#34) remain out of scope (separate issues); libvirt `patch_firewall`
+stays a stub until then. Default policy unchanged (allow-all); anti-spoof always
+enforced.
+
+## Notes
+
+- Default policy: inbound allow-all, outbound allow-all (current behaviour).
+- Anti-spoof ipfilter rules always enforced regardless of user rules.
+- Protocols: TCP/UDP/ICMP/Any. Port range optional (start/end).
+- Direction: inbound / outbound.


### PR DESCRIPTION
Implements basic user-configurable per-VM firewall rules.

Fixes #36

## What

User-defined ACCEPT/DROP firewall rules per VM, applied on top of the
always-enforced ipfilter (anti-spoof) protection. The default policy stays
allow-all inbound/outbound, so there is no behaviour change for existing VMs.

## Changes

**Data model** (`lnvps_db`)
- Migration `20260624123544_vm_firewall_rule.sql`: new `vm_firewall_rule` table +
  nullable `firewall_rule_limit` on `vm_template` / `vm_custom_template`
- `VmFirewallRule` model + `VmFirewallDirection` / `VmFirewallProtocol` /
  `VmFirewallRuleAction` enums
- `LNVpsDbBase` CRUD methods (MySQL + MockDb impls)

**User API** (`lnvps_api`)
- `GET/POST /api/v1/vm/{id}/firewall`
- `PATCH/DELETE /api/v1/vm/{id}/firewall/{rule_id}`
- Ownership check, per-VM rule limit (template-configurable, default 20),
  CIDR + port-range validation (ports 1–65535, start ≤ end)

**Re-apply plumbing**
- New `WorkJob::ApplyVmFirewall { vm_id }` + worker handler; queued on every change
- `FullVmInfo` now loads `firewall_rules`

**Proxmox backend**
- `to_pve_firewall_rule` translates DB rules → PVE firewall rules (tagged with a
  `lnvps-fw:{id}` comment)
- `patch_firewall` syncs: deletes stale tagged rules (by position, descending)
  then re-adds the current set in reverse priority order, always preserving the
  ipfilter anti-spoof rule
- New `delete_vm_firewall_rule` API client method

**Docs**: `API_CHANGELOG.md` + `API_DOCUMENTATION.md` (OpenAPI auto-generated).

## Out of scope

nftables backend (#33) and the `use_nftables` host flag (#34) — libvirt's
`patch_firewall` remains a stub until then.

## Testing

- Unit tests: validators, enum round-trips, `ApiVmFirewallRule::from`, mock DB
  CRUD, Proxmox rule translation
- `cargo test --workspace --exclude lnvps_e2e -- --test-threads=1` green
- `cargo fmt` clean; builds with `--features openapi`