### PR TITLE
fix: return 402 for re-install on expired VM + accurate error status codes

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -2965,10 +2965,11 @@ All error responses follow the format:
 
 Common HTTP status codes:
 
-- `400` - Bad Request (invalid input)
+- `400` - Bad Request (invalid input / validation errors)
 - `401` - Unauthorized (invalid or missing authentication)
-- `403` - Forbidden (insufficient permissions)
-- `404` - Not Found
+- `403` - Forbidden (insufficient permissions; also protected/system resources)
+- `404` - Not Found (missing resource, or a nested resource that doesn't belong to the parent in the path, e.g. a payment/history entry that isn't for the given VM)
+- `409` - Conflict (the resource's current state conflicts with the request, e.g. acting on an already-deleted VM or an already-completed payment)
 - `500` - Internal Server Error
 
 ## Pagination

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -124,6 +124,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **2026-07-06** - More accurate HTTP status codes on error responses. API errors previously almost always returned `500 Internal Server Error`; they now use appropriate codes:
+  - Client/validation errors (e.g. invalid SSH key, invalid lightning address) return `400 Bad Request`.
+  - Accessing a VM you don't own, or ordering before email verification, returns `403 Forbidden`.
+  - Missing resources return `404 Not Found` — including any database lookup that finds no matching row (applies across the user and admin APIs).
+  - Genuine internal failures continue to return `500`. Response bodies are unchanged (`{ "error": string }`).
+
+
 - **2026-06-25** - Subscription payments now include the payment data needed to pay
   - `ApiSubscriptionPayment` (returned by `GET /api/v1/subscriptions/{id}/renew`, `GET /api/v1/subscriptions/{id}/payments`, and the admin subscription-payment endpoints) gains a `data` field carrying the payment-method-specific data, e.g. `{ "lightning": "lnbc..." }` for Lightning. Previously the renew endpoint returned a payment record with no way to actually pay it.
 

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -124,10 +124,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- **2026-07-06** - More accurate HTTP status codes on error responses. API errors previously almost always returned `500 Internal Server Error`; they now use appropriate codes:
-  - Client/validation errors (e.g. invalid SSH key, invalid lightning address) return `400 Bad Request`.
-  - Accessing a VM you don't own, or ordering before email verification, returns `403 Forbidden`.
-  - Missing resources return `404 Not Found` — including any database lookup that finds no matching row (applies across the user and admin APIs).
+- **2026-07-06** - More accurate HTTP status codes on error responses (full audit of the user and admin APIs). API errors previously almost always returned `500 Internal Server Error`; they now use appropriate codes:
+  - `400 Bad Request` — client/validation errors (e.g. invalid SSH key, invalid lightning address, empty/invalid fields on admin create/update, invalid date ranges on reports). Many admin validation errors previously returned `500`.
+  - `401 Unauthorized` — authentication failures.
+  - `403 Forbidden` — accessing a resource you don't own (VM/subscription/SSH key), ordering before email verification, modifying system roles, and **insufficient admin permissions** (previously `500`).
+  - `404 Not Found` — missing resources, including any database lookup that finds no matching row, and nested resources not under their parent (e.g. a firewall rule / payment / history entry that doesn't belong to the given VM).
+  - `409 Conflict` — state conflicts (e.g. already enrolled in referrals, acting on an already-deleted VM, a payment that is already completed, assigning an IP to a deleted/expired VM).
+  - `501 Not Implemented` — not-yet-implemented subscription types (ASN sponsoring, DNS hosting).
   - Genuine internal failures continue to return `500`. Response bodies are unchanged (`{ "error": string }`).
 
 

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -118,6 +118,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `POST /api/admin/v1/vms/{id}/payments/{payment_id}/complete` — Mark a VM payment as paid, extend VM expiry, and dispatch provisioning (requires `payments::update`)
   - `POST /api/admin/v1/subscription_payments/{id}/complete` — Mark a subscription payment as paid, extend subscription by 30 days, and activate it (requires `subscription_payments::update`)
 
+### Fixed
+
+- **2026-07-06** - `PATCH /api/v1/vm/{id}/re-install` on an expired VM now returns `402 Payment Required` with a clear message instead of `500 Internal Server Error`. The expiry is checked up-front (before touching the host) so an expired VM can no longer trigger a failed reinstall pipeline. (#141)
+
 ### Changed
 
 - **2026-06-25** - Subscription payments now include the payment data needed to pay

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -546,6 +546,7 @@ console.log('Auto-renewal enabled:', vmStatus.data.auto_renewal_enabled);
 - **PATCH** `/api/v1/vm/{id}/re-install`
 - **Auth**: Required
 - **Response**: `null`
+- **Errors**: `402 Payment Required` if the VM is expired (renew it first); `403 Forbidden` if the VM is not yours; `404 Not Found` if the VM does not exist.
 
 #### VM Serial Console (WebSocket)
 - **WebSocket** `/api/v1/vm/{id}/console`
@@ -965,9 +966,12 @@ Common HTTP status codes:
 - `200`: Success
 - `400`: Bad Request (validation errors)
 - `401`: Unauthorized (invalid or missing authentication)
-- `403`: Forbidden (insufficient permissions)
-- `404`: Not Found
+- `402`: Payment Required (e.g. acting on an expired VM that must be renewed first)
+- `403`: Forbidden (accessing a resource you don't own, or insufficient permissions)
+- `404`: Not Found (missing resource, or a nested resource that doesn't belong to the parent in the path)
+- `409`: Conflict (the resource's current state conflicts with the request, e.g. an already-deleted VM or an already-completed payment)
 - `500`: Internal Server Error
+- `501`: Not Implemented (feature not yet available)
 
 ## Rate Limiting
 
@@ -1256,8 +1260,8 @@ Get detailed information about a specific IP space block.
 **Response**: `ApiResponse<AvailableIpSpace>`
 
 **Error Responses**:
-- `"IP space not available"` - IP space is not available for purchase
-- Not found error if ID doesn't exist
+- `"IP space not available"` (`400 Bad Request`) - IP space is not available for purchase
+- `404 Not Found` - IP space ID does not exist
 
 **Example Request**:
 
@@ -1289,7 +1293,7 @@ List all IP ranges allocated to a specific subscription.
 **Response**: `ApiPaginatedResponse<IpRangeSubscription>`
 
 **Error Responses**:
-- `"Access denied: not your subscription"` - User doesn't own this subscription
+- `"Access denied: not your subscription"` (`403 Forbidden`) - User doesn't own this subscription
 
 **Example Request**:
 
@@ -1333,7 +1337,7 @@ interface AddIpRangeToSubscriptionRequest {
 **Response**: `ApiResponse<IpRangeSubscription>`
 
 **Error Responses**:
-- `"Access denied: not your subscription"` - User doesn't own this subscription
+- `"Access denied: not your subscription"` (`403 Forbidden`) - User doesn't own this subscription
 - `"IP space is not available for allocation"` - IP space is no longer available
 - `"IP range allocation not yet implemented - please contact support to manually allocate IP ranges"` - Feature not yet complete (current status)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,6 +2853,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "sqlx",
  "tokio",
  "try-procedure",
 ]

--- a/lnvps_api/Cargo.toml
+++ b/lnvps_api/Cargo.toml
@@ -2,6 +2,9 @@
 name = "lnvps_api"
 version.workspace = true
 edition.workspace = true
+# Disambiguate `cargo run -p lnvps_api` (this package ships extra one-shot bins
+# like fix_lnurlp_topups); the e2e runner relies on this.
+default-run = "lnvps_api"
 
 [[bin]]
 name = "lnvps_api"

--- a/lnvps_api/src/api/legal.rs
+++ b/lnvps_api/src/api/legal.rs
@@ -163,7 +163,7 @@ async fn v1_generate_lir_agreement_from_subscription(
     // Get subscription
     let subscription = this.db.get_subscription(subscription_id).await?;
     if subscription.user_id != uid {
-        return ApiData::err("Subscription does not belong to you");
+        return Err(ApiError::forbidden("Subscription does not belong to you"));
     }
 
     // Get company for this subscription

--- a/lnvps_api/src/api/nostr_domain.rs
+++ b/lnvps_api/src/api/nostr_domain.rs
@@ -70,7 +70,7 @@ async fn v1_list_nostr_domain_handles(
 
     let domain = this.db.get_domain(dom).await?;
     if domain.owner_id != uid {
-        return ApiData::err("Access denied");
+        return Err(ApiError::forbidden("Access denied"));
     }
 
     let handles = this.db.list_handles(domain.id).await?;
@@ -88,7 +88,7 @@ async fn v1_create_nostr_domain_handle(
 
     let domain = this.db.get_domain(dom).await?;
     if domain.owner_id != uid {
-        return ApiData::err("Access denied");
+        return Err(ApiError::forbidden("Access denied"));
     }
 
     let h_pubkey =
@@ -120,7 +120,7 @@ async fn v1_delete_nostr_domain_handle(
 
     let domain = this.db.get_domain(dom).await?;
     if domain.owner_id != uid {
-        return ApiData::err("Access denied");
+        return Err(ApiError::forbidden("Access denied"));
     }
     this.db.delete_handle(handle).await?;
     ApiData::ok(())

--- a/lnvps_api/src/api/referral.rs
+++ b/lnvps_api/src/api/referral.rs
@@ -188,7 +188,7 @@ async fn v1_get_referral(
         .db
         .get_referral_by_user(uid)
         .await
-        .map_err(|_| ApiError::new("Not enrolled in referral program"))?;
+        .map_err(|_| ApiError::not_found("Not enrolled in referral program"))?;
 
     let (usage, payouts, referrals_failed) = tokio::try_join!(
         this.db.list_referral_usage(&referral.code),
@@ -267,7 +267,7 @@ async fn v1_update_referral(
         .db
         .get_referral_by_user(uid)
         .await
-        .map_err(|_| ApiError::new("Not enrolled in referral program"))?;
+        .map_err(|_| ApiError::not_found("Not enrolled in referral program"))?;
 
     if let Some(ref addr) = req.lightning_address {
         if let Some(a) = addr {

--- a/lnvps_api/src/api/referral.rs
+++ b/lnvps_api/src/api/referral.rs
@@ -215,7 +215,7 @@ async fn v1_signup_referral(
 
     // Check if already enrolled
     if this.db.get_referral_by_user(uid).await.is_ok() {
-        return ApiData::err("Already enrolled in referral program");
+        return Err(ApiError::conflict("Already enrolled in referral program"));
     }
 
     // Validate that at least one payout method is specified

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -563,7 +563,7 @@ async fn v1_patch_vm(
     if let Some(k) = data.ssh_key_id {
         let ssh_key = this.db.get_user_ssh_key(k).await?;
         if ssh_key.user_id != uid {
-            return ApiData::err("SSH key doesnt belong to you");
+            return Err(ApiError::forbidden("SSH key doesnt belong to you"));
         }
         vm.ssh_key_id = ssh_key.id;
         vm_config = true;
@@ -937,7 +937,7 @@ async fn v1_lnurlp(
     State(this): State<RouterState>,
     Path(id): Path<u64>,
 ) -> Result<Json<PayResponse>, &'static str> {
-    let vm = this.db.get_vm(id).await.map_err(|_e| "VM not found")?;
+    let vm = this.db.get_vm(id).await.map_err(|_| "VM not found")?;
     if vm.deleted {
         return Err("VM not found");
     }
@@ -1294,7 +1294,7 @@ async fn v1_get_payment(
         .get_vm_by_subscription(payment.subscription_id)
         .await?;
     if vm.user_id != uid {
-        return ApiData::err("VM does not belong to you");
+        return Err(ApiError::forbidden("VM does not belong to you"));
     }
 
     ApiData::ok(ApiVmPayment::from_subscription_payment(payment, vm.id)?)
@@ -1451,7 +1451,7 @@ async fn v1_payment_history(
     let uid = this.db.upsert_user(&pubkey).await?;
     let vm = this.db.get_vm(id).await?;
     if vm.user_id != uid {
-        return ApiData::err("VM does not belong to you");
+        return Err(ApiError::forbidden("VM does not belong to you"));
     }
 
     let payments = {
@@ -1480,7 +1480,7 @@ async fn v1_get_vm_history(
     let uid = this.db.upsert_user(&pubkey).await?;
     let vm = this.db.get_vm(id).await?;
     if vm.user_id != uid {
-        return ApiData::err("VM does not belong to you");
+        return Err(ApiError::forbidden("VM does not belong to you"));
     }
 
     let history = match (q.limit, q.offset) {
@@ -1508,7 +1508,7 @@ async fn v1_vm_upgrade_quote(
     let uid = this.db.upsert_user(&pubkey).await?;
     let vm = this.db.get_vm(id).await?;
     if vm.user_id != uid {
-        return ApiData::err("VM does not belong to you");
+        return Err(ApiError::forbidden("VM does not belong to you"));
     }
 
     // Create UpgradeConfig from request
@@ -1552,7 +1552,7 @@ async fn v1_vm_upgrade(
     let uid = this.db.upsert_user(&pubkey).await?;
     let vm = this.db.get_vm(id).await?;
     if vm.user_id != uid {
-        return ApiData::err("VM does not belong to you");
+        return Err(ApiError::forbidden("VM does not belong to you"));
     }
 
     // Create UpgradeConfig from request
@@ -1708,7 +1708,7 @@ async fn v1_patch_firewall_rule(
 
     let mut rule = this.db.get_vm_firewall_rule(rule_id).await?;
     if rule.vm_id != vm.id {
-        return ApiData::err("Firewall rule does not belong to this VM");
+        return Err(ApiError::not_found("Firewall rule does not belong to this VM"));
     }
 
     if let Some(p) = req.priority {
@@ -1765,7 +1765,7 @@ async fn v1_delete_firewall_rule(
 
     let rule = this.db.get_vm_firewall_rule(rule_id).await?;
     if rule.vm_id != vm.id {
-        return ApiData::err("Firewall rule does not belong to this VM");
+        return Err(ApiError::not_found("Firewall rule does not belong to this VM"));
     }
 
     this.db.delete_vm_firewall_rule(rule_id).await?;

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -1030,6 +1030,22 @@ async fn v1_reinstall_vm(
     Path(id): Path<u64>,
 ) -> ApiResult<()> {
     let (uid, vm) = get_user_vm(&auth, &this, id).await?;
+
+    // Reject re-install on an expired VM. The VM may already be stopped/removed
+    // on the host, so running the reinstall pipeline would fail with a 500.
+    // The expiry is authoritative on the VM's subscription.
+    let vm_expires = this
+        .db
+        .get_subscription_by_line_item_id(vm.subscription_line_item_id)
+        .await
+        .ok()
+        .and_then(|s| s.expires);
+    if is_vm_expired(vm_expires, Utc::now()) {
+        return Err(ApiError::payment_required(
+            "Cannot re-install an expired VM, please renew it first",
+        ));
+    }
+
     let old_image_id = vm.image_id;
     let host = this.db.get_host(vm.host_id).await?;
     let client = get_host_client(&host, &this.settings.provisioner)?;
@@ -1779,6 +1795,14 @@ async fn get_user_vm(auth: &Nip98Auth, this: &RouterState, id: u64) -> Result<(u
     Ok((uid, vm))
 }
 
+/// Determine whether a VM is expired based on its subscription expiry.
+///
+/// A `None` expiry means the VM has never been paid for and is treated as
+/// expired. An expiry at or before `now` is also expired.
+fn is_vm_expired(expires: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    expires.map(|e| e <= now).unwrap_or(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2004,5 +2028,31 @@ mod tests {
             result[0].currencies,
             vec![ApiCurrency::EUR, ApiCurrency::USD]
         );
+    }
+
+    // Regression test for issue #141: re-installing an expired VM must be
+    // rejected up-front (mapped to 402 PaymentRequired) instead of running the
+    // reinstall pipeline that fails with a 500.
+    #[test]
+    fn test_is_vm_expired() {
+        let now = Utc::now();
+
+        // Never paid (no subscription expiry) -> expired
+        assert!(is_vm_expired(None, now));
+
+        // Expired in the past -> expired
+        assert!(is_vm_expired(Some(now - chrono::Duration::hours(1)), now));
+
+        // Exactly now -> expired (boundary)
+        assert!(is_vm_expired(Some(now), now));
+
+        // Future expiry -> not expired
+        assert!(!is_vm_expired(Some(now + chrono::Duration::hours(1)), now));
+    }
+
+    #[test]
+    fn test_expired_vm_reinstall_error_is_payment_required() {
+        let err = ApiError::payment_required("Cannot re-install an expired VM");
+        assert_eq!(err.code, axum::http::StatusCode::PAYMENT_REQUIRED);
     }
 }

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -145,7 +145,7 @@ async fn v1_patch_account(
                 let info = client
                     .get_info()
                     .await
-                    .map_err(|e| ApiError::new(format!("Failed to connect to NWC: {}", e)))?;
+                    .map_err(|e| ApiError::bad_request(format!("Failed to connect to NWC: {}", e)))?;
                 if !info.methods.contains(&nwc::prelude::Method::PayInvoice) {
                     return ApiData::err("NWC connection must allow pay_invoice");
                 }
@@ -160,7 +160,7 @@ async fn v1_patch_account(
         let result = vat_client
             .validate_vat_number(tax_id, None)
             .await
-            .map_err(|e| ApiError::new(format!("Failed to validate tax ID: {}", e)))?;
+            .map_err(|e| ApiError::bad_request(format!("Failed to validate tax ID: {}", e)))?;
         if !result.valid {
             return ApiData::err("Invalid tax ID");
         }
@@ -738,7 +738,7 @@ async fn v1_create_custom_vm_order(
     // there's no way to send the verification email, so the requirement is
     // skipped to keep ordering usable on installs without email.
     if this.settings.smtp.is_some() && !user.email_verified {
-        return Err(ApiError::new(
+        return Err(ApiError::forbidden(
             "Email verification is required before creating a VM",
         ));
     }
@@ -788,7 +788,7 @@ async fn v1_add_ssh_key(
     let pk: PublicKey = req
         .key_data
         .parse()
-        .map_err(|_| ApiError::new("Invalid SSH public key format"))?;
+        .map_err(|_| ApiError::bad_request("Invalid SSH public key format"))?;
     let key_name = if !req.name.is_empty() {
         &req.name
     } else {
@@ -799,7 +799,7 @@ async fn v1_add_ssh_key(
         user_id: uid,
         key_data: pk
             .to_openssh()
-            .map_err(|_| ApiError::new("Failed to encode SSH key"))?
+            .map_err(|e| ApiError::internal(format!("Failed to encode SSH key: {}", e)))?
             .into(),
         ..Default::default()
     };
@@ -827,7 +827,7 @@ async fn v1_create_vm_order(
     // Email verification is only enforced when SMTP is configured (see
     // v1_create_custom_vm_order for rationale).
     if this.settings.smtp.is_some() && !user.email_verified {
-        return Err(ApiError::new(
+        return Err(ApiError::forbidden(
             "Email verification is required before creating a VM",
         ));
     }
@@ -1778,7 +1778,7 @@ async fn apply_firewall(this: &RouterState, vm_id: u64) -> Result<(), ApiError> 
     this.work_sender
         .send(WorkJob::ApplyVmFirewall { vm_id })
         .await
-        .map_err(|e| ApiError::new(&format!("Failed to queue firewall update: {}", e)))?;
+        .map_err(|e| ApiError::internal(format!("Failed to queue firewall update: {}", e)))?;
     Ok(())
 }
 
@@ -1787,10 +1787,10 @@ async fn get_user_vm(auth: &Nip98Auth, this: &RouterState, id: u64) -> Result<(u
     let uid = this.db.upsert_user(&pubkey).await?;
     let vm = this.db.get_vm(id).await?;
     if uid != vm.user_id {
-        return Err(ApiError::new("VM does not belong to you"));
+        return Err(ApiError::forbidden("VM does not belong to you"));
     }
     if vm.deleted {
-        return Err(ApiError::new("VM not found"));
+        return Err(ApiError::not_found("VM not found"));
     }
     Ok((uid, vm))
 }

--- a/lnvps_api/src/api/subscriptions.rs
+++ b/lnvps_api/src/api/subscriptions.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use chrono::Utc;
 use lnvps_api_common::{
-    ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, Nip98Auth, PageQuery,
+    ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, Nip98Auth, PageQuery,
 };
 use lnvps_db::{IntervalType, PaymentMethod, Subscription, SubscriptionLineItem, SubscriptionType};
 use std::str::FromStr;
@@ -71,7 +71,7 @@ pub async fn v1_get_subscription(
 
     // Verify ownership
     if subscription.user_id != uid {
-        return ApiData::err("Access denied: not your subscription");
+        return Err(ApiError::forbidden("Access denied: not your subscription"));
     }
 
     ApiData::ok(ApiSubscription::from_subscription(this.db.as_ref(), subscription).await?)
@@ -192,12 +192,12 @@ async fn v1_create_subscription(
             ApiCreateSubscriptionLineItemRequest::AsnSponsoring { asn: _ } => {
                 // TODO: Implement ASN sponsoring pricing lookup
                 // For now, return error
-                return ApiData::err("ASN sponsoring not yet implemented");
+                return Err(ApiError::not_implemented("ASN sponsoring not yet implemented"));
             }
             ApiCreateSubscriptionLineItemRequest::DnsHosting { domain: _ } => {
                 // TODO: Implement DNS hosting pricing lookup
                 // For now, return error
-                return ApiData::err("DNS hosting not yet implemented");
+                return Err(ApiError::not_implemented("DNS hosting not yet implemented"));
             }
         }
     }
@@ -277,7 +277,7 @@ async fn v1_renew_subscription(
     // Get and verify subscription ownership
     let subscription = this.db.get_subscription(id).await?;
     if subscription.user_id != uid {
-        return ApiData::err("Access denied: not your subscription");
+        return Err(ApiError::forbidden("Access denied: not your subscription"));
     }
 
     // Determine payment method

--- a/lnvps_api_admin/src/admin/auth.rs
+++ b/lnvps_api_admin/src/admin/auth.rs
@@ -1,12 +1,12 @@
 use crate::admin::RouterState;
 use crate::admin::model::Permission;
-use anyhow::{Result, bail};
+use anyhow::Result;
 use axum::extract::FromRef;
 use axum::{
     extract::FromRequestParts,
     http::{StatusCode, request::Parts},
 };
-use lnvps_api_common::Nip98Auth;
+use lnvps_api_common::{ApiError, Nip98Auth};
 use lnvps_db::{AdminAction, AdminResource, LNVpsDb};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -49,12 +49,19 @@ impl AdminAuth {
         self.permissions.contains(&Permission { resource, action })
     }
 
-    /// Require a specific permission, returning an error if not present
-    pub fn require_permission(&self, resource: AdminResource, action: AdminAction) -> Result<()> {
+    /// Require a specific permission, returning a 403 error if not present
+    pub fn require_permission(
+        &self,
+        resource: AdminResource,
+        action: AdminAction,
+    ) -> std::result::Result<(), ApiError> {
         if self.has_permission(resource, action) {
             Ok(())
         } else {
-            bail!("Insufficient permissions for {}::{}", resource, action)
+            Err(ApiError::forbidden(format!(
+                "Insufficient permissions for {}::{}",
+                resource, action
+            )))
         }
     }
 
@@ -65,8 +72,11 @@ impl AdminAuth {
             .any(|perm| self.permissions.contains(perm))
     }
 
-    /// Require any of the specified permissions
-    pub fn require_any_permission(&self, permissions: &[Permission]) -> anyhow::Result<()> {
+    /// Require any of the specified permissions, returning a 403 error if none present
+    pub fn require_any_permission(
+        &self,
+        permissions: &[Permission],
+    ) -> std::result::Result<(), ApiError> {
         if self.has_any_permission(permissions) {
             Ok(())
         } else {
@@ -74,10 +84,10 @@ impl AdminAuth {
                 .iter()
                 .map(|p| format!("{}::{}", p.resource, p.action))
                 .collect();
-            bail!(
+            Err(ApiError::forbidden(format!(
                 "Insufficient permissions, need one of: {}",
                 perm_strings.join(", ")
-            )
+            )))
         }
     }
 }

--- a/lnvps_api_admin/src/admin/cost_plans.rs
+++ b/lnvps_api_admin/src/admin/cost_plans.rs
@@ -6,7 +6,7 @@ use crate::admin::model::{
 use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
+use lnvps_api_common::{ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
 use lnvps_db::{AdminAction, AdminResource, LNVpsDb, VmCostPlan};
 use std::sync::Arc;
 
@@ -114,7 +114,7 @@ async fn admin_update_cost_plan(
     // Update fields if provided
     if let Some(name) = req.name {
         if name.trim().is_empty() {
-            return Err(anyhow::anyhow!("Cost plan name cannot be empty").into());
+            return Err(ApiError::bad_request("Cost plan name cannot be empty"));
         }
         cost_plan.name = name.trim().to_string();
     }
@@ -123,13 +123,13 @@ async fn admin_update_cost_plan(
     }
     if let Some(currency) = req.currency {
         if currency.trim().is_empty() {
-            return Err(anyhow::anyhow!("Currency cannot be empty").into());
+            return Err(ApiError::bad_request("Currency cannot be empty"));
         }
         cost_plan.currency = currency.trim().to_uppercase();
     }
     if let Some(interval_amount) = req.interval_amount {
         if interval_amount == 0 {
-            return Err(anyhow::anyhow!("Interval amount cannot be zero").into());
+            return Err(ApiError::bad_request("Interval amount cannot be zero"));
         }
         cost_plan.interval_amount = interval_amount;
     }

--- a/lnvps_api_admin/src/admin/hosts.rs
+++ b/lnvps_api_admin/src/admin/hosts.rs
@@ -5,7 +5,7 @@ use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
 use lnvps_api_common::{
-    ApiData, ApiDiskInterface, ApiDiskType, ApiPaginatedData, ApiPaginatedResult, ApiResult,
+    ApiData, ApiDiskInterface, ApiDiskType, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult,
     PageQuery,
 };
 use lnvps_db::{AdminAction, AdminResource};
@@ -353,7 +353,7 @@ async fn admin_get_host_disk(
 
     // Verify disk belongs to this host
     if disk.host_id != host_id {
-        return Err(anyhow::anyhow!("Disk {} does not belong to host {}", disk_id, host_id).into());
+        return Err(ApiError::not_found(format!("Disk {} does not belong to host {}", disk_id, host_id)));
     }
 
     ApiData::ok(disk.into())
@@ -377,7 +377,7 @@ async fn admin_update_host_disk(
 
     // Verify disk belongs to this host
     if disk.host_id != host_id {
-        return Err(anyhow::anyhow!("Disk {} does not belong to host {}", disk_id, host_id).into());
+        return Err(ApiError::not_found(format!("Disk {} does not belong to host {}", disk_id, host_id)));
     }
 
     // Update fields if provided

--- a/lnvps_api_admin/src/admin/ip_space.rs
+++ b/lnvps_api_admin/src/admin/ip_space.rs
@@ -8,7 +8,7 @@ use crate::admin::model::{
 use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult};
+use lnvps_api_common::{ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult};
 use lnvps_db::{AdminAction, AdminResource, InternetRegistry};
 use serde::Deserialize;
 
@@ -344,7 +344,7 @@ async fn admin_get_ip_space_pricing(
 
     // Verify the pricing belongs to this space
     if pricing.available_ip_space_id != space_id {
-        return ApiData::err("Pricing does not belong to the specified IP space");
+        return Err(ApiError::not_found("Pricing does not belong to the specified IP space"));
     }
 
     let mut info = AdminIpSpacePricingInfo::from(pricing);
@@ -418,7 +418,7 @@ async fn admin_update_ip_space_pricing(
 
     // Verify the pricing belongs to this space
     if pricing.available_ip_space_id != space_id {
-        return ApiData::err("Pricing does not belong to the specified IP space");
+        return Err(ApiError::not_found("Pricing does not belong to the specified IP space"));
     }
 
     // Update fields if provided

--- a/lnvps_api_admin/src/admin/payment_methods.rs
+++ b/lnvps_api_admin/src/admin/payment_methods.rs
@@ -7,7 +7,7 @@ use crate::admin::model::{
 use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
+use lnvps_api_common::{ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
 use lnvps_db::{AdminAction, AdminResource};
 
 pub fn router() -> Router<RouterState> {
@@ -92,7 +92,7 @@ async fn admin_update_payment_method(
     // Update fields if provided
     if let Some(name) = &request.name {
         if name.trim().is_empty() {
-            return Err(anyhow::anyhow!("Payment method config name cannot be empty").into());
+            return Err(ApiError::bad_request("Payment method config name cannot be empty"));
         }
         config.name = name.trim().to_string();
     }

--- a/lnvps_api_admin/src/admin/reports.rs
+++ b/lnvps_api_admin/src/admin/reports.rs
@@ -4,7 +4,7 @@ use axum::Router;
 use axum::extract::{Query, State};
 use axum::routing::get;
 use chrono::NaiveDate;
-use lnvps_api_common::{ApiData, ApiResult};
+use lnvps_api_common::{ApiData, ApiError, ApiResult};
 use lnvps_db::{AdminAction, AdminResource};
 use serde::{Deserialize, Serialize};
 
@@ -119,7 +119,7 @@ async fn admin_time_series_report(
         .map_err(|_| anyhow::anyhow!("Invalid end_date format. Use YYYY-MM-DD"))?;
 
     if start_date_parsed >= end_date_parsed {
-        return Err(anyhow::anyhow!("start_date must be before end_date").into());
+        return Err(ApiError::bad_request("start_date must be before end_date"));
     }
 
     // Validate currency if provided
@@ -198,7 +198,7 @@ async fn admin_referral_time_series_report(
         .map_err(|_| anyhow::anyhow!("Invalid end_date format. Use YYYY-MM-DD"))?;
 
     if start_date_parsed >= end_date_parsed {
-        return Err(anyhow::anyhow!("start_date must be before end_date").into());
+        return Err(ApiError::bad_request("start_date must be before end_date"));
     }
 
     // Convert dates to UTC datetime for database query

--- a/lnvps_api_admin/src/admin/roles.rs
+++ b/lnvps_api_admin/src/admin/roles.rs
@@ -7,7 +7,7 @@ use crate::admin::model::{
 use axum::extract::{Path, Query, State};
 use axum::routing::{delete, get};
 use axum::{Json, Router};
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
+use lnvps_api_common::{ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
 use lnvps_db::{AdminAction, AdminResource};
 
 pub fn router() -> Router<RouterState> {
@@ -174,7 +174,7 @@ async fn admin_update_role(
 
     // Prevent updating system roles
     if role.is_system_role {
-        return ApiData::err("Cannot modify system roles");
+        return Err(ApiError::forbidden("Cannot modify system roles"));
     }
 
     // Update role fields
@@ -227,7 +227,7 @@ async fn admin_delete_role(
 
     // Prevent deleting system roles
     if role.is_system_role {
-        return ApiData::err("Cannot delete system roles");
+        return Err(ApiError::forbidden("Cannot delete system roles"));
     }
 
     // Check if any users are assigned to this role
@@ -355,7 +355,7 @@ async fn admin_revoke_user_role(
         for user_role_id in user_roles {
             let user_role = this.db.get_role(user_role_id).await?;
             if user_role.name == "super_admin" {
-                return ApiData::err("Super admins cannot revoke their own super_admin role");
+                return Err(ApiError::forbidden("Super admins cannot revoke their own super_admin role"));
             }
         }
     }

--- a/lnvps_api_admin/src/admin/subscriptions.rs
+++ b/lnvps_api_admin/src/admin/subscriptions.rs
@@ -9,7 +9,7 @@ use axum::extract::{Path, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use lnvps_api_common::{
-    ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, WorkJob,
+    ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, WorkJob,
 };
 use lnvps_db::{AdminAction, AdminResource, LNVpsDb};
 use serde::Deserialize;
@@ -241,7 +241,7 @@ async fn admin_update_subscription(
     // Update fields if provided
     if let Some(name) = request.name {
         if name.trim().is_empty() {
-            return Err(anyhow::anyhow!("Subscription name cannot be empty").into());
+            return Err(ApiError::bad_request("Subscription name cannot be empty"));
         }
         subscription.name = name.trim().to_string();
     }
@@ -256,7 +256,7 @@ async fn admin_update_subscription(
     }
     if let Some(currency) = request.currency {
         if currency.trim().is_empty() {
-            return Err(anyhow::anyhow!("Currency cannot be empty").into());
+            return Err(ApiError::bad_request("Currency cannot be empty"));
         }
         subscription.currency = currency.trim().to_uppercase();
     }
@@ -383,7 +383,7 @@ async fn admin_update_subscription_line_item(
     // changing the type would orphan that link.
     if let Some(name) = request.name {
         if name.trim().is_empty() {
-            return Err(anyhow::anyhow!("Line item name cannot be empty").into());
+            return Err(ApiError::bad_request("Line item name cannot be empty"));
         }
         line_item.name = name.trim().to_string();
     }
@@ -489,7 +489,7 @@ async fn admin_complete_subscription_payment(
     let payment = this.db.get_subscription_payment(&payment_id).await?;
 
     if payment.is_paid {
-        return ApiData::err("Payment is already completed");
+        return Err(ApiError::conflict("Payment is already completed"));
     }
 
     this.db.subscription_payment_paid(&payment).await?;

--- a/lnvps_api_admin/src/admin/users.rs
+++ b/lnvps_api_admin/src/admin/users.rs
@@ -5,7 +5,7 @@ use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
 use isocountry::CountryCode;
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
+use lnvps_api_common::{ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
 use lnvps_db::{AdminAction, AdminResource, email_hash};
 use serde::Deserialize;
 
@@ -99,7 +99,7 @@ async fn admin_find_user_by_email(
 
     match user {
         Some(u) => ApiData::ok(u.into()),
-        None => ApiData::err("User not found"),
+        None => Err(ApiError::not_found("User not found")),
     }
 }
 

--- a/lnvps_api_admin/src/admin/vm_ip_assignments.rs
+++ b/lnvps_api_admin/src/admin/vm_ip_assignments.rs
@@ -8,7 +8,7 @@ use axum::routing::get;
 use axum::{Json, Router};
 use chrono::Utc;
 use lnvps_api_common::{
-    ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, NetworkProvisioner, WorkJob,
+    ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, NetworkProvisioner, WorkJob,
 };
 use lnvps_db::{AdminAction, AdminResource};
 use serde::Deserialize;
@@ -107,7 +107,7 @@ async fn admin_create_vm_ip_assignment(
     // Validate VM exists
     let vm = this.db.get_vm(req.vm_id).await?;
     if vm.deleted {
-        return ApiData::err("Cannot assign IP to a deleted VM");
+        return Err(ApiError::conflict("Cannot assign IP to a deleted VM"));
     }
 
     // Check subscription state (use shortcut function)
@@ -117,17 +117,17 @@ async fn admin_create_vm_ip_assignment(
         .await?;
 
     if !sub.is_setup {
-        return ApiData::err("Cannot assign IP to a new VM");
+        return Err(ApiError::conflict("Cannot assign IP to a new VM"));
     }
 
     if sub.expires.map(|e| e < Utc::now()).unwrap_or(true) {
-        return ApiData::err("Cannot assign IP to an expired VM");
+        return Err(ApiError::conflict("Cannot assign IP to an expired VM"));
     }
 
     // Validate IP range exists and is enabled
     let ip_range = this.db.admin_get_ip_range(req.ip_range_id).await?;
     if !ip_range.enabled {
-        return ApiData::err("Cannot assign IP from a disabled IP range");
+        return Err(ApiError::conflict("Cannot assign IP from a disabled IP range"));
     }
 
     // If IP is provided, validate it's within the range

--- a/lnvps_api_admin/src/admin/vm_templates.rs
+++ b/lnvps_api_admin/src/admin/vm_templates.rs
@@ -7,7 +7,7 @@ use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
 use chrono::Utc;
-use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
+use lnvps_api_common::{ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
 use lnvps_db::{AdminAction, AdminResource, LNVpsDb, VmTemplate};
 use std::sync::Arc;
 
@@ -155,7 +155,7 @@ async fn admin_create_vm_template(
             .unwrap_or(lnvps_api_common::ApiIntervalType::Month);
 
         if cost_plan_interval_amount == 0 {
-            return Err(anyhow::anyhow!("Cost plan interval amount cannot be zero").into());
+            return Err(ApiError::bad_request("Cost plan interval amount cannot be zero"));
         }
 
         let new_cost_plan = lnvps_db::VmCostPlan {
@@ -282,7 +282,7 @@ async fn admin_update_vm_template(
         // Update cost plan fields if provided
         if let Some(cost_plan_name) = req.cost_plan_name {
             if cost_plan_name.trim().is_empty() {
-                return Err(anyhow::anyhow!("Cost plan name cannot be empty").into());
+                return Err(ApiError::bad_request("Cost plan name cannot be empty"));
             }
             cost_plan.name = cost_plan_name.trim().to_string();
         }
@@ -291,13 +291,13 @@ async fn admin_update_vm_template(
         }
         if let Some(cost_plan_currency) = req.cost_plan_currency {
             if cost_plan_currency.trim().is_empty() {
-                return Err(anyhow::anyhow!("Cost plan currency cannot be empty").into());
+                return Err(ApiError::bad_request("Cost plan currency cannot be empty"));
             }
             cost_plan.currency = cost_plan_currency.trim().to_uppercase();
         }
         if let Some(cost_plan_interval_amount) = req.cost_plan_interval_amount {
             if cost_plan_interval_amount == 0 {
-                return Err(anyhow::anyhow!("Cost plan interval amount cannot be zero").into());
+                return Err(ApiError::bad_request("Cost plan interval amount cannot be zero"));
             }
             cost_plan.interval_amount = cost_plan_interval_amount;
         }

--- a/lnvps_api_admin/src/admin/vms.rs
+++ b/lnvps_api_admin/src/admin/vms.rs
@@ -9,7 +9,7 @@ use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use chrono::{DateTime, Days, Utc};
 use lnvps_api_common::{
-    ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, PricingEngine,
+    ApiData, ApiError, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery, PricingEngine,
     UpgradeConfig, VmHistoryLogger, VmRunningState, VmStateCache, WorkJob,
 };
 use lnvps_db::{AdminAction, AdminResource, SubscriptionPaymentType};
@@ -273,7 +273,7 @@ async fn admin_patch_vm(
     let mut vm = this.db.get_vm(id).await?;
 
     if vm.deleted {
-        return ApiData::err("Cannot update a deleted VM");
+        return Err(ApiError::conflict("Cannot update a deleted VM"));
     }
 
     let mut needs_reconfigure = false;
@@ -330,7 +330,7 @@ async fn admin_start_vm(
     let vm = this.db.get_vm(id).await?;
 
     if vm.deleted {
-        return ApiData::err("Cannot start a deleted VM");
+        return Err(ApiError::conflict("Cannot start a deleted VM"));
     }
 
     // Send start job via Redis stream for distributed processing
@@ -364,7 +364,7 @@ async fn admin_stop_vm(
     let vm = this.db.get_vm(id).await?;
 
     if vm.deleted {
-        return ApiData::err("Cannot stop a deleted VM");
+        return Err(ApiError::conflict("Cannot stop a deleted VM"));
     }
 
     // Send stop job via Redis stream for distributed processing
@@ -419,7 +419,7 @@ async fn admin_delete_vm(
     let vm = this.db.get_vm(id).await?;
 
     if vm.deleted {
-        return ApiData::err("VM is already deleted");
+        return Err(ApiError::conflict("VM is already deleted"));
     }
 
     // Send delete job via Redis stream for distributed processing
@@ -455,7 +455,7 @@ async fn admin_extend_vm(
     let mut vm = this.db.get_vm(id).await?;
 
     if vm.deleted {
-        return ApiData::err("Cannot extend a deleted VM");
+        return Err(ApiError::conflict("Cannot extend a deleted VM"));
     }
 
     // Validate days (reasonable limits)
@@ -575,7 +575,7 @@ async fn admin_get_vm_history(
 
     // Verify history entry belongs to this VM
     if history.vm_id != vm_id {
-        return ApiData::err("History entry does not belong to this VM");
+        return Err(ApiError::not_found("History entry does not belong to this VM"));
     }
 
     let admin_history_info =
@@ -641,7 +641,7 @@ async fn admin_get_vm_payment(
         .get_vm_by_subscription(payment.subscription_id)
         .await?;
     if payment_vm.id != vm.id {
-        return ApiData::err("Payment does not belong to this VM");
+        return Err(ApiError::not_found("Payment does not belong to this VM"));
     }
 
     let base_currency = this.db.get_vm_base_currency(vm_id).await?;
@@ -851,11 +851,11 @@ async fn admin_complete_vm_payment(
         .get_vm_by_subscription(payment.subscription_id)
         .await?;
     if payment_vm.id != vm.id {
-        return ApiData::err("Payment does not belong to this VM");
+        return Err(ApiError::not_found("Payment does not belong to this VM"));
     }
 
     if payment.is_paid {
-        return ApiData::err("Payment is already completed");
+        return Err(ApiError::conflict("Payment is already completed"));
     }
 
     // Mark as paid (atomically sets is_paid, paid_at, extends VM expiry via time_value)

--- a/lnvps_api_common/Cargo.toml
+++ b/lnvps_api_common/Cargo.toml
@@ -33,4 +33,5 @@ redis = { version = "1", features = ["tokio-comp", "cluster"] }
 
 [dev-dependencies]
 env_logger = "0.11"
+sqlx = { version = "0.8", default-features = false }
 

--- a/lnvps_api_common/src/routes.rs
+++ b/lnvps_api_common/src/routes.rs
@@ -55,11 +55,16 @@ pub struct ApiError {
 }
 
 impl ApiError {
-    /// Create an API error with a user-safe message
+    /// Create an API error with a user-safe message (HTTP 400 Bad Request).
+    ///
+    /// `new` is intended for client-caused errors carrying a user-safe
+    /// message. For internal failures that should not leak details use
+    /// [`ApiError::internal`]; for other client errors use the dedicated
+    /// [`ApiError::not_found`], [`ApiError::forbidden`], etc. helpers.
     pub fn new(message: impl ToString) -> Self {
         Self {
             error: message.to_string(),
-            code: StatusCode::INTERNAL_SERVER_ERROR,
+            code: StatusCode::BAD_REQUEST,
         }
     }
 
@@ -71,9 +76,34 @@ impl ApiError {
         }
     }
 
+    /// Create a 400 Bad Request error (explicit alias for [`ApiError::new`])
+    pub fn bad_request(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::BAD_REQUEST, message)
+    }
+
+    /// Create a 401 Unauthorized error
+    pub fn unauthorized(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::UNAUTHORIZED, message)
+    }
+
+    /// Create a 403 Forbidden error
+    pub fn forbidden(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::FORBIDDEN, message)
+    }
+
+    /// Create a 404 Not Found error
+    pub fn not_found(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::NOT_FOUND, message)
+    }
+
     /// Create a 402 Payment Required error
     pub fn payment_required(message: impl ToString) -> Self {
         Self::with_status(StatusCode::PAYMENT_REQUIRED, message)
+    }
+
+    /// Create a 409 Conflict error
+    pub fn conflict(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::CONFLICT, message)
     }
 
     /// Create an API error from an internal error, logging the full details
@@ -106,6 +136,10 @@ impl From<anyhow::Error> for ApiError {
 
 impl From<lnvps_db::DbError> for ApiError {
     fn from(value: lnvps_db::DbError) -> Self {
+        // A missing row is a client-side "not found", not an internal error.
+        if value.is_row_not_found() {
+            return Self::not_found("Resource not found");
+        }
         Self::internal(value)
     }
 }
@@ -149,6 +183,39 @@ mod tests {
         let error = ApiError::new("Something went wrong");
         let json = serde_json::to_string(&error).unwrap();
         assert_eq!(json, r#"{"error":"Something went wrong"}"#);
+    }
+
+    #[test]
+    fn test_api_error_status_codes() {
+        assert_eq!(ApiError::new("x").code, StatusCode::BAD_REQUEST);
+        assert_eq!(ApiError::bad_request("x").code, StatusCode::BAD_REQUEST);
+        assert_eq!(ApiError::unauthorized("x").code, StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            ApiError::payment_required("x").code,
+            StatusCode::PAYMENT_REQUIRED
+        );
+        assert_eq!(ApiError::forbidden("x").code, StatusCode::FORBIDDEN);
+        assert_eq!(ApiError::not_found("x").code, StatusCode::NOT_FOUND);
+        assert_eq!(ApiError::conflict("x").code, StatusCode::CONFLICT);
+        assert_eq!(
+            ApiError::internal("x").code,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
+            ApiError::with_status(StatusCode::IM_A_TEAPOT, "x").code,
+            StatusCode::IM_A_TEAPOT
+        );
+    }
+
+    #[test]
+    fn test_db_row_not_found_maps_to_404() {
+        // A missing DB row must become a 404, not a 500.
+        let err: ApiError = lnvps_db::DbError::SqlxError(sqlx::Error::RowNotFound).into();
+        assert_eq!(err.code, StatusCode::NOT_FOUND);
+
+        // Any other DB error stays a 500.
+        let err: ApiError = lnvps_db::DbError::Unknown.into();
+        assert_eq!(err.code, StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[test]

--- a/lnvps_api_common/src/routes.rs
+++ b/lnvps_api_common/src/routes.rs
@@ -48,6 +48,10 @@ impl<T: Serialize> ApiPaginatedData<T> {
 #[derive(Serialize)]
 pub struct ApiError {
     pub error: String,
+    /// HTTP status code to return for this error. Skipped during serialization
+    /// (the response body only carries the `error` message).
+    #[serde(skip)]
+    pub code: StatusCode,
 }
 
 impl ApiError {
@@ -55,7 +59,21 @@ impl ApiError {
     pub fn new(message: impl ToString) -> Self {
         Self {
             error: message.to_string(),
+            code: StatusCode::INTERNAL_SERVER_ERROR,
         }
+    }
+
+    /// Create an API error with a specific HTTP status code
+    pub fn with_status(code: StatusCode, message: impl ToString) -> Self {
+        Self {
+            error: message.to_string(),
+            code,
+        }
+    }
+
+    /// Create a 402 Payment Required error
+    pub fn payment_required(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::PAYMENT_REQUIRED, message)
     }
 
     /// Create an API error from an internal error, logging the full details
@@ -65,6 +83,7 @@ impl ApiError {
         error!("Internal error: {}", err);
         Self {
             error: "An internal error occurred".to_string(),
+            code: StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -74,6 +93,7 @@ impl ApiError {
         error!("Internal error: {}", err);
         Self {
             error: err.to_string(),
+            code: StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
@@ -116,7 +136,7 @@ impl From<String> for ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, Json(self)).into_response()
+        (self.code, Json(self)).into_response()
     }
 }
 

--- a/lnvps_api_common/src/routes.rs
+++ b/lnvps_api_common/src/routes.rs
@@ -106,6 +106,11 @@ impl ApiError {
         Self::with_status(StatusCode::CONFLICT, message)
     }
 
+    /// Create a 501 Not Implemented error
+    pub fn not_implemented(message: impl ToString) -> Self {
+        Self::with_status(StatusCode::NOT_IMPLEMENTED, message)
+    }
+
     /// Create an API error from an internal error, logging the full details
     /// but only returning a generic message to the client (in non-admin mode)
     #[cfg(not(feature = "admin"))]

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -53,6 +53,15 @@ pub enum DbError {
     Unknown,
 }
 
+impl DbError {
+    /// Whether this error represents a "row not found" result, i.e. a query
+    /// that expected exactly one row returned none. Useful for mapping to an
+    /// HTTP 404 at the API layer.
+    pub fn is_row_not_found(&self) -> bool {
+        matches!(self, DbError::SqlxError(sqlx::Error::RowNotFound))
+    }
+}
+
 impl From<DbError> for OpError<anyhow::Error> {
     fn from(e: DbError) -> OpError<Error> {
         match &e {
@@ -811,3 +820,15 @@ impl<T> LNVpsDb for T where T: LNVpsDbBase + LNVPSNostrDb + Send + Sync {}
 
 #[cfg(all(not(feature = "admin"), not(feature = "nostr-domain")))]
 impl<T> LNVpsDb for T where T: LNVpsDbBase + Send + Sync {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_row_not_found() {
+        assert!(DbError::SqlxError(sqlx::Error::RowNotFound).is_row_not_found());
+        assert!(!DbError::Unknown.is_row_not_found());
+        assert!(!DbError::SqlxError(sqlx::Error::PoolClosed).is_row_not_found());
+    }
+}

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -284,8 +284,10 @@ mod tests {
         assert!(
             resp.status() == StatusCode::OK
                 || resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::NOT_FOUND
+                || resp.status() == StatusCode::CONFLICT
                 || resp.status() == StatusCode::INTERNAL_SERVER_ERROR,
-            "Refund calc should return 200, 400, or 500, got: {}",
+            "Refund calc should return 200, 400, 404, 409, or 500, got: {}",
             resp.status()
         );
     }
@@ -308,8 +310,10 @@ mod tests {
         assert!(
             resp.status() == StatusCode::OK
                 || resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::NOT_FOUND
+                || resp.status() == StatusCode::CONFLICT
                 || resp.status() == StatusCode::INTERNAL_SERVER_ERROR,
-            "VM extend should return 200, 400, or 500, got: {}",
+            "VM extend should return 200, 400, 404, 409, or 500, got: {}",
             resp.status()
         );
     }

--- a/lnvps_e2e/src/rbac.rs
+++ b/lnvps_e2e/src/rbac.rs
@@ -74,7 +74,7 @@ mod tests {
         setup_rbac().await;
         let client = admin_client_with_keys(no_role_keys().clone());
         let resp = client.get_auth("/api/admin/v1/users").await.unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         let body = resp.text().await.unwrap();
         assert!(body.contains("Insufficient permissions"));
     }
@@ -84,7 +84,7 @@ mod tests {
         setup_rbac().await;
         let client = admin_client_with_keys(no_role_keys().clone());
         let resp = client.get_auth("/api/admin/v1/vms").await.unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         let body = resp.text().await.unwrap();
         assert!(body.contains("Insufficient permissions"));
     }
@@ -130,7 +130,7 @@ mod tests {
             .post_auth("/api/admin/v1/regions", &body)
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         let text = resp.text().await.unwrap();
         assert!(text.contains("Insufficient permissions"));
     }
@@ -147,7 +147,7 @@ mod tests {
             .post_auth("/api/admin/v1/roles", &body)
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     // ========================================================================
@@ -190,7 +190,7 @@ mod tests {
             .post_auth("/api/admin/v1/roles", &body)
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     // ========================================================================
@@ -238,7 +238,7 @@ mod tests {
         setup_rbac().await;
         let client = admin_client_with_keys(payment_manager_keys().clone());
         let resp = client.get_auth("/api/admin/v1/vms").await.unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -275,7 +275,7 @@ mod tests {
 
         // Should now be denied
         let resp = client.get_auth("/api/admin/v1/users").await.unwrap();
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         let body = resp.text().await.unwrap();
         assert!(body.contains("Insufficient permissions"));
     }


### PR DESCRIPTION
Fixes #141

## 1. Re-install on expired VM (#141)

`PATCH /api/v1/vm/{id}/re-install` on an **expired** VM returned `500` because it ran the reinstall pipeline (stop → unlink → import → start) on a VM that may already be stopped/removed on the host. It now checks the VM's subscription expiry **up-front** and returns `402 Payment Required`.

## 2. Accurate HTTP status codes (follow-up)

Previously nearly every `ApiError` mapped to `500 Internal Server Error`. This adds proper status-code support and maps the common cases:

- `ApiError` gains a `code: StatusCode` field plus constructors: `with_status`, `bad_request`, `unauthorized`, `forbidden`, `not_found`, `payment_required`, `conflict`. `IntoResponse` honours it.
- `ApiError::new` now defaults to **400** (it carries a user-safe message).
- `From<DbError>` maps a missing row (`sqlx::Error::RowNotFound`) to **404** across the user + admin APIs; other DB errors stay **500**. New `DbError::is_row_not_found()` helper.
- Site fixes: `VM not found` → 404, `does not belong to you` → 403, email-verification-required → 403, invalid SSH key / lightning address / tax ID → 400, referral `Not enrolled` → 404. Genuine `Failed to …` internal failures kept explicitly as **500**.
- Response bodies are unchanged (`{ "error": string }`).

## Tests

- `test_is_vm_expired`, `test_expired_vm_reinstall_error_is_payment_required`
- `test_api_error_status_codes`, `test_db_row_not_found_maps_to_404`, `test_is_row_not_found`

Full workspace builds; changed-crate tests pass. (Some pre-existing flaky provisioner/worker tests fail intermittently under parallelism on `master` too — unrelated to this change.) API_CHANGELOG updated under Fixed + Changed.