### PR TITLE
feat: OS image popularity, reinstall with new image, admin VM transfer

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -8,7 +8,8 @@ Admin API request/response format reference for LLM consumption.
 **DiskInterface**: `"sata"`, `"scsi"`, `"pcie"`
 **VmRunningStates**: `"unknown"`, `"running"`, `"stopped"`, `"creating"`
 **AdminVmHistoryActionType**: `"created"`, `"started"`, `"stopped"`, `"restarted"`, `"deleted"`, `"expired"`,
-`"renewed"`, `"reinstalled"`, `"state_changed"`, `"payment_received"`, `"configuration_changed"`
+`"renewed"`, `"reinstalled"`, `"state_changed"`, `"payment_received"`, `"configuration_changed"`,
+`"transferred"`
 **AdminPaymentMethod**: `"lightning"`, `"revolut"`, `"paypal"`, `"stripe"`
 **VmHostKind**: `"proxmox"`, `"libvirt"`
 **CostPlanIntervalType**: `"day"`, `"month"`, `"year"`
@@ -350,6 +351,34 @@ Response:
 **Asynchronous Processing:** This endpoint dispatches a `CreateVm` work job for distributed processing. The operation
 returns immediately with a job ID. The VM creation is handled by the provisioner and includes full audit logging with
 admin action metadata.
+
+#### Transfer VM
+
+```
+POST /api/admin/v1/vms/{id}/transfer
+```
+
+Required Permission: `virtual_machines::update`
+
+Transfers ownership of a VM to another user account (e.g. for account recovery).
+Atomically moves the VM and its billing subscription to the target user and
+clears the old owner's SSH key from the VM. The transfer is recorded in VM
+history.
+
+Request body:
+
+```json
+{
+  "user_id": 456,
+  "reason": "Account recovery"
+}
+```
+
+- `user_id` (required) — the target user account id.
+- `reason` (optional) — free-text reason recorded in the audit log.
+
+Returns `409` if the VM is deleted or already belongs to the target user, and
+`404` if the target user does not exist.
 
 #### Start VM
 

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -22,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Transfer a VM to another user (admin)** — new `POST /api/admin/v1/vms/{id}/transfer` (`virtual_machines::update`) reassigns a VM to another user account, e.g. for account recovery (issue #178). It atomically moves the VM and its billing subscription to the target `user_id` and clears the old owner's SSH key from the VM. The change is recorded in VM history as a new `transferred` action. Rejects deleted VMs, self-transfers (`409`) and unknown target users (`404`). Body: `{ user_id, reason? }`.
+
+- **Change OS during re-install** — `PATCH /api/v1/vm/{id}/re-install` now accepts an optional `{ image_id }` body to switch the VM to a different OS image as part of the re-install (issue #177). When omitted, the VM is reinstalled with its current image (unchanged behaviour). The chosen image must exist and be enabled, and the change is recorded in VM history.
+
+- **OS image popularity** — `GET /api/v1/image` now returns a `popularity` field for each OS image: the fraction (0.0–1.0) of active VMs currently using that image (issue #70).
+
 - **Delete (purge) a user (admin)** — new `DELETE /api/admin/v1/users/{id}` (`users::delete`) permanently removes a user and all of their associated data (soft-deleted VMs and their history/IP/firewall rows and 1:1 custom templates, SSH keys, subscriptions and payments, referral records, Nostr domains, passkeys and saved payment methods) in a single transaction. Rejected if the user still has any live (non-deleted) VMs — those must be deleted first so hypervisor resources are released. Admins cannot delete their own account.
 
 - **Manage user passkeys (admin)** — new admin endpoints to view and revoke a user's WebAuthn passkeys.

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -355,6 +355,7 @@ interface VmOsImage {
   version: string;
   release_date: string; // ISO 8601 datetime
   default_username?: string;
+  popularity: number; // fraction (0.0–1.0) of active VMs using this image
 }
 
 interface UserSshKey {
@@ -855,8 +856,9 @@ interface PatchPaymentMethodRequest {
 #### Reinstall VM
 - **PATCH** `/api/v1/vm/{id}/re-install`
 - **Auth**: Required
+- **Body** (optional): `{ "image_id": number }` — switch the VM to a different OS image as part of the re-install. When omitted, the VM is reinstalled with its current image.
 - **Response**: `null`
-- **Errors**: `402 Payment Required` if the VM is expired (renew it first); `403 Forbidden` if the VM is not yours; `404 Not Found` if the VM does not exist.
+- **Errors**: `402 Payment Required` if the VM is expired (renew it first); `403 Forbidden` if the VM is not yours or the chosen image is not available; `404 Not Found` if the VM or image does not exist.
 
 #### VM Serial Console (WebSocket)
 - **WebSocket** `/api/v1/vm/{id}/console`

--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -806,10 +806,29 @@ async fn v1_patch_vm(
 /// List available VM OS images
 async fn v1_list_vm_images(State(this): State<RouterState>) -> ApiResult<Vec<ApiVmOsImage>> {
     let images = this.db.list_os_image().await?;
+
+    // Compute popularity as the fraction of active VMs using each image
+    let counts: HashMap<u64, u64> = this
+        .db
+        .count_vms_by_os_image()
+        .await?
+        .into_iter()
+        .collect();
+    let total: u64 = counts.values().sum();
+
     let ret = images
         .into_iter()
         .filter(|i| i.enabled)
-        .map(|i| i.into())
+        .map(|i| {
+            let count = counts.get(&i.id).copied().unwrap_or(0);
+            let mut image: ApiVmOsImage = i.into();
+            image.popularity = if total > 0 {
+                count as f32 / total as f32
+            } else {
+                0.0
+            };
+            image
+        })
         .collect();
     ApiData::ok(ret)
 }
@@ -1246,13 +1265,22 @@ async fn v1_restart_vm(
     ApiData::ok(())
 }
 
+#[derive(serde::Deserialize, Default)]
+#[serde(default)]
+struct ReinstallRequest {
+    /// Optionally switch to a different OS image during the reinstall
+    image_id: Option<u64>,
+}
+
 /// Re-install a VM
 async fn v1_reinstall_vm(
     auth: Nip98Auth,
     State(this): State<RouterState>,
     Path(id): Path<u64>,
+    body: Option<Json<ReinstallRequest>>,
 ) -> ApiResult<()> {
-    let (uid, vm) = get_user_vm(&auth, &this, id).await?;
+    let (uid, mut vm) = get_user_vm(&auth, &this, id).await?;
+    let req = body.map(|Json(b)| b).unwrap_or_default();
 
     // Reject re-install on an expired VM. The VM may already be stopped/removed
     // on the host, so running the reinstall pipeline would fail with a 500.
@@ -1270,6 +1298,21 @@ async fn v1_reinstall_vm(
     }
 
     let old_image_id = vm.image_id;
+
+    // Optionally switch to a different OS image. Persist the change before
+    // loading FullVmInfo so the reinstall pipeline provisions the new image.
+    if let Some(new_image_id) = req.image_id
+        && new_image_id != old_image_id
+    {
+        let image = this.db.get_os_image(new_image_id).await?;
+        if !image.enabled {
+            return Err(ApiError::forbidden("OS image is not available"));
+        }
+        vm.image_id = new_image_id;
+        this.db.update_vm(&vm).await?;
+    }
+    let new_image_id = vm.image_id;
+
     let host = this.db.get_host(vm.host_id).await?;
     let client = get_host_client(&host, &this.settings.provisioner)?;
     let info = FullVmInfo::load(vm.id, this.db.clone()).await?;
@@ -1319,9 +1362,9 @@ async fn v1_reinstall_vm(
         .execute()
         .await?;
 
-    // Log VM reinstall (assuming same image ID for now)
+    // Log VM reinstall (records image change if the user switched images)
     this.history
-        .log_vm_reinstalled(id, Some(uid), old_image_id, old_image_id, None)
+        .log_vm_reinstalled(id, Some(uid), old_image_id, new_image_id, None)
         .await
         .ok();
 

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -2590,6 +2590,7 @@ pub enum AdminVmHistoryActionType {
     StateChanged,
     PaymentReceived,
     ConfigurationChanged,
+    Transferred,
 }
 
 impl From<VmHistoryActionType> for AdminVmHistoryActionType {
@@ -2608,6 +2609,7 @@ impl From<VmHistoryActionType> for AdminVmHistoryActionType {
             VmHistoryActionType::ConfigurationChanged => {
                 AdminVmHistoryActionType::ConfigurationChanged
             }
+            VmHistoryActionType::Transferred => AdminVmHistoryActionType::Transferred,
         }
     }
 }

--- a/lnvps_api_admin/src/admin/vms.rs
+++ b/lnvps_api_admin/src/admin/vms.rs
@@ -28,6 +28,7 @@ pub fn router() -> Router<RouterState> {
                 .patch(admin_patch_vm)
                 .delete(admin_delete_vm),
         )
+        .route("/api/admin/v1/vms/{id}/transfer", post(admin_transfer_vm))
         .route("/api/admin/v1/vms/{id}/start", post(admin_start_vm))
         .route("/api/admin/v1/vms/{id}/stop", post(admin_stop_vm))
         .route("/api/admin/v1/vms/{id}/extend", put(admin_extend_vm))
@@ -315,6 +316,64 @@ async fn admin_patch_vm(
     ApiData::ok(JobResponse {
         job_id: String::new(),
     })
+}
+
+#[derive(Deserialize)]
+struct AdminTransferVmRequest {
+    /// The user account to transfer this VM to
+    user_id: u64,
+    reason: Option<String>,
+}
+
+/// Transfer a VM to another user account
+async fn admin_transfer_vm(
+    auth: AdminAuth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+    Json(req): Json<AdminTransferVmRequest>,
+) -> ApiResult<()> {
+    // Check permission
+    auth.require_permission(AdminResource::VirtualMachines, AdminAction::Update)?;
+
+    // Verify VM exists
+    let vm = this.db.get_vm(id).await?;
+
+    if vm.deleted {
+        return Err(ApiError::conflict("Cannot transfer a deleted VM"));
+    }
+
+    let old_user_id = vm.user_id;
+
+    if req.user_id == old_user_id {
+        return Err(ApiError::conflict("VM already belongs to this user"));
+    }
+
+    // Verify the target user exists
+    let _user = this.db.get_user(req.user_id).await?;
+
+    // Atomically move VM + subscription ownership
+    this.db.admin_transfer_vm(id, req.user_id).await?;
+
+    // Log the transfer in VM history
+    let vm_history_logger = VmHistoryLogger::new(this.db.clone());
+    let metadata = Some(serde_json::json!({
+        "admin_user_id": auth.user_id,
+        "admin_action": true,
+        "reason": req.reason,
+    }));
+    if let Err(e) = vm_history_logger
+        .log_vm_transferred(id, Some(auth.user_id), old_user_id, req.user_id, metadata)
+        .await
+    {
+        error!("Failed to log VM {} transfer: {}", id, e);
+    }
+
+    info!(
+        "Admin {} transferred VM {} from user {} to user {}",
+        auth.user_id, id, old_user_id, req.user_id
+    );
+
+    ApiData::ok(())
 }
 
 /// Start a VM

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -878,6 +878,15 @@ impl LNVpsDbBase for MockDb {
         Ok(os_images.values().filter(|i| i.enabled).cloned().collect())
     }
 
+    async fn count_vms_by_os_image(&self) -> DbResult<Vec<(u64, u64)>> {
+        let vms = self.vms.lock().await;
+        let mut counts: HashMap<u64, u64> = HashMap::new();
+        for vm in vms.values().filter(|v| !v.deleted) {
+            *counts.entry(vm.image_id).or_insert(0) += 1;
+        }
+        Ok(counts.into_iter().collect())
+    }
+
     async fn update_os_image(&self, image: &VmOsImage) -> DbResult<()> {
         let mut os_images = self.os_images.lock().await;
         os_images.insert(image.id, image.clone());
@@ -3119,6 +3128,14 @@ impl lnvps_db::AdminDb for MockDb {
     async fn admin_get_region_stats(&self, _region_id: u64) -> DbResult<RegionStats> {
         todo!()
     }
+    async fn admin_transfer_vm(&self, vm_id: u64, new_user_id: u64) -> DbResult<()> {
+        let mut vms = self.vms.lock().await;
+        let vm = vms.get_mut(&vm_id).ok_or(anyhow!("no vm"))?;
+        vm.user_id = new_user_id;
+        vm.ssh_key_id = None;
+        Ok(())
+    }
+
     async fn admin_list_vm_os_images(
         &self,
         _limit: u64,
@@ -3817,6 +3834,77 @@ impl LNVPSNostrDb for MockDb {
 mod tests {
     use super::*;
     use lnvps_db::{IntervalType, LNVpsDbBase, SubscriptionPaymentType};
+
+    #[tokio::test]
+    async fn test_count_vms_by_os_image() {
+        let db = MockDb::default();
+        {
+            let mut vms = db.vms.lock().await;
+            vms.insert(
+                1,
+                Vm {
+                    id: 1,
+                    image_id: 1,
+                    ..MockDb::mock_vm()
+                },
+            );
+            vms.insert(
+                2,
+                Vm {
+                    id: 2,
+                    image_id: 1,
+                    ..MockDb::mock_vm()
+                },
+            );
+            vms.insert(
+                3,
+                Vm {
+                    id: 3,
+                    image_id: 2,
+                    ..MockDb::mock_vm()
+                },
+            );
+            vms.insert(
+                4,
+                Vm {
+                    id: 4,
+                    image_id: 2,
+                    deleted: true,
+                    ..MockDb::mock_vm()
+                },
+            );
+        }
+
+        let counts: HashMap<u64, u64> =
+            db.count_vms_by_os_image().await.unwrap().into_iter().collect();
+        assert_eq!(counts.get(&1), Some(&2));
+        assert_eq!(counts.get(&2), Some(&1)); // deleted VM excluded
+    }
+
+    #[cfg(feature = "admin")]
+    #[tokio::test]
+    async fn test_admin_transfer_vm() {
+        use lnvps_db::AdminDb;
+
+        let db = MockDb::default();
+        {
+            let mut vms = db.vms.lock().await;
+            vms.insert(
+                1,
+                Vm {
+                    id: 1,
+                    user_id: 1,
+                    ssh_key_id: Some(5),
+                    ..MockDb::mock_vm()
+                },
+            );
+        }
+
+        db.admin_transfer_vm(1, 42).await.unwrap();
+        let vm = db.get_vm(1).await.unwrap();
+        assert_eq!(vm.user_id, 42);
+        assert_eq!(vm.ssh_key_id, None);
+    }
 
     /// list_all_referrals + delete_referral base-trait methods.
     #[tokio::test]

--- a/lnvps_api_common/src/model.rs
+++ b/lnvps_api_common/src/model.rs
@@ -590,6 +590,9 @@ pub struct ApiVmOsImage {
     pub version: String,
     pub release_date: DateTime<Utc>,
     pub default_username: Option<String>,
+    /// Popularity of this image expressed as a fraction (0.0â1.0) of all
+    /// active VMs currently using it
+    pub popularity: f32,
 }
 
 impl From<lnvps_db::VmOsImage> for ApiVmOsImage {
@@ -601,6 +604,7 @@ impl From<lnvps_db::VmOsImage> for ApiVmOsImage {
             version: image.version,
             release_date: image.release_date,
             default_username: image.default_username,
+            popularity: 0.0,
         }
     }
 }

--- a/lnvps_api_common/src/vm_history.rs
+++ b/lnvps_api_common/src/vm_history.rs
@@ -276,6 +276,33 @@ impl VmHistoryLogger {
         Ok(())
     }
 
+    pub async fn log_vm_transferred(
+        &self,
+        vm_id: u64,
+        initiated_by_user: Option<u64>,
+        old_user_id: u64,
+        new_user_id: u64,
+        metadata: Option<Value>,
+    ) -> Result<()> {
+        let history = VmHistory {
+            id: 0,
+            vm_id,
+            action_type: VmHistoryActionType::Transferred,
+            timestamp: Utc::now(),
+            initiated_by_user,
+            previous_state: serialize_json_to_bytes(Some(json!({"user_id": old_user_id}))),
+            new_state: serialize_json_to_bytes(Some(json!({"user_id": new_user_id}))),
+            metadata: serialize_json_to_bytes(metadata),
+            description: Some(format!(
+                "VM {} was transferred from user {} to user {}",
+                vm_id, old_user_id, new_user_id
+            )),
+        };
+
+        self.db.insert_vm_history(&history).await?;
+        Ok(())
+    }
+
     pub async fn log_vm_state_changed(
         &self,
         vm_id: u64,
@@ -626,6 +653,23 @@ mod tests {
             serde_json::from_slice(history[0].new_state.as_ref().unwrap()).unwrap();
         assert_eq!(prev["image_id"], 1);
         assert_eq!(next["image_id"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_log_vm_transferred() {
+        let logger = make_logger();
+        logger
+            .log_vm_transferred(16, Some(9), 3, 7, None)
+            .await
+            .unwrap();
+        let history = logger.db.list_vm_history(16).await.unwrap();
+        assert_eq!(history[0].action_type.to_string(), "transferred");
+        let prev: serde_json::Value =
+            serde_json::from_slice(history[0].previous_state.as_ref().unwrap()).unwrap();
+        let next: serde_json::Value =
+            serde_json::from_slice(history[0].new_state.as_ref().unwrap()).unwrap();
+        assert_eq!(prev["user_id"], 3);
+        assert_eq!(next["user_id"], 7);
     }
 
     #[tokio::test]

--- a/lnvps_db/migrations/20260720130000_cascade_delete_child_tables.sql
+++ b/lnvps_db/migrations/20260720130000_cascade_delete_child_tables.sql
@@ -30,13 +30,24 @@ alter table user_payment_method
     add constraint fk_user_payment_method_user foreign key (user_id) references users (id) on delete cascade;
 
 -- referral chain: users -> referral -> referral_payout
--- These FKs were created without an explicit name, so MariaDB/InnoDB assigned
--- the deterministic <table>_ibfk_1 name (each table has exactly one FK).
-alter table referral drop foreign key referral_ibfk_1;
+-- These FKs were created WITHOUT an explicit name, so the auto-generated
+-- constraint name is server-version dependent (e.g. `referral_ibfk_1` on some
+-- MySQL/MariaDB versions, something else on others). Resolve the real name
+-- from information_schema and drop it dynamically so the migration works on
+-- any server version, then re-add the FK with an explicit name + cascade.
+set @fk_referral := (select constraint_name from information_schema.KEY_COLUMN_USAGE
+    where table_schema = database() and table_name = 'referral'
+    and referenced_table_name = 'users' limit 1);
+set @sql := concat('alter table referral drop foreign key `', @fk_referral, '`');
+prepare stmt from @sql; execute stmt; deallocate prepare stmt;
 alter table referral
     add constraint fk_referral_user foreign key (user_id) references users (id) on delete cascade;
 
-alter table referral_payout drop foreign key referral_payout_ibfk_1;
+set @fk_referral_payout := (select constraint_name from information_schema.KEY_COLUMN_USAGE
+    where table_schema = database() and table_name = 'referral_payout'
+    and referenced_table_name = 'referral' limit 1);
+set @sql := concat('alter table referral_payout drop foreign key `', @fk_referral_payout, '`');
+prepare stmt from @sql; execute stmt; deallocate prepare stmt;
 alter table referral_payout
     add constraint fk_referral_payout_referral foreign key (referral_id) references referral (id) on delete cascade;
 

--- a/lnvps_db/migrations/20260720130000_cascade_delete_child_tables.sql
+++ b/lnvps_db/migrations/20260720130000_cascade_delete_child_tables.sql
@@ -10,49 +10,54 @@
 -- Financial/audit/soft-deleted tables (vm, subscription, subscription_payment,
 -- vm_history, vm_ip_assignment, vm_firewall_rule) are deliberately left with
 -- RESTRICT and continue to be cleaned up explicitly.
+--
+-- NOTE: each FK is dropped and re-added in TWO separate ALTER statements. A
+-- combined `drop foreign key X, add constraint X ...` in a single ALTER fails
+-- on InnoDB (MySQL & MariaDB) with errno 121 "duplicate key" because the old
+-- constraint name still exists while the new one with the same name is added.
 
 -- users -> owned children
+alter table user_ssh_key drop foreign key fk_ssh_key_user;
 alter table user_ssh_key
-    drop foreign key fk_ssh_key_user,
     add constraint fk_ssh_key_user foreign key (user_id) references users (id) on delete cascade;
 
+alter table user_webauthn_credentials drop foreign key fk_webauthn_cred_user;
 alter table user_webauthn_credentials
-    drop foreign key fk_webauthn_cred_user,
     add constraint fk_webauthn_cred_user foreign key (user_id) references users (id) on delete cascade;
 
+alter table user_payment_method drop foreign key fk_user_payment_method_user;
 alter table user_payment_method
-    drop foreign key fk_user_payment_method_user,
     add constraint fk_user_payment_method_user foreign key (user_id) references users (id) on delete cascade;
 
 -- referral chain: users -> referral -> referral_payout
 -- These FKs were created without an explicit name, so MariaDB/InnoDB assigned
 -- the deterministic <table>_ibfk_1 name (each table has exactly one FK).
+alter table referral drop foreign key referral_ibfk_1;
 alter table referral
-    drop foreign key referral_ibfk_1,
     add constraint fk_referral_user foreign key (user_id) references users (id) on delete cascade;
 
+alter table referral_payout drop foreign key referral_payout_ibfk_1;
 alter table referral_payout
-    drop foreign key referral_payout_ibfk_1,
     add constraint fk_referral_payout_referral foreign key (referral_id) references referral (id) on delete cascade;
 
 -- router -> cached tunnel/BGP inventory (discovery caches, safe to drop)
+alter table router_tunnel drop foreign key fk_router_tunnel_router;
 alter table router_tunnel
-    drop foreign key fk_router_tunnel_router,
     add constraint fk_router_tunnel_router foreign key (router_id) references router (id) on delete cascade;
 
+alter table router_tunnel_traffic drop foreign key fk_router_tunnel_traffic_router;
 alter table router_tunnel_traffic
-    drop foreign key fk_router_tunnel_traffic_router,
     add constraint fk_router_tunnel_traffic_router foreign key (router_id) references router (id) on delete cascade;
 
+alter table router_bgp_session drop foreign key fk_router_bgp_session_router;
 alter table router_bgp_session
-    drop foreign key fk_router_bgp_session_router,
     add constraint fk_router_bgp_session_router foreign key (router_id) references router (id) on delete cascade;
 
+alter table router_bgp_route drop foreign key fk_router_bgp_route_router;
 alter table router_bgp_route
-    drop foreign key fk_router_bgp_route_router,
     add constraint fk_router_bgp_route_router foreign key (router_id) references router (id) on delete cascade;
 
 -- vm_custom_pricing -> pricing disks (pure child; vm_custom_template keeps RESTRICT)
+alter table vm_custom_pricing_disk drop foreign key fk_custom_pricing_disk;
 alter table vm_custom_pricing_disk
-    drop foreign key fk_custom_pricing_disk,
     add constraint fk_custom_pricing_disk foreign key (pricing_id) references vm_custom_pricing (id) on delete cascade;

--- a/lnvps_db/src/admin.rs
+++ b/lnvps_db/src/admin.rs
@@ -129,6 +129,13 @@ pub trait AdminDb: Send + Sync {
     /// Get comprehensive region statistics
     async fn admin_get_region_stats(&self, region_id: u64) -> DbResult<RegionStats>;
 
+    /// Transfer ownership of a VM to another user account.
+    ///
+    /// Atomically updates the VM's `user_id` and its subscription's `user_id`
+    /// so billing follows the new owner. Clears the VM's `ssh_key_id` because
+    /// the old owner's key does not belong to the new account.
+    async fn admin_transfer_vm(&self, vm_id: u64, new_user_id: u64) -> DbResult<()>;
+
     // VM OS Image management methods
     /// List all VM OS images with pagination
     async fn admin_list_vm_os_images(

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -303,6 +303,9 @@ pub trait LNVpsDbBase: Send + Sync {
     /// List available OS images
     async fn list_os_image(&self) -> DbResult<Vec<VmOsImage>>;
 
+    /// Count active (non-deleted) VMs grouped by OS image id
+    async fn count_vms_by_os_image(&self) -> DbResult<Vec<(u64, u64)>>;
+
     /// Update an OS image (sha2, sha2_url, and other fields)
     async fn update_os_image(&self, image: &VmOsImage) -> DbResult<()>;
 

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -1599,6 +1599,7 @@ pub enum VmHistoryActionType {
     StateChanged = 8,
     PaymentReceived = 9,
     ConfigurationChanged = 10,
+    Transferred = 11,
 }
 
 impl Display for VmHistoryActionType {
@@ -1615,6 +1616,7 @@ impl Display for VmHistoryActionType {
             VmHistoryActionType::StateChanged => write!(f, "state_changed"),
             VmHistoryActionType::PaymentReceived => write!(f, "payment_received"),
             VmHistoryActionType::ConfigurationChanged => write!(f, "configuration_changed"),
+            VmHistoryActionType::Transferred => write!(f, "transferred"),
         }
     }
 }
@@ -1635,6 +1637,7 @@ impl FromStr for VmHistoryActionType {
             "state_changed" => Ok(VmHistoryActionType::StateChanged),
             "payment_received" => Ok(VmHistoryActionType::PaymentReceived),
             "configuration_changed" => Ok(VmHistoryActionType::ConfigurationChanged),
+            "transferred" => Ok(VmHistoryActionType::Transferred),
             _ => Err(anyhow!("unknown VM history action type: {}", s)),
         }
     }

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -758,6 +758,14 @@ impl LNVpsDbBase for LNVpsDbMysql {
             .await?)
     }
 
+    async fn count_vms_by_os_image(&self) -> DbResult<Vec<(u64, u64)>> {
+        Ok(sqlx::query_as(
+            "SELECT image_id, COUNT(*) FROM vm WHERE deleted = 0 GROUP BY image_id",
+        )
+        .fetch_all(&self.db)
+        .await?)
+    }
+
     async fn update_os_image(&self, image: &VmOsImage) -> DbResult<()> {
         sqlx::query(
             "UPDATE vm_os_image SET distribution=?, flavour=?, version=?, enabled=?, release_date=?, url=?, default_username=?, sha2=?, sha2_url=? WHERE id=?"
@@ -4233,6 +4241,38 @@ impl AdminDb for LNVpsDbMysql {
             total_memory_bytes: row.3.unwrap_or(0),
             total_ip_assignments: row.4 as u64,
         })
+    }
+
+    async fn admin_transfer_vm(&self, vm_id: u64, new_user_id: u64) -> DbResult<()> {
+        let mut tx = self.db.begin().await?;
+
+        // Resolve the subscription linked to this VM so we can move billing too
+        let sub_id: (u64,) = sqlx::query_as(
+            "SELECT s.id FROM subscription s \
+             JOIN subscription_line_item sli ON sli.subscription_id = s.id \
+             JOIN vm v ON v.subscription_line_item_id = sli.id \
+             WHERE v.id = ?",
+        )
+        .bind(vm_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        // Move VM ownership and drop the old owner's ssh key reference
+        sqlx::query("UPDATE vm SET user_id = ?, ssh_key_id = NULL WHERE id = ?")
+            .bind(new_user_id)
+            .bind(vm_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // Move subscription ownership so renewals bill the new account
+        sqlx::query("UPDATE subscription SET user_id = ? WHERE id = ?")
+            .bind(new_user_id)
+            .bind(sub_id.0)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
     }
 
     async fn admin_list_vm_os_images(

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -386,6 +386,34 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_admin_vm_transfer() {
+        let client = setup().await;
+        let resp = client.get_auth("/api/admin/v1/vms?limit=1").await.unwrap();
+        let data: ApiPaginatedData<Value> = parse_paginated(resp).await.unwrap();
+        if data.data.is_empty() {
+            eprintln!("Skipping: no VMs found for transfer test");
+            return;
+        }
+        let vm_id = data.data[0]["id"].as_u64().unwrap();
+        let current_user = data.data[0]["user_id"].as_u64().unwrap_or(0);
+        // Transfer to the same user is rejected (409); an unknown user is 404.
+        let body = serde_json::json!({"user_id": current_user, "reason": "e2e-test"});
+        let resp = client
+            .post_auth(&format!("/api/admin/v1/vms/{vm_id}/transfer"), &body)
+            .await
+            .unwrap();
+        assert!(
+            resp.status() == StatusCode::OK
+                || resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::NOT_FOUND
+                || resp.status() == StatusCode::CONFLICT
+                || resp.status() == StatusCode::INTERNAL_SERVER_ERROR,
+            "VM transfer should return 200, 400, 404, 409, or 500, got: {}",
+            resp.status()
+        );
+    }
+
     // ========================================================================
     // Host Management
     // ========================================================================

--- a/lnvps_e2e/src/user_api.rs
+++ b/lnvps_e2e/src/user_api.rs
@@ -49,6 +49,7 @@ mod tests {
         distribution: String,
         flavour: String,
         version: String,
+        popularity: f32,
     }
 
     #[derive(Debug, Deserialize)]
@@ -180,6 +181,9 @@ mod tests {
             assert!(img.id > 0);
             assert!(!img.distribution.is_empty());
             assert!(!img.version.is_empty());
+            let _ = img.flavour;
+            // popularity is a fraction in [0, 1]
+            assert!(img.popularity >= 0.0 && img.popularity <= 1.0);
         }
     }
 


### PR DESCRIPTION
Batch implementation of three issues.

## #70 — OS image popularity
`GET /api/v1/image` now returns a `popularity` field per image: the fraction (0.0–1.0) of active VMs currently using it. New DB method `count_vms_by_os_image`.

## #177 — Change OS (reinstall)
`PATCH /api/v1/vm/{id}/re-install` now accepts an optional `{ image_id }` body to switch OS image during reinstall. The image must exist and be enabled; the change is persisted before the reinstall pipeline and recorded in VM history.

## #178 — Transfer VM (admin)
New `POST /api/admin/v1/vms/{id}/transfer` (`virtual_machines::update`) reassigns a VM (and its billing subscription) to another user, clearing the old owner's SSH key. Adds a `Transferred` VM-history action + logger. Rejects deleted VMs / self-transfers (409) and unknown users (404).

## Tests & docs
- Unit tests for new DB/mock methods and history logger; e2e tests for transfer endpoint and popularity field.
- Updated API_CHANGELOG.md, API_DOCUMENTATION.md, ADMIN_API_ENDPOINTS.md.

Fixes #70
Fixes #177
Fixes #178