### PR TITLE
fix: codebase audit — correctness and safety fixes

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -192,6 +192,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **2026-07-07** - Codebase audit: correctness and safety fixes
+  - **Payments:** subscription payment settlement is now idempotent — duplicate webhook deliveries or replayed Lightning settle events no longer extend a subscription's expiry more than once (`subscription_payment_paid` now guards on `is_paid` and skips the extension when the payment was already paid). Revolut order metadata is now persisted on settlement.
+  - **Custom VM orders:** requested CPU/memory/disk are now validated against the pricing plan's configured min/max limits, disk pricing is matched on both disk kind *and* interface, and sub-GB memory/disk is billed (rounded up) instead of truncating to zero. Previously a custom order could be under-billed or effectively free.
+  - **VM lifecycle:** `PATCH /api/v1/vm/{id}/restart` now actually restarts the VM (it previously only issued a stop, leaving the VM powered off). VM deletion no longer frees the DB record and IP assignments when the hypervisor is merely unreachable — only a definitive 404 is treated as "already gone"; transient errors abort the delete. Proxmox HTTP errors are now classified fatal/transient by status code instead of blanket-retrying 4xx.
+  - **Renewals & pricing:** a pending renewal invoice is no longer reused for a request covering a different number of intervals (which let a multi-interval request be paid off with a smaller single-interval invoice); VPS-only subscription setup fees are now charged on the first invoice; and extending an already-expired VM now clamps the new expiry to "now" consistently with every other renewal path.
+  - **Robustness:** fixed remote-triggerable panics in NIP-98 auth (malformed single-element tags) and VAT-number parsing (multi-byte input), and a panic in VM status when an IP range fails to load.
+  - **Admin/DB:** creating or updating available IP space now persists `company_id` (the insert previously failed on the NOT-NULL column); non-VM subscription payments are correctly attributed to their company in admin payment views and revenue reports; `admin_update_company` now persists `base_currency`; and per-region capacity stats no longer under-count hosts that share the same CPU/memory values.
+  - **Support agent, health checks & host tooling:** the support agent no longer crashes on non-ASCII messages or empty LLM responses, uses UID-based IMAP operations (no duplicate replies), and URL-encodes email lookups; health-check metrics handle IPv6 DNS servers and IPv6 bind addresses; and host CPU-feature detection uses a safe CPUID intrinsic with a max-leaf guard.
+  - **XDP firewall:** corrected the SYN rate-limiter token-bucket refill math (previously refilled far too fast, defeating the limit), stopped counting SYN-ACK replies, and guarded against a zero-limit division.
+
 - **2026-06-25** - Admin VM `template_id` is now `null` for custom-template VMs
   - `AdminVmInfo.template_id` (returned by `GET /api/admin/v1/vms` and `GET /api/admin/v1/vms/{id}`) changed from `u64` to a nullable integer. VMs on a custom template previously reported `template_id: 0`; they now correctly report `template_id: null` (with the linked template carried by `custom_template_id`). Standard-template VMs are unaffected.
 

--- a/lnvps_agent/src/agent/mod.rs
+++ b/lnvps_agent/src/agent/mod.rs
@@ -21,6 +21,12 @@ use crate::settings::Settings;
 
 pub use executor::{LnvpsToolExecutor, PublicToolExecutor, ToolExecutor};
 
+/// Truncate a string to at most `max` characters for logging, without panicking
+/// on multi-byte UTF-8 boundaries (byte-index slicing would panic).
+fn truncate_chars(s: &str, max: usize) -> String {
+    s.chars().take(max).collect()
+}
+
 /// Number of stored chat messages that triggers a compaction pass.
 const COMPACTION_THRESHOLD: usize = 30;
 
@@ -190,7 +196,10 @@ impl SupportAgent {
                 .build()?;
 
             let response = client.chat().create(request).await?;
-            let choice = &response.choices[0];
+            let choice = response
+                .choices
+                .first()
+                .ok_or_else(|| anyhow!("LLM returned no choices"))?;
 
             if let Some(ref tool_calls) = choice.message.tool_calls
                 && !tool_calls.is_empty()
@@ -219,7 +228,7 @@ impl SupportAgent {
                         Ok(content) => content,
                         Err(e) => format!("Error: {}", e),
                     };
-                    log::info!("Tool {} result: {}", name, &result[..result.len().min(200)]);
+                    log::info!("Tool {} result: {}", name, truncate_chars(&result, 200));
 
                     request_messages.push(
                         ChatCompletionRequestToolMessageArgs::default()
@@ -314,7 +323,10 @@ impl SupportAgent {
             .build()?;
 
         let response = client.chat().create(request).await?;
-        let summary = response.choices[0]
+        let summary = response
+            .choices
+            .first()
+            .ok_or_else(|| anyhow!("LLM returned no choices"))?
             .message
             .content
             .clone()
@@ -428,7 +440,7 @@ impl SupportAgent {
             log::info!(
                 "Processing request from {}: {}",
                 req.sender.conversation_key(),
-                &req.message[..req.message.len().min(100)]
+                truncate_chars(&req.message, 100)
             );
 
             let reply_ctx = req.channel_context.clone();
@@ -443,7 +455,7 @@ impl SupportAgent {
                 }
             };
 
-            log::info!("Response: {}", &response[..response.len().min(200)]);
+            log::info!("Response: {}", truncate_chars(&response, 200));
 
             if let Err(e) = channel
                 .send_reply(SupportReply {
@@ -463,6 +475,22 @@ impl SupportAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: truncating for logging must not panic on multi-byte UTF-8
+    /// input (byte-index slicing previously panicked mid-character).
+    #[test]
+    fn truncate_chars_handles_multibyte() {
+        // 100th byte lands inside a multi-byte char in the original bug.
+        let s = "é".repeat(200);
+        let out = truncate_chars(&s, 100);
+        assert_eq!(out.chars().count(), 100);
+        // Emoji (4-byte) input must also be safe.
+        let emoji = "🚀".repeat(50);
+        let out = truncate_chars(&emoji, 10);
+        assert_eq!(out.chars().count(), 10);
+        // Shorter-than-limit input is returned whole.
+        assert_eq!(truncate_chars("hi", 100), "hi");
+    }
 
     #[test]
     fn to_request_message_maps_roles() {

--- a/lnvps_agent/src/api_client.rs
+++ b/lnvps_agent/src/api_client.rs
@@ -7,6 +7,22 @@ use crate::identity::{Requester, SenderIdentity};
 use crate::nip98::Nip98Signer;
 use crate::settings::Settings;
 
+/// Percent-encode a string for safe use as a URL query-component value.
+/// Only the RFC 3986 unreserved characters are passed through verbatim;
+/// everything else (including `&`, `=`, `+`, space, `@`) is percent-encoded.
+fn encode_query_component(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
 /// HTTP client for calling the LNVPS admin and user APIs.
 ///
 /// Generates fresh NIP-98 auth tokens from an nsec key on every request.
@@ -228,7 +244,12 @@ impl ApiClient {
 
     /// Lookup a user by email address via the indexed email_hash column.
     pub async fn admin_find_user_by_email(&self, email: &str) -> Result<Option<serde_json::Value>> {
-        let request_path = format!("/api/admin/v1/users/by-email?email={}", email);
+        // Percent-encode the (untrusted) email so characters like `&`/`=`/space
+        // can't inject extra query parameters into the admin API request.
+        let request_path = format!(
+            "/api/admin/v1/users/by-email?email={}",
+            encode_query_component(email)
+        );
         let rsp: serde_json::Value = self
             .admin_request(
                 Method::GET,
@@ -377,4 +398,20 @@ struct ApiResponseWrapper<T> {
     #[serde(default)]
     #[allow(dead_code)]
     error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_query_component;
+
+    /// Regression: untrusted email values must be percent-encoded so they can't
+    /// inject extra query parameters into the admin API request.
+    #[test]
+    fn encode_query_component_escapes_injection() {
+        assert_eq!(encode_query_component("a@b.com"), "a%40b.com");
+        assert_eq!(encode_query_component("x&admin=1"), "x%26admin%3D1");
+        assert_eq!(encode_query_component("a b"), "a%20b");
+        // Unreserved chars pass through.
+        assert_eq!(encode_query_component("A9-_.~"), "A9-_.~");
+    }
 }

--- a/lnvps_agent/src/channel/email.rs
+++ b/lnvps_agent/src/channel/email.rs
@@ -291,12 +291,16 @@ async fn fetch_and_process(
 
     let t = Duration::from_secs(15);
 
-    let unseen: Vec<String> = timeout(t, session.search("UNSEEN"))
+    // Use UID-based search/fetch/store throughout. Mixing sequence numbers
+    // (from `search`/`fetch`/`store`) with UIDs flags the wrong messages
+    // whenever UID != seq (any mailbox that has had messages expunged), causing
+    // processed mail to stay UNSEEN and be re-processed after every reconnect.
+    let unseen: Vec<String> = timeout(t, session.uid_search("UNSEEN"))
         .await
         .context("IMAP search timed out")?
         .context("IMAP search failed")?
         .into_iter()
-        .map(|seq: async_imap::types::Seq| seq.to_string())
+        .map(|uid: async_imap::types::Uid| uid.to_string())
         .collect();
 
     if unseen.is_empty() {
@@ -305,7 +309,7 @@ async fn fetch_and_process(
 
     log::info!("Found {} unseen messages", unseen.len());
     let fetch_range = unseen.join(",");
-    let fetch_stream = timeout(t, session.fetch(&fetch_range, "(FLAGS UID RFC822)"))
+    let fetch_stream = timeout(t, session.uid_fetch(&fetch_range, "(FLAGS UID RFC822)"))
         .await
         .context("IMAP fetch timed out")?
         .context("IMAP fetch failed")?;
@@ -340,7 +344,7 @@ async fn fetch_and_process(
 
         let Some(ref from_email) = from_email else {
             log::warn!("Message UID {} has no From address, skipping", uid);
-            session.store(uid_str, "+FLAGS (\\Seen)").await.ok();
+            session.uid_store(uid_str, "+FLAGS (\\Seen)").await.ok();
             continue;
         };
 
@@ -384,7 +388,7 @@ async fn fetch_and_process(
             return Ok(());
         }
 
-        session.store(uid_str, "+FLAGS (\\Seen)").await.ok();
+        session.uid_store(uid_str, "+FLAGS (\\Seen)").await.ok();
     }
 
     Ok(())

--- a/lnvps_agent/src/channel/kind1.rs
+++ b/lnvps_agent/src/channel/kind1.rs
@@ -122,7 +122,7 @@ impl Kind1SupportChannel {
                                     "Kind1 mention from {} (event {}): {}",
                                     &author_hex[..16.min(author_hex.len())],
                                     event.id,
-                                    &event.content[..event.content.len().min(100)]
+                                    event.content.chars().take(100).collect::<String>()
                                 );
 
                                 let req = IncomingSupportRequest {

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -414,10 +414,7 @@ async fn v1_telegram_link(
 }
 
 /// Unlink the user's Telegram chat and disable Telegram notifications.
-async fn v1_telegram_unlink(
-    auth: Nip98Auth,
-    State(this): State<RouterState>,
-) -> ApiResult<()> {
+async fn v1_telegram_unlink(auth: Nip98Auth, State(this): State<RouterState>) -> ApiResult<()> {
     let pubkey = auth.event.pubkey.to_bytes();
     let uid = this.db.upsert_user(&pubkey).await?;
     let mut user = this.db.get_user(uid).await?;
@@ -467,8 +464,7 @@ async fn v1_whatsapp_verify(
     user.whatsapp_verify_code = Some(code.clone());
     this.db.update_user(&user).await?;
 
-    let client =
-        crate::notifications::WhatsAppClient::new(wa, reqwest::Client::new());
+    let client = crate::notifications::WhatsAppClient::new(wa, reqwest::Client::new());
     if let Err(e) = client
         .send_template(number, &wa.verify_template, &wa.verify_template_lang, &code)
         .await
@@ -504,10 +500,7 @@ async fn v1_whatsapp_confirm(
 }
 
 /// Remove the user's WhatsApp number and disable WhatsApp notifications.
-async fn v1_whatsapp_unlink(
-    auth: Nip98Auth,
-    State(this): State<RouterState>,
-) -> ApiResult<()> {
+async fn v1_whatsapp_unlink(auth: Nip98Auth, State(this): State<RouterState>) -> ApiResult<()> {
     let pubkey = auth.event.pubkey.to_bytes();
     let uid = this.db.upsert_user(&pubkey).await?;
     let mut user = this.db.get_user(uid).await?;
@@ -1009,7 +1002,9 @@ async fn v1_restart_vm(
     let (uid, vm) = get_user_vm(&auth, &this, id).await?;
     let host = this.db.get_host(vm.host_id).await?;
     let client = get_host_client(&host, &this.settings.provisioner)?;
-    client.stop_vm(&vm).await?;
+    // Hard reset (restart) the VM — previously this only issued a stop, leaving
+    // the VM powered off.
+    client.reset_vm(&vm).await?;
 
     // Log VM restart
     this.history

--- a/lnvps_api/src/host/proxmox.rs
+++ b/lnvps_api/src/host/proxmox.rs
@@ -80,6 +80,24 @@ impl ProxmoxClient {
         Ok(rsp.data)
     }
 
+    /// Like [`get_vm_status`] but returns `Ok(None)` when the VM does not exist
+    /// (404). Transient failures (timeout, connection error, 5xx) are returned
+    /// as `Err` so callers can tell "gone" apart from "couldn't reach the host".
+    pub async fn get_vm_status_opt(
+        &self,
+        node: &str,
+        vm_id: ProxmoxVmId,
+    ) -> OpResult<Option<VmInfo>> {
+        let rsp: Option<ResponseBase<VmInfo>> = self
+            .api
+            .get_opt(&format!(
+                "/api2/json/nodes/{}/qemu/{}/status/current",
+                node, vm_id
+            ))
+            .await?;
+        Ok(rsp.map(|r| r.data))
+    }
+
     pub async fn list_vms(&self, node: &str) -> OpResult<Vec<VmInfo>> {
         let rsp: ResponseBase<Vec<VmInfo>> = self
             .api
@@ -1168,16 +1186,27 @@ impl ProxmoxClient {
 
     /// Destroy a VM by ID (stop first, then delete via SSH)
     async fn destroy_vm(&self, vm_id: ProxmoxVmId) -> OpResult<()> {
-        // Check if VM exists first
-        if self.get_vm_status(&self.node, vm_id).await.is_err() {
+        // Check if VM exists first. Only a definitive 404 (Ok(None)) means the VM
+        // is already gone; a transient failure returns Err and must abort the
+        // destroy so we don't free the DB record / IPs while the VM is still
+        // running on the host.
+        if self.get_vm_status_opt(&self.node, vm_id).await?.is_none() {
             info!("VM {} doesn't exist, skipping destroy", vm_id);
             return Ok(());
         }
 
+        // Destroying requires SSH access to run `qm destroy`. Without it we can
+        // only stop the VM, which would leave it undestroyed while the caller
+        // proceeds to release its resources — fail loudly instead.
+        let ssh = match &self.ssh {
+            Some(ssh) => ssh,
+            None => op_fatal!("Cannot destroy VM {}: no SSH access configured", vm_id),
+        };
+
         // Stop first, ignoring errors
         self.stop_vm(&self.node, vm_id).await.ok();
 
-        if let Some(ssh) = &self.ssh {
+        {
             let mut ses = SshClient::new().map_err(OpError::Transient)?;
             ses.connect(
                 (self.api.base().host().unwrap().to_string(), 22),
@@ -1548,6 +1577,10 @@ impl VmHostClient for ProxmoxClient {
         let mut states = Vec::new();
 
         for vm in vm_list {
+            // Skip VMs not managed by LNVPS (vmid < 100 has no valid db id).
+            if vm.vm_id < 100 {
+                continue;
+            }
             let vmid: ProxmoxVmId = vm.vm_id.into();
             states.push((vmid.0, vm.into()));
         }
@@ -1951,7 +1984,10 @@ impl From<u64> for ProxmoxVmId {
 
 impl From<i32> for ProxmoxVmId {
     fn from(value: i32) -> Self {
-        Self(value as u64 - 100)
+        // LNVPS VMs use vmid = db_id + 100. Saturate instead of wrapping so a
+        // non-LNVPS VM with vmid < 100 can't underflow into a huge u64 (release)
+        // or panic (debug). Ids below 100 aren't managed by us anyway.
+        Self((value as i64 - 100).max(0) as u64)
     }
 }
 
@@ -2857,6 +2893,24 @@ mod tests {
         );
         assert_eq!(vm.cpu_limit, None);
         Ok(())
+    }
+
+    /// Regression: converting an i32 vmid below 100 (a VM not managed by LNVPS)
+    /// must not underflow/panic. Ids >= 100 map to db_id = vmid - 100.
+    #[test]
+    fn test_proxmox_vm_id_from_i32_no_underflow() {
+        // Below 100 saturates to 0 rather than wrapping / panicking.
+        assert_eq!(ProxmoxVmId::from(0i32).0, 0);
+        assert_eq!(ProxmoxVmId::from(50i32).0, 0);
+        assert_eq!(ProxmoxVmId::from(99i32).0, 0);
+        // Normal LNVPS ids map correctly.
+        assert_eq!(ProxmoxVmId::from(100i32).0, 0);
+        assert_eq!(ProxmoxVmId::from(101i32).0, 1);
+        assert_eq!(ProxmoxVmId::from(600i32).0, 500);
+        // Round-trip for a valid id.
+        let id = ProxmoxVmId::from(1234u64);
+        let back: i32 = id.into();
+        assert_eq!(back, 1334);
     }
 
     #[test]

--- a/lnvps_api/src/json_api.rs
+++ b/lnvps_api/src/json_api.rs
@@ -229,9 +229,23 @@ impl JsonApi {
                     op_fatal!("Failed to parse JSON from {}: {} {}", path, text, e);
                 }
             }
-        } else {
-            // TODO: handle status codes as fatal/transient
+        } else if is_retryable_status(status) {
             op_transient!("{} {}: {}: {}", method, path, status, &text);
+        } else {
+            // Definitive client errors (404/401/403/400 ...) must not be retried:
+            // e.g. a 404 means the resource really is gone, not a transient outage.
+            op_fatal!("{} {}: {}: {}", method, path, status, &text);
+        }
+    }
+
+    /// GET that maps a 404 Not Found response to `Ok(None)`, so callers can
+    /// distinguish "the resource definitively does not exist" from a transient
+    /// failure (timeout, connection error, 5xx) which is returned as `Err`.
+    pub async fn get_opt<T: DeserializeOwned>(&self, path: &str) -> OpResult<Option<T>> {
+        match self.get::<T>(path).await {
+            Ok(v) => Ok(Some(v)),
+            Err(e) if is_not_found_error(e.inner()) => Ok(None),
+            Err(e) => Err(e),
         }
     }
 
@@ -272,15 +286,56 @@ impl JsonApi {
         debug!("<< {}", text);
         if status.is_success() {
             Ok(status.as_u16())
-        } else {
+        } else if is_retryable_status(status) {
             op_transient!("{} {}: {}: {}", method, path, status, &text);
+        } else {
+            op_fatal!("{} {}: {}: {}", method, path, status, &text);
         }
     }
 }
 
+/// HTTP status codes that are worth retrying: server errors (5xx) plus the two
+/// retryable client errors (408 Request Timeout, 429 Too Many Requests). All
+/// other 4xx codes are definitive and should be treated as fatal.
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error()
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
+/// Detect whether a fatal request error was caused by a 404 Not Found response.
+fn is_not_found_error(err: &anyhow::Error) -> bool {
+    err.to_string().contains("404 Not Found")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::is_stale_connection_message;
+    use super::{is_not_found_error, is_retryable_status, is_stale_connection_message};
+    use reqwest::StatusCode;
+
+    #[test]
+    fn only_5xx_408_429_are_retryable() {
+        // Retryable
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        // Definitive (fatal) — must NOT be retried
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn detects_404_not_found_error() {
+        // Mirrors the message built in req(): "GET /path: 404 Not Found: body"
+        let err = anyhow::anyhow!("GET /api2/json/nodes/n/qemu/100: 404 Not Found: ");
+        assert!(is_not_found_error(&err));
+        let other = anyhow::anyhow!("GET /api2/json/nodes/n/qemu/100: 500 Internal Server Error: ");
+        assert!(!is_not_found_error(&other));
+    }
 
     #[test]
     fn detects_connection_closed_before_message_completed() {

--- a/lnvps_api/src/subscription/mod.rs
+++ b/lnvps_api/src/subscription/mod.rs
@@ -310,17 +310,22 @@ impl SubscriptionHandler {
         let subscription_currency = Currency::from_str(&subscription.currency)
             .map_err(|_| anyhow::anyhow!("Invalid currency"))?;
 
-        // Convert non-VM amounts to the payment method currency if any exist
+        // Setup fees are charged once, on the first (purchase) invoice. They are
+        // denominated in the subscription currency and must be converted to the
+        // payment currency together with any non-VM line item cost. Include them
+        // even when there are no non-VM items (e.g. a VPS-only subscription),
+        // otherwise VPS setup fees are silently dropped.
+        let setup_fee_due = if subscription.is_setup { 0 } else { setup_fee };
+        let non_vm_base = non_vm_interval_cost + setup_fee_due;
+
+        // Convert non-VM amounts (+ setup fee) to the payment method currency
         let (non_vm_converted_amount, non_vm_rate, non_vm_tax, non_vm_processing_fee): (
             u64,
             f32,
             u64,
             u64,
-        ) = if non_vm_interval_cost > 0 {
-            let mut base = non_vm_interval_cost;
-            if !subscription.is_setup {
-                base += setup_fee;
-            }
+        ) = if non_vm_base > 0 {
+            let base = non_vm_base;
             let list_price = CurrencyAmount::from_u64(subscription_currency, base);
             let converted = self.pe.get_amount_and_rate(list_price, method).await?;
             let tax = self

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -1951,11 +1951,19 @@ impl LNVpsDbBase for MockDb {
     }
 
     async fn subscription_payment_paid(&self, payment: &SubscriptionPayment) -> DbResult<()> {
-        // Mark payment as paid with timestamp
+        // Mark payment as paid with timestamp. Idempotent: if the payment is already
+        // paid (or unknown), do nothing and skip the expiry extension below.
         let mut payments = self.subscription_payments.lock().await;
-        if let Some(p) = payments.iter_mut().find(|p| p.id == payment.id) {
-            p.is_paid = true;
-            p.paid_at = Some(Utc::now());
+        match payments.iter_mut().find(|p| p.id == payment.id) {
+            Some(p) if !p.is_paid => {
+                p.is_paid = true;
+                p.paid_at = Some(Utc::now());
+                p.external_data = payment.external_data.clone();
+            }
+            _ => {
+                drop(payments);
+                return Ok(());
+            }
         }
         drop(payments);
 
@@ -3571,6 +3579,70 @@ mod tests {
             (diff - 86400).abs() < 5,
             "Second payment should add ~86400s from first expiry, but diff was {}s",
             diff
+        );
+    }
+
+    /// Regression: vm_to_status must return an error (not panic) when a VM's IP
+    /// assignment references an IP range that cannot be loaded. Previously the
+    /// failed range lookup was silently dropped and then `.expect()` panicked.
+    #[tokio::test]
+    async fn test_vm_to_status_missing_ip_range_errors_not_panics() {
+        use crate::model::vm_to_status;
+        use lnvps_db::{LNVpsDb, UserSshKey, VmIpAssignment};
+
+        let db = MockDb::default();
+        db.vms.lock().await.insert(1, MockDb::mock_vm());
+        db.insert_user_ssh_key(&UserSshKey {
+            id: 0,
+            name: "k".to_string(),
+            user_id: 1,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        // IP assignment pointing at a non-existent range id.
+        db.ip_assignments.lock().await.insert(
+            1,
+            VmIpAssignment {
+                id: 1,
+                vm_id: 1,
+                ip_range_id: 999,
+                ip: "10.0.0.5".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let db: std::sync::Arc<dyn LNVpsDb> = std::sync::Arc::new(db);
+        let vm = db.get_vm(1).await.unwrap();
+        let res = vm_to_status(&db, vm, None).await;
+        assert!(res.is_err(), "expected error, not a panic");
+    }
+
+    /// Regression: paying the SAME payment twice (e.g. duplicate webhook / replayed
+    /// settle event) must extend the subscription only once. Before the idempotency
+    /// guard, the second call double-credited the subscription with free time.
+    #[tokio::test]
+    async fn test_subscription_payment_paid_is_idempotent() {
+        let db = MockDb::default();
+        let payment = make_payment(1, Some(86400));
+        db.insert_subscription_payment(&payment).await.unwrap();
+
+        db.subscription_payment_paid(&payment).await.unwrap();
+        let expires_after_first = {
+            let subs = db.subscriptions.lock().await;
+            subs.get(&1).unwrap().expires.unwrap()
+        };
+
+        // Re-deliver the exact same (already paid) payment.
+        db.subscription_payment_paid(&payment).await.unwrap();
+        let expires_after_second = {
+            let subs = db.subscriptions.lock().await;
+            subs.get(&1).unwrap().expires.unwrap()
+        };
+
+        assert_eq!(
+            expires_after_first, expires_after_second,
+            "duplicate payment settlement must not extend the subscription again"
         );
     }
 

--- a/lnvps_api_common/src/model.rs
+++ b/lnvps_api_common/src/model.rs
@@ -246,10 +246,15 @@ pub async fn vm_to_status(
     let ips = db.list_vm_ip_assignments(vm.id).await?;
     let ip_range_ids: HashSet<u64> = ips.iter().map(|i| i.ip_range_id).collect();
     let ip_ranges: Vec<_> = ip_range_ids.iter().map(|i| db.get_ip_range(*i)).collect();
+    // Propagate errors instead of silently dropping failed range lookups — a
+    // dropped range later caused an `.expect()` panic when building the IP
+    // assignments below.
     let ip_ranges: HashMap<u64, IpRange> = join_all(ip_ranges)
         .await
         .into_iter()
-        .filter_map(Result::ok)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(anyhow::Error::from)?
+        .into_iter()
         .map(|i| (i.id, i))
         .collect();
 
@@ -277,10 +282,10 @@ pub async fn vm_to_status(
             .map(|i| {
                 let range = ip_ranges
                     .get(&i.ip_range_id)
-                    .expect("ip range id not found");
-                ApiVmIpAssignment::from(&i, range)
+                    .ok_or_else(|| anyhow::anyhow!("ip range {} not found", i.ip_range_id))?;
+                Ok(ApiVmIpAssignment::from(&i, range))
             })
-            .collect(),
+            .collect::<Result<Vec<_>>>()?,
         auto_renewal_enabled: sub_auto_renewal,
     })
 }

--- a/lnvps_api_common/src/nip98.rs
+++ b/lnvps_api_common/src/nip98.rs
@@ -30,10 +30,11 @@ impl Nip98Auth {
         // check url tag
         if let Some(url) = self.event.tags.iter().find_map(|t| {
             let vec = t.as_slice();
-            if vec[0] == "u" {
-                Some(vec[1].clone())
-            } else {
-                None
+            // Use get() to avoid panicking on a malformed single-element tag
+            // like ["u"] supplied in an attacker-controlled auth event.
+            match (vec.first(), vec.get(1)) {
+                (Some(k), Some(v)) if k == "u" => Some(v.clone()),
+                _ => None,
             }
         }) {
             // Simple path comparison - extract path from URL
@@ -51,10 +52,9 @@ impl Nip98Auth {
         // check method tag
         if let Some(t_method) = self.event.tags.iter().find_map(|t| {
             let vec = t.as_slice();
-            if vec[0] == "method" {
-                Some(vec[1].clone())
-            } else {
-                None
+            match (vec.first(), vec.get(1)) {
+                (Some(k), Some(v)) if k == "method" => Some(v.clone()),
+                _ => None,
             }
         }) {
             if method != t_method {
@@ -82,6 +82,58 @@ impl Nip98Auth {
         } else {
             bail!("Invalid auth string");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Tag};
+
+    fn signed_event(tags: Vec<Tag>) -> Event {
+        let keys = Keys::generate();
+        EventBuilder::new(Kind::HttpAuth, "")
+            .tags(tags)
+            .custom_created_at(Timestamp::now())
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    /// Regression: a validly-signed auth event containing a malformed
+    /// single-element `["u"]` tag must NOT panic (previously `vec[1]` indexed
+    /// out of bounds). It should be treated as a missing url tag.
+    #[test]
+    fn malformed_single_element_u_tag_does_not_panic() {
+        let event = signed_event(vec![
+            Tag::parse(["u"]).unwrap(),
+            Tag::parse(["method", "GET"]).unwrap(),
+        ]);
+        let auth = Nip98Auth { event };
+        let res = auth.check("/api/v1/account", "GET");
+        assert!(res.is_err(), "expected error, not a panic");
+    }
+
+    /// Same for a malformed single-element `["method"]` tag.
+    #[test]
+    fn malformed_single_element_method_tag_does_not_panic() {
+        let event = signed_event(vec![
+            Tag::parse(["u", "https://example.com/api/v1/account"]).unwrap(),
+            Tag::parse(["method"]).unwrap(),
+        ]);
+        let auth = Nip98Auth { event };
+        let res = auth.check("/api/v1/account", "GET");
+        assert!(res.is_err(), "expected error, not a panic");
+    }
+
+    /// A well-formed auth event still validates successfully.
+    #[test]
+    fn well_formed_tags_pass() {
+        let event = signed_event(vec![
+            Tag::parse(["u", "https://example.com/api/v1/account"]).unwrap(),
+            Tag::parse(["method", "GET"]).unwrap(),
+        ]);
+        let auth = Nip98Auth { event };
+        assert!(auth.check("/api/v1/account", "GET").is_ok());
     }
 }
 

--- a/lnvps_api_common/src/pricing.rs
+++ b/lnvps_api_common/src/pricing.rs
@@ -203,10 +203,14 @@ impl PricingEngine {
         let new_time = (cost.time_value as f64 * scale).floor() as u64;
         ensure!(new_time > 0, "Extend time is less than 1 second");
 
+        // Clamp the base to now for already-expired VMs, matching every other
+        // renewal path. Otherwise the paid time is added onto a past expiry and
+        // the VM can remain expired despite a real payment.
         let vm_expires = self
             .vm_subscription_expires(&vm)
             .await
-            .unwrap_or_else(Utc::now);
+            .unwrap_or_else(Utc::now)
+            .max(Utc::now());
         Ok(CostResult::New(NewPaymentInfo {
             amount: input.value(),
             currency: cost.currency,
@@ -243,13 +247,18 @@ impl PricingEngine {
             self.get_custom_vm_cost(&vm, method, company_id).await?
         };
 
+        // Total time this request would add (one interval's worth * intervals).
+        let requested_time = base_cost.time_value * intervals as u64;
+
         // Check for an existing pending (unpaid, non-expired) renewal payment.
-        // We match on payment_method + payment_type only — matching on time_value is
-        // unreliable because time_value is computed from vm.expires, which advances
-        // after each confirmed payment.
+        // Match on payment_method + payment_type AND the time value it covers, so
+        // that a pending 1-month invoice is NOT returned for a 12-month request
+        // (which would let the user pay the smaller invoice and get 1 month).
         let pending = self.db.list_pending_vm_subscription_payments(vm.id).await?;
         if let Some(px) = pending.into_iter().find(|p| {
-            p.payment_method == method && p.payment_type == SubscriptionPaymentType::Renewal
+            p.payment_method == method
+                && p.payment_type == SubscriptionPaymentType::Renewal
+                && p.time_value == Some(requested_time)
         }) {
             return Ok(CostResult::Existing(px));
         }
@@ -308,15 +317,51 @@ impl PricingEngine {
             })
             .count()
             .max(1); // must have at least 1
-        let disk_pricing =
-            if let Some(p) = pricing_disk.iter().find(|p| p.kind == template.disk_type) {
-                p
-            } else {
-                bail!("No disk price found")
-            };
-        // All costs are in smallest currency units (cents/millisats)
-        let disk_size_gb = template.disk_size / crate::GB;
-        let memory_gb = template.memory / crate::GB;
+        // Match disk pricing on BOTH kind and interface — pricing rows are keyed
+        // by (kind, interface), so matching on kind alone can bill the wrong rate
+        // (or a rate for an interface the user never requested).
+        let disk_pricing = if let Some(p) = pricing_disk
+            .iter()
+            .find(|p| p.kind == template.disk_type && p.interface == template.disk_interface)
+        {
+            p
+        } else {
+            bail!("No disk price found")
+        };
+
+        // Validate the requested spec against the plan's configured limits so a
+        // user cannot order out-of-range (or sub-GB, effectively free) resources.
+        if template.cpu < pricing.min_cpu || template.cpu > pricing.max_cpu {
+            bail!(
+                "CPU count {} out of range ({}-{})",
+                template.cpu,
+                pricing.min_cpu,
+                pricing.max_cpu
+            );
+        }
+        if template.memory < pricing.min_memory || template.memory > pricing.max_memory {
+            bail!(
+                "Memory {} out of range ({}-{})",
+                template.memory,
+                pricing.min_memory,
+                pricing.max_memory
+            );
+        }
+        if template.disk_size < disk_pricing.min_disk_size
+            || template.disk_size > disk_pricing.max_disk_size
+        {
+            bail!(
+                "Disk size {} out of range ({}-{})",
+                template.disk_size,
+                disk_pricing.min_disk_size,
+                disk_pricing.max_disk_size
+            );
+        }
+
+        // All costs are in smallest currency units (cents/millisats). Round GB
+        // counts UP so sub-GB fractions are billed rather than truncated to 0.
+        let disk_size_gb = template.disk_size.div_ceil(crate::GB);
+        let memory_gb = template.memory.div_ceil(crate::GB);
 
         let disk_cost = disk_size_gb * disk_pricing.cost;
         let cpu_cost = pricing.cpu_cost * template.cpu as u64;
@@ -1099,6 +1144,71 @@ mod tests {
         assert_eq!(400, price.disk_cost);
         assert_eq!(855, price.total());
 
+        Ok(())
+    }
+
+    /// Regression: sub-GB memory/disk must be billed (rounded up), not truncated
+    /// to 0. Previously `memory / GB` floored a request just under 2 GB to 1 GB
+    /// (and anything under 1 GB to free).
+    #[tokio::test]
+    async fn custom_pricing_rounds_up_partial_gb() -> Result<()> {
+        let db = MockDb::default();
+        add_custom_pricing(&db).await;
+        // Request 1 byte over 1 GB of RAM and 1 byte over 5 GB disk.
+        {
+            let mut t = db.custom_template.lock().await;
+            let tpl = t.get_mut(&1).unwrap();
+            tpl.memory = crate::GB + 1;
+            tpl.disk_size = 5 * crate::GB + 1;
+        }
+        let db: Arc<dyn LNVpsDb> = Arc::new(db);
+        let template = db.get_custom_vm_template(1).await?;
+        let price = PricingEngine::get_custom_vm_cost_amount(&db, 1, &template).await?;
+        // memory rounds up to 2 GB * 50 = 100 cents
+        assert_eq!(100, price.memory_cost);
+        // disk rounds up to 6 GB * 5 = 30 cents
+        assert_eq!(30, price.disk_cost);
+        Ok(())
+    }
+
+    /// Regression: requests outside the plan's min/max limits must be rejected.
+    #[tokio::test]
+    async fn custom_pricing_rejects_out_of_range() -> Result<()> {
+        let db = MockDb::default();
+        add_custom_pricing(&db).await;
+        {
+            let mut t = db.custom_template.lock().await;
+            // 0 CPUs is below min_cpu = 1
+            t.get_mut(&1).unwrap().cpu = 0;
+        }
+        let db: Arc<dyn LNVpsDb> = Arc::new(db);
+        let template = db.get_custom_vm_template(1).await?;
+        let res = PricingEngine::get_custom_vm_cost_amount(&db, 1, &template).await;
+        assert!(res.is_err(), "cpu=0 must be rejected (below min_cpu)");
+        Ok(())
+    }
+
+    /// Regression: disk pricing must match the requested interface, not just the
+    /// disk kind. A request for an interface with no pricing row must be rejected
+    /// rather than silently billed at another interface's rate.
+    #[tokio::test]
+    async fn custom_pricing_matches_disk_interface() -> Result<()> {
+        let db = MockDb::default();
+        add_custom_pricing(&db).await;
+        {
+            let mut t = db.custom_template.lock().await;
+            // The only disk pricing row uses the default interface; request a
+            // different one for which no pricing exists.
+            let tpl = t.get_mut(&1).unwrap();
+            tpl.disk_interface = DiskInterface::PCIe;
+        }
+        let db: Arc<dyn LNVpsDb> = Arc::new(db);
+        let template = db.get_custom_vm_template(1).await?;
+        let res = PricingEngine::get_custom_vm_cost_amount(&db, 1, &template).await;
+        assert!(
+            res.is_err(),
+            "an interface with no pricing row must be rejected"
+        );
         Ok(())
     }
 
@@ -2175,7 +2285,21 @@ mod tests {
             },
         );
 
-        // Insert an existing unpaid renewal payment that has not yet expired
+        let db_arc: Arc<dyn LNVpsDb> = db.clone();
+        let pe = make_pe(db_arc).await;
+
+        // Determine the time_value the engine computes for a single-interval
+        // renewal, so the pending payment covers exactly the requested time.
+        let quoted_time = match pe
+            .get_vm_cost_for_intervals(1, PaymentMethod::Lightning, 1)
+            .await?
+        {
+            CostResult::New(p) => p.time_value,
+            CostResult::Existing(_) => bail!("no pending payment expected yet"),
+        };
+
+        // Insert an existing unpaid renewal payment that has not yet expired and
+        // covers the same time value as the request.
         let existing = SubscriptionPayment {
             id: vec![0xabu8; 16],
             subscription_id: 1,
@@ -2190,7 +2314,7 @@ mod tests {
             external_id: None,
             is_paid: false,
             rate: MOCK_RATE,
-            time_value: Some(86400),
+            time_value: Some(quoted_time),
             metadata: None,
             tax: 0,
             processing_fee: 0,
@@ -2198,8 +2322,6 @@ mod tests {
         };
         db.insert_subscription_payment(&existing).await?;
 
-        let db_arc: Arc<dyn LNVpsDb> = db;
-        let pe = make_pe(db_arc).await;
         let result = pe
             .get_vm_cost_for_intervals(1, PaymentMethod::Lightning, 1)
             .await?;
@@ -2209,6 +2331,71 @@ mod tests {
                 assert_eq!(p.id, existing.id, "should return the pre-existing payment");
             }
             CostResult::New(_) => bail!("expected Existing, got New"),
+        }
+        Ok(())
+    }
+
+    /// Regression: a pending 1-interval payment must NOT be reused for a request
+    /// covering more intervals. Otherwise a user could request 12 months, be
+    /// handed the pending 1-month invoice, and get only 1 month for the smaller
+    /// amount.
+    #[tokio::test]
+    async fn test_get_vm_cost_dedup_ignores_interval_mismatch() -> Result<()> {
+        let db = Arc::new(MockDb::default());
+        db.vms.lock().await.insert(1, MockDb::mock_vm());
+        db.users.lock().await.insert(
+            1,
+            User {
+                id: 1,
+                pubkey: vec![],
+                ..Default::default()
+            },
+        );
+
+        let db_arc: Arc<dyn LNVpsDb> = db.clone();
+        let pe = make_pe(db_arc).await;
+
+        // Time value the engine computes for a single interval.
+        let one_interval_time = match pe
+            .get_vm_cost_for_intervals(1, PaymentMethod::Lightning, 1)
+            .await?
+        {
+            CostResult::New(p) => p.time_value,
+            CostResult::Existing(_) => bail!("no pending payment expected yet"),
+        };
+
+        // Insert a pending payment covering only ONE interval.
+        let existing = SubscriptionPayment {
+            id: vec![0xabu8; 16],
+            subscription_id: 1,
+            user_id: 1,
+            created: Utc::now(),
+            expires: Utc::now() + chrono::Duration::minutes(10),
+            amount: 9999,
+            currency: "BTC".to_string(),
+            payment_method: PaymentMethod::Lightning,
+            payment_type: SubscriptionPaymentType::Renewal,
+            external_data: "lnbc_test".to_string().into(),
+            external_id: None,
+            is_paid: false,
+            rate: MOCK_RATE,
+            time_value: Some(one_interval_time),
+            metadata: None,
+            tax: 0,
+            processing_fee: 0,
+            paid_at: None,
+        };
+        db.insert_subscription_payment(&existing).await?;
+
+        // Requesting 12 intervals must NOT reuse the 1-interval pending payment.
+        let result = pe
+            .get_vm_cost_for_intervals(1, PaymentMethod::Lightning, 12)
+            .await?;
+        match result {
+            CostResult::New(_) => {}
+            CostResult::Existing(_) => {
+                bail!("12-interval request must not reuse a 1-interval pending payment")
+            }
         }
         Ok(())
     }

--- a/lnvps_api_common/src/vat.rs
+++ b/lnvps_api_common/src/vat.rs
@@ -165,17 +165,24 @@ impl EuVatClient {
         let (country, number) = if let Some(cc) = country_code {
             (cc.to_uppercase(), cleaned)
         } else {
-            // Extract country code from VAT number (first 2 characters)
-            if cleaned.len() < 3 {
-                bail!("VAT number too short");
-            }
-            let cc = &cleaned[..2];
-            if !cc.chars().all(|c| c.is_ascii_alphabetic()) {
+            // Extract country code from VAT number (first 2 characters).
+            // Operate on chars, not bytes: byte-slicing user-supplied input like
+            // "€12345" (where byte offset 2 is not a char boundary) would panic.
+            let mut chars = cleaned.chars();
+            let c0 = chars.next();
+            let c1 = chars.next();
+            let (c0, c1) = match (c0, c1) {
+                (Some(a), Some(b)) if chars.next().is_some() => (a, b),
+                _ => bail!("VAT number too short"),
+            };
+            if !c0.is_ascii_alphabetic() || !c1.is_ascii_alphabetic() {
                 bail!(
                     "VAT number must start with 2-letter country code or country_code must be provided"
                 );
             }
-            (cc.to_uppercase(), cleaned[2..].to_string())
+            let country = format!("{}{}", c0, c1).to_uppercase();
+            let number: String = cleaned.chars().skip(2).collect();
+            (country, number)
         };
 
         trace!("Validating VAT number: {} for country: {}", number, country);
@@ -302,5 +309,25 @@ mod tests {
         assert!(!result.valid, "Random VAT number should be invalid");
         assert_eq!(result.country_code, "DE");
         assert_eq!(result.vat_number, "123456789");
+    }
+
+    /// Regression: a VAT number starting with a multi-byte character (byte
+    /// offset 2 not on a char boundary) must return an error, not panic on
+    /// `&cleaned[..2]`. Parsing fails before any network call is made.
+    #[tokio::test]
+    async fn test_validate_vat_number_multibyte_does_not_panic() {
+        let client = EuVatClient::new();
+        let result = client.validate_vat_number("€12345", None).await;
+        assert!(
+            result.is_err(),
+            "multi-byte VAT number should error, not panic"
+        );
+    }
+
+    /// A single-character (too short) input must also error cleanly.
+    #[tokio::test]
+    async fn test_validate_vat_number_too_short() {
+        let client = EuVatClient::new();
+        assert!(client.validate_vat_number("D", None).await.is_err());
     }
 }

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -2072,8 +2072,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         let result: (String,) = sqlx::query_as(
             "SELECT c.base_currency 
              FROM subscription s
-             JOIN users u ON s.user_id = u.id
-             JOIN company c ON u.id = c.id
+             JOIN company c ON s.company_id = c.id
              WHERE s.id = ?",
         )
         .bind(subscription_id)
@@ -2254,7 +2253,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
              LEFT JOIN vm_host_region vhr ON vh.region_id = vhr.id
              JOIN company c ON (CASE WHEN vhr.company_id IS NOT NULL
                                      THEN vhr.company_id
-                                     ELSE s.user_id END) = c.id
+                                     ELSE s.company_id END) = c.id
              WHERE sp.id = ?",
         )
         .bind(id)
@@ -2320,11 +2319,22 @@ impl LNVpsDbBase for LNVpsDbMysql {
     async fn subscription_payment_paid(&self, payment: &SubscriptionPayment) -> DbResult<()> {
         let mut tx = self.db.begin().await?;
 
-        // Mark payment as paid
-        sqlx::query("UPDATE subscription_payment SET is_paid = 1, paid_at = NOW() WHERE id = ?")
-            .bind(&payment.id)
-            .execute(tx.as_mut())
-            .await?;
+        // Mark payment as paid. The `AND is_paid = 0` guard makes this idempotent:
+        // duplicate webhook deliveries / replayed settle events affect 0 rows and
+        // are skipped below, so the subscription expiry is never extended twice.
+        let paid = sqlx::query(
+            "UPDATE subscription_payment SET is_paid = 1, external_data = ?, paid_at = NOW() WHERE id = ? AND is_paid = 0",
+        )
+        .bind(&payment.external_data)
+        .bind(&payment.id)
+        .execute(tx.as_mut())
+        .await?;
+
+        if paid.rows_affected() == 0 {
+            // Already paid (or unknown id) — nothing to extend, commit no-op.
+            tx.commit().await?;
+            return Ok(());
+        }
 
         // Un-delete any VM linked to this subscription (e.g. auto-cleaned up before
         // payment arrived). This handles payment methods with longer timeouts.
@@ -2465,7 +2475,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
 
     async fn insert_available_ip_space(&self, space: &AvailableIpSpace) -> DbResult<u64> {
         let result = sqlx::query(
-            "INSERT INTO available_ip_space (cidr, min_prefix_size, max_prefix_size, registry, external_id, is_available, is_reserved, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO available_ip_space (cidr, min_prefix_size, max_prefix_size, registry, external_id, is_available, is_reserved, metadata, company_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(&space.cidr)
         .bind(space.min_prefix_size)
@@ -2475,6 +2485,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         .bind(space.is_available)
         .bind(space.is_reserved)
         .bind(&space.metadata)
+        .bind(space.company_id)
         .execute(&self.db)
         .await?;
 
@@ -2483,7 +2494,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
 
     async fn update_available_ip_space(&self, space: &AvailableIpSpace) -> DbResult<()> {
         sqlx::query(
-            "UPDATE available_ip_space SET cidr = ?, min_prefix_size = ?, max_prefix_size = ?, registry = ?, external_id = ?, is_available = ?, is_reserved = ?, metadata = ? WHERE id = ?"
+            "UPDATE available_ip_space SET cidr = ?, min_prefix_size = ?, max_prefix_size = ?, registry = ?, external_id = ?, is_available = ?, is_reserved = ?, metadata = ?, company_id = ? WHERE id = ?"
         )
         .bind(&space.cidr)
         .bind(space.min_prefix_size)
@@ -2493,6 +2504,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         .bind(space.is_available)
         .bind(space.is_reserved)
         .bind(&space.metadata)
+        .bind(space.company_id)
         .bind(space.id)
         .execute(&self.db)
         .await?;
@@ -3744,20 +3756,30 @@ impl AdminDb for LNVpsDbMysql {
     async fn admin_get_region_stats(&self, region_id: u64) -> DbResult<RegionStats> {
         // Get comprehensive region statistics with a single efficient query
         // Use CAST to ensure we get the right SQL types for Rust compatibility
+        // Host aggregates (cpu/memory) must be summed over the deduplicated host
+        // set. Using SUM(DISTINCT h.cpu) deduplicated by *value*, so two hosts
+        // with identical cpu/memory were counted once. Compute host totals and
+        // VM/IP counts in separate subqueries to avoid both the value-dedup bug
+        // and row multiplication from the joins.
         let row: (i64, i64, Option<u64>, Option<u64>, i64) = sqlx::query_as(
             r#"
-            SELECT 
-                COUNT(DISTINCT h.id) as host_count,
-                COUNT(DISTINCT CASE WHEN v.deleted = 0 THEN v.id END) as total_vms,
-                CAST(COALESCE(SUM(DISTINCT h.cpu), 0) AS UNSIGNED) as total_cpu_cores,
-                CAST(COALESCE(SUM(DISTINCT h.memory), 0) AS UNSIGNED) as total_memory_bytes,
-                COUNT(DISTINCT CASE WHEN v.deleted = 0 THEN ip.id END) as total_ip_assignments
-            FROM vm_host h
-            LEFT JOIN vm v ON v.host_id = h.id
-            LEFT JOIN vm_ip_assignment ip ON ip.vm_id = v.id AND ip.deleted = 0
-            WHERE h.region_id = ?
+            SELECT
+                (SELECT COUNT(*) FROM vm_host WHERE region_id = ?) as host_count,
+                (SELECT COUNT(*) FROM vm v
+                    JOIN vm_host h ON v.host_id = h.id
+                    WHERE h.region_id = ? AND v.deleted = 0) as total_vms,
+                CAST((SELECT COALESCE(SUM(cpu), 0) FROM vm_host WHERE region_id = ?) AS UNSIGNED) as total_cpu_cores,
+                CAST((SELECT COALESCE(SUM(memory), 0) FROM vm_host WHERE region_id = ?) AS UNSIGNED) as total_memory_bytes,
+                (SELECT COUNT(*) FROM vm_ip_assignment ip
+                    JOIN vm v ON ip.vm_id = v.id
+                    JOIN vm_host h ON v.host_id = h.id
+                    WHERE h.region_id = ? AND v.deleted = 0 AND ip.deleted = 0) as total_ip_assignments
             "#,
         )
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
         .bind(region_id)
         .fetch_one(&self.db)
         .await?;
@@ -4288,7 +4310,7 @@ impl AdminDb for LNVpsDbMysql {
         sqlx::query(
             r#"UPDATE company SET 
                name = ?, address_1 = ?, address_2 = ?, city = ?, state = ?, 
-               country_code = ?, tax_id = ?, postcode = ?, phone = ?, email = ?
+               country_code = ?, tax_id = ?, postcode = ?, phone = ?, email = ?, base_currency = ?
                WHERE id = ?"#,
         )
         .bind(&company.name)
@@ -4301,6 +4323,7 @@ impl AdminDb for LNVpsDbMysql {
         .bind(&company.postcode)
         .bind(&company.phone)
         .bind(&company.email)
+        .bind(&company.base_currency)
         .bind(company.id)
         .execute(&self.db)
         .await?;
@@ -4362,7 +4385,7 @@ impl AdminDb for LNVpsDbMysql {
              LEFT JOIN vm_host_region vhr ON vh.region_id = vhr.id
              JOIN company c ON (CASE WHEN vhr.company_id IS NOT NULL
                                      THEN vhr.company_id
-                                     ELSE s.user_id END) = c.id
+                                     ELSE s.company_id END) = c.id
              WHERE sp.created >= ",
         );
         query.push_bind(start_date);

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -966,6 +966,46 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    /// Regression: creating IP space must persist company_id. The INSERT
+    /// previously omitted the NOT-NULL company_id column, so this endpoint
+    /// always failed at the DB layer.
+    #[tokio::test]
+    async fn test_admin_create_ip_space_persists_company_id() {
+        let client = setup().await;
+
+        // Pick an existing company id.
+        let resp = client.get_auth("/api/admin/v1/companies").await.unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        let company_id = body["data"]
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|c| c["id"].as_u64())
+            .unwrap_or(1);
+
+        let create_body = serde_json::json!({
+            "company_id": company_id,
+            "cidr": "203.0.113.0/24",
+            "min_prefix_size": 24,
+            "max_prefix_size": 32,
+            "registry": 1
+        });
+        let resp = client
+            .post_auth("/api/admin/v1/ip_space", &create_body)
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "IP space creation should succeed and persist company_id"
+        );
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(
+            body["data"]["company_id"].as_u64(),
+            Some(company_id),
+            "created IP space should carry the requested company_id"
+        );
+    }
+
     #[tokio::test]
     async fn test_admin_get_ip_space_with_pricing_and_subscriptions() {
         let client = setup().await;

--- a/lnvps_e2e/src/lifecycle.rs
+++ b/lnvps_e2e/src/lifecycle.rs
@@ -903,6 +903,33 @@ mod tests {
         let start = json_ok(resp).await;
         eprintln!("Start job: {}", start["data"]["job_id"]);
 
+        // -- RESTART (user endpoint) --
+        // Regression: v1_restart_vm previously only issued a stop, leaving the VM
+        // powered off. It must now hard-reset the VM. The dummy host sets the VM
+        // Running on reset and Stopped on stop, so after a restart the VM must not
+        // be reported as stopped.
+        let resp = user
+            .patch_auth(
+                &format!("/api/v1/vm/{vm_id}/restart"),
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "user restart endpoint should succeed"
+        );
+        let vm_status = json_ok(user.get_auth(&format!("/api/v1/vm/{vm_id}")).await.unwrap()).await;
+        let state = vm_status["data"]["status"]["state"].as_str();
+        assert_ne!(
+            state,
+            Some("stopped"),
+            "VM must not be stopped after a restart, got state={:?}",
+            state
+        );
+        eprintln!("Restart left VM {vm_id} in state {:?}", state);
+
         // -- DISABLE --
         let resp = admin
             .patch_auth(

--- a/lnvps_ebpf/src/main.rs
+++ b/lnvps_ebpf/src/main.rs
@@ -97,7 +97,7 @@ fn handle_ipv4(ctx: &XdpContext) -> Result<u32, &'static str> {
             let udp = ptr_at::<UdpHdr>(&ctx, EthHdr::LEN + Ipv4Hdr::LEN)?;
             handle_l4(ctx, L4Packet::UdpV4 { eth, ip, udp })
         }
-        IpProto::Ipv6Icmp => {
+        IpProto::Icmp => {
             let icmp = ptr_at::<IcmpHdr>(&ctx, EthHdr::LEN + Ipv4Hdr::LEN)?;
             handle_l4(ctx, L4Packet::IcmpV4 { eth, ip, icmp })
         }
@@ -131,9 +131,9 @@ fn handle_ipv6(ctx: &XdpContext) -> Result<u32, &'static str> {
 fn handle_l4(ctx: &XdpContext, pkt: L4Packet<'_>) -> Result<u32, &'static str> {
     match pkt {
         L4Packet::TcpV4 { ip, tcp, .. } => {
-            let syn_flag = tcp.syn();
-            // Is only SYN flag set
-            if syn_flag != 0 && syn_flag == syn_flag {
+            // Only count genuine connection-initiating SYNs (SYN set, ACK clear)
+            // so that SYN-ACK replies to outbound connections aren't rate limited.
+            if tcp.syn() != 0 && tcp.ack() == 0 {
                 // test SYN rate limits
                 if !Bucket::syn_dest_v4(ctx, ip)? {
                     info!(ctx, "L4 TCPv4 SYN DROP");

--- a/lnvps_ebpf/src/maps.rs
+++ b/lnvps_ebpf/src/maps.rs
@@ -19,9 +19,22 @@ impl Bucket {
     /// Tick bucket with rate/burst values
     #[inline(always)]
     pub fn tick(&mut self, now: u64, limits: &PacketLimits) {
-        let tokens_per_ns = 1_000_000_000 / limits.limit;
-        let elapsed = now - self.timestamp;
-        let new_tokens = (elapsed / tokens_per_ns) * limits.limit;
+        // A limit of 0 would divide by zero; treat it as "no refill".
+        if limits.limit == 0 {
+            self.timestamp = now;
+            return;
+        }
+        // Nanoseconds required to accrue a single token.
+        let ns_per_token = 1_000_000_000 / limits.limit;
+        if ns_per_token == 0 {
+            // Refill faster than 1 token/ns: just top up to burst.
+            self.tokens = limits.burst;
+            self.timestamp = now;
+            return;
+        }
+        let elapsed = now.saturating_sub(self.timestamp);
+        // Tokens accrued over the elapsed time (do NOT multiply by limit again).
+        let new_tokens = elapsed / ns_per_token;
         self.tokens = limits.burst.min(self.tokens.saturating_add(new_tokens));
         self.timestamp = now;
     }
@@ -46,11 +59,15 @@ impl Bucket {
                 Ok(false)
             }
         } else {
+            // First packet seen for this destination: seed the bucket with the
+            // configured burst (not the default) and consume one token for this
+            // packet. Fail open (pass) if the map insert fails rather than
+            // panicking into the abort handler.
             let new_bucket = Bucket {
-                tokens: DEFAULT_V4_SYN_RATE_BURST_LIMIT,
+                tokens: rate.burst.saturating_sub(1),
                 timestamp: now,
             };
-            V4_SYN_RATE.insert(&ip.dst_addr, &new_bucket, 0).unwrap();
+            let _ = V4_SYN_RATE.insert(&ip.dst_addr, &new_bucket, 0);
             Ok(true)
         }
     }

--- a/lnvps_health/src/main.rs
+++ b/lnvps_health/src/main.rs
@@ -322,19 +322,32 @@ async fn run_checks(
     Ok(())
 }
 
+/// Split a `type:middle:field2:field1` check id into
+/// `(kind, middle, field2, field1)` where `middle` may itself contain colons
+/// (e.g. an IPv6 DNS server address). Returns None if there aren't enough
+/// segments. The two trailing fields are parsed from the right so the colon-rich
+/// middle segment stays intact.
+fn parse_check_id(check_id: &str) -> Option<(&str, &str, &str, &str)> {
+    let (kind, rest) = check_id.split_once(':')?;
+    // rest = "middle:field2:field1"; take the two trailing fields from the right.
+    let (rest, field1) = rest.rsplit_once(':')?;
+    let (middle, field2) = rest.rsplit_once(':')?;
+    if middle.is_empty() {
+        return None;
+    }
+    Some((kind, middle, field2, field1))
+}
+
 /// Record type-specific metrics based on check ID pattern
 fn record_check_metric(metrics: &HealthMetrics, check_id: &str, result: &checks::CheckResult) {
-    let parts: Vec<&str> = check_id.split(':').collect();
-    if parts.is_empty() {
+    let Some((kind, middle, field2, family)) = parse_check_id(check_id) else {
         return;
-    }
+    };
 
-    match parts[0] {
-        "mss" if parts.len() >= 4 => {
-            // mss:host:port:family
-            let host = parts[1];
-            let port = parts[2];
-            let family = parts[3];
+    match kind {
+        "mss" => {
+            // mss:host:port:family (host may be an IPv6 literal with colons)
+            let (host, port) = (middle, field2);
             if let Some(value) = result.metric_value {
                 metrics
                     .mss_gauge
@@ -348,11 +361,9 @@ fn record_check_metric(metrics: &HealthMetrics, check_id: &str, result: &checks:
                     .set(pmtu);
             }
         }
-        "dns" if parts.len() >= 4 => {
-            // dns:server:query:family
-            let server = parts[1];
-            let query = parts[2];
-            let family = parts[3];
+        "dns" => {
+            // dns:server:query:family (server may be an IPv6 address with colons)
+            let (server, query) = (middle, field2);
             if let Some(value) = result.metric_value {
                 metrics
                     .dns_latency_gauge
@@ -365,8 +376,47 @@ fn record_check_metric(metrics: &HealthMetrics, check_id: &str, result: &checks:
 }
 
 async fn bind_address(address: SocketAddr) -> std::io::Result<TcpListener> {
-    let socket = TcpSocket::new_v4()?;
+    // Create a socket matching the address family so IPv6 bind addresses work.
+    let socket = if address.is_ipv6() {
+        TcpSocket::new_v6()?
+    } else {
+        TcpSocket::new_v4()?
+    };
     socket.set_reuseaddr(true)?;
     socket.bind(address)?;
     socket.listen(1024)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_check_id;
+
+    /// Regression: an IPv6 DNS server address contains colons, so naive
+    /// `split(':')` mis-labelled the exported metrics. parse_check_id keeps the
+    /// colon-rich server segment intact and parses the trailing fields from the
+    /// right.
+    #[test]
+    fn parse_check_id_handles_ipv6_server() {
+        let (kind, server, query, family) =
+            parse_check_id("dns:2606:4700:4700::1111:example.com:v6").unwrap();
+        assert_eq!(kind, "dns");
+        assert_eq!(server, "2606:4700:4700::1111");
+        assert_eq!(query, "example.com");
+        assert_eq!(family, "v6");
+    }
+
+    #[test]
+    fn parse_check_id_handles_ipv4() {
+        let (kind, server, query, family) = parse_check_id("dns:1.1.1.1:example.com:v4").unwrap();
+        assert_eq!(kind, "dns");
+        assert_eq!(server, "1.1.1.1");
+        assert_eq!(query, "example.com");
+        assert_eq!(family, "v4");
+    }
+
+    #[test]
+    fn parse_check_id_rejects_too_short() {
+        assert!(parse_check_id("dns:only").is_none());
+        assert!(parse_check_id("dns").is_none());
+    }
 }

--- a/lnvps_host_util/src/main.rs
+++ b/lnvps_host_util/src/main.rs
@@ -426,22 +426,20 @@ fn detect_cpu_features() -> Vec<String> {
 /// Check for SHA512 extensions via CPUID (leaf 7, subleaf 1, EAX bit 0)
 #[cfg(target_arch = "x86_64")]
 fn has_sha512_extensions() -> bool {
-    // raw-cpuid doesn't expose subleaf 1 directly, so we use inline asm
-    // CPUID leaf 7, subleaf 1, EAX bit 0 = SHA512
-    let eax: u32;
+    // Use the `__cpuid_count` intrinsic instead of hand-written asm: it correctly
+    // preserves rbx and doesn't rely on the (previously incorrect) `nostack`
+    // option, which is UB when the asm pushes/pops the stack.
+    use std::arch::x86_64::__cpuid_count;
     unsafe {
-        std::arch::asm!(
-            "push rbx",       // Save rbx (used by LLVM)
-            "cpuid",
-            "pop rbx",        // Restore rbx
-            inout("eax") 7u32 => eax,
-            inout("ecx") 1u32 => _,
-            out("edx") _,
-            options(nostack),
-        );
+        // Guard: leaf 7 must be supported. The maximum basic leaf is returned in
+        // EAX of leaf 0; executing leaf 7 on an older CPU returns garbage.
+        let max_leaf = __cpuid_count(0, 0).eax;
+        if max_leaf < 7 {
+            return false;
+        }
+        // CPUID leaf 7, subleaf 1, EAX bit 0 = SHA512
+        (__cpuid_count(7, 1).eax & 1) != 0
     }
-    // Bit 0 of EAX = SHA512
-    (eax & 1) != 0
 }
 
 #[cfg(not(target_arch = "x86_64"))]


### PR DESCRIPTION
A codebase audit surfaced a set of correctness and safety bugs across the workspace. This PR fixes the concrete code bugs, each with a regression test where the test harness allows. All non-e2e tests pass (20/20 test binaries) and the workspace compiles cleanly.

## Highlights

**Payments / money**
- `subscription_payment_paid` is now idempotent — duplicate webhooks / replayed Lightning settle events no longer extend a subscription more than once (guarded `UPDATE ... AND is_paid = 0`, skip extension on 0 rows). Persists Revolut `external_data` on settlement.
- Custom VM orders validate cpu/memory/disk against the plan's min/max, match disk pricing on kind **and** interface, and round GB up (`div_ceil`) so sub-GB resources are billed instead of being effectively free.
- A pending renewal invoice is only reused when it covers the same time value (a 12-interval request can no longer be settled with a pending 1-interval invoice); VPS-only setup fees are charged on the first invoice; expired-VM renewals clamp to `now`.

**Hosts / lifecycle**
- `PATCH /api/v1/vm/{id}/restart` now actually restarts (was stop-only).
- `destroy_vm` no longer frees the DB record + IPs on a transient hypervisor error — only a definitive 404 is "already gone". JSON API errors are classified fatal/transient by status code.
- `ProxmoxVmId` conversion no longer underflows for non-LNVPS vmids < 100.

**Robustness / panics**
- Fixed remote-triggerable panics in NIP-98 auth (malformed single-element tags), VAT parsing (multi-byte input), and `vm_to_status` (IP range load failure).

**Admin / DB**
- `insert/update_available_ip_space` now persist `company_id` (insert previously failed on the NOT-NULL column).
- Non-VM subscription payments are attributed to the correct company in admin views/reports; `admin_update_company` persists `base_currency`; region capacity stats no longer under-count hosts sharing CPU/memory values.

**Support agent, health, host tooling**
- Agent no longer crashes on non-ASCII messages or empty LLM responses; uses UID-based IMAP ops (no duplicate replies); URL-encodes email lookups.
- Health metrics handle IPv6 DNS servers and IPv6 bind addresses.
- Host CPU-feature detection uses a safe CPUID intrinsic with a max-leaf guard.

**XDP firewall (eBPF)**
- Corrected token-bucket refill math (was refilling ~limit²/sec, disabling the SYN limit), stopped counting SYN-ACKs, guarded a zero-limit division, fixed the IPv4 ICMP proto constant.

## Testing
- Regression tests added across `lnvps_api`, `lnvps_api_common`, and `lnvps_e2e`.
- `cargo test --workspace --exclude lnvps_e2e -- --test-threads=1` passes (20/20 binaries, 0 failures).
- `lnvps_ebpf` and `lnvps_host_util` can't be compiled in CI-less environments here (BPF target / `cros-libva` system lib); fixes use standard verified APIs.

## Not included (design-level, follow-up)
Email `From:`-header spoofing granting destructive admin tools (needs MTA DMARC/ARC verdict), Kind-1 replies posting PII publicly, capacity oversubscription races, WhatsApp code brute-force rate limiting, and the IPv4-options (IHL) XDP evasion (needs on-target verifier testing).