### PR TITLE
refactor(db): rename vm_host_region → region (internal, API stable)

### DIFF
--- a/lnvps_api/src/api/routes.rs
+++ b/lnvps_api/src/api/routes.rs
@@ -26,8 +26,8 @@ use lnvps_api_common::{
     VatClient, WorkJob,
 };
 use lnvps_db::{
-    CpuArch, LNVpsDb, PaymentMethod, Vm, VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate,
-    VmHost, VmHostRegion,
+    CpuArch, LNVpsDb, PaymentMethod, Region, Vm, VmCustomPricing, VmCustomPricingDisk,
+    VmCustomTemplate, VmHost,
 };
 
 use crate::api::model::{
@@ -887,7 +887,7 @@ async fn v1_list_vm_templates(State(this): State<RouterState>) -> ApiResult<ApiT
     let templates = hc.list_available_vm_templates().await?;
 
     let cost_plans: HashSet<u64> = templates.iter().map(|t| t.cost_plan_id).collect();
-    let regions: HashMap<u64, VmHostRegion> = this
+    let regions: HashMap<u64, Region> = this
         .db
         .list_host_region()
         .await?

--- a/lnvps_api/src/mocks.rs
+++ b/lnvps_api/src/mocks.rs
@@ -26,9 +26,9 @@ use lnvps_api_common::{ExchangeRateService, VmRunningState, VmRunningStates, op_
 use lnvps_db::nostr::LNVPSNostrDb;
 use lnvps_db::{
     AccessPolicy, Company, DiskInterface, DiskType, IpRange, IpRangeAllocationMode, LNVpsDb,
-    NostrDomain, NostrDomainHandle, OsDistribution, User, UserSshKey, Vm, VmCostPlan,
+    NostrDomain, NostrDomainHandle, OsDistribution, Region, User, UserSshKey, Vm, VmCostPlan,
     VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmHistory, VmHost, VmHostDisk,
-    VmHostKind, VmHostRegion, VmIpAssignment, VmOsImage, VmTemplate,
+    VmHostKind, VmIpAssignment, VmOsImage, VmTemplate,
 };
 use nostr_sdk::Timestamp;
 use payments_rs::lightning::{

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -1026,7 +1026,7 @@ pub struct UpdateRegionRequest {
 }
 
 impl AdminHostInfo {
-    pub fn from_host_and_region(host: lnvps_db::VmHost, region: lnvps_db::VmHostRegion) -> Self {
+    pub fn from_host_and_region(host: lnvps_db::VmHost, region: lnvps_db::Region) -> Self {
         let ssh_key_configured = host.ssh_key.is_some();
         Self {
             id: host.id,
@@ -1075,7 +1075,7 @@ impl AdminHostInfo {
 
     pub fn from_host_region_and_disks(
         host: lnvps_db::VmHost,
-        region: lnvps_db::VmHostRegion,
+        region: lnvps_db::Region,
         disks: Vec<lnvps_db::VmHostDisk>,
     ) -> Self {
         let admin_disks = disks.into_iter().map(|disk| disk.into()).collect();
@@ -1128,7 +1128,7 @@ impl AdminHostInfo {
 
     pub fn from_host_capacity(
         capacity: &lnvps_api_common::HostCapacity,
-        region: lnvps_db::VmHostRegion,
+        region: lnvps_db::Region,
         disks: Vec<lnvps_db::VmHostDisk>,
         active_vms: u64,
     ) -> Self {

--- a/lnvps_api_admin/src/bin/generate_demo_data.rs
+++ b/lnvps_api_admin/src/bin/generate_demo_data.rs
@@ -7,9 +7,9 @@ use lnvps_api_admin::settings::Settings;
 use lnvps_db::{
     AdminDb, Company, DiskInterface, DiskType, EncryptedString, EncryptionContext, IntervalType,
     IpRange, IpRangeAllocationMode, LNVpsDbBase, LNVpsDbMysql, OsDistribution, PaymentMethod,
-    SubscriptionPayment, SubscriptionPaymentType, User, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomTemplate, VmHost, VmHostDisk, VmHostKind, VmHostRegion,
-    VmIpAssignment, VmOsImage, VmTemplate,
+    Region, SubscriptionPayment, SubscriptionPaymentType, User, UserSshKey, Vm, VmCostPlan,
+    VmCustomPricing, VmCustomTemplate, VmHost, VmHostDisk, VmHostKind, VmIpAssignment, VmOsImage,
+    VmTemplate,
 };
 use log::info;
 use std::path::PathBuf;
@@ -209,7 +209,7 @@ async fn create_companies(db: &LNVpsDbMysql) -> Result<Vec<Company>> {
     Ok(created_companies)
 }
 
-async fn create_regions(db: &LNVpsDbMysql, companies: &[Company]) -> Result<Vec<VmHostRegion>> {
+async fn create_regions(db: &LNVpsDbMysql, companies: &[Company]) -> Result<Vec<Region>> {
     let regions_data = vec![
         ("US-East-1 (Virginia)", companies[0].id),
         ("US-West-1 (California)", companies[0].id),
@@ -223,7 +223,7 @@ async fn create_regions(db: &LNVpsDbMysql, companies: &[Company]) -> Result<Vec<
 
     let mut regions = Vec::new();
     for (name, company_id) in regions_data {
-        let region = VmHostRegion {
+        let region = Region {
             id: 0, // Will be auto-generated
             name: name.to_string(),
             enabled: true,
@@ -242,7 +242,7 @@ async fn create_regions(db: &LNVpsDbMysql, companies: &[Company]) -> Result<Vec<
     Ok(regions)
 }
 
-async fn create_ip_ranges(db: &LNVpsDbMysql, regions: &[VmHostRegion]) -> Result<Vec<IpRange>> {
+async fn create_ip_ranges(db: &LNVpsDbMysql, regions: &[Region]) -> Result<Vec<IpRange>> {
     let ranges_data = vec![
         ("10.1.0.0/24", "10.1.0.1", regions[0].id),
         ("10.2.0.0/24", "10.2.0.1", regions[1].id),
@@ -281,7 +281,7 @@ async fn create_ip_ranges(db: &LNVpsDbMysql, regions: &[VmHostRegion]) -> Result
     Ok(ip_ranges)
 }
 
-async fn create_hosts(db: &LNVpsDbMysql, regions: &[VmHostRegion]) -> Result<Vec<VmHost>> {
+async fn create_hosts(db: &LNVpsDbMysql, regions: &[Region]) -> Result<Vec<VmHost>> {
     let hosts_data = vec![
         (
             VmHostKind::Proxmox,
@@ -643,7 +643,7 @@ async fn create_cost_plans(db: &LNVpsDbMysql) -> Result<Vec<VmCostPlan>> {
 async fn create_vm_templates(
     db: &LNVpsDbMysql,
     cost_plans: &[VmCostPlan],
-    regions: &[VmHostRegion],
+    regions: &[Region],
 ) -> Result<Vec<VmTemplate>> {
     let mut templates = Vec::new();
 
@@ -825,7 +825,7 @@ async fn create_vm_templates(
 
 async fn create_custom_pricing(
     db: &LNVpsDbMysql,
-    regions: &[VmHostRegion],
+    regions: &[Region],
 ) -> Result<Vec<VmCustomPricing>> {
     // Costs are in smallest currency units per resource unit:
     // - cpu_cost: per CPU core per month

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -7,11 +7,11 @@ use lnvps_db::{
     CpuMfg, DbError, DbResult, DiskInterface, DiskType, DnsServer, DnsServerKind, IntervalType,
     IpRange, IpRangeAllocationMode, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, NostrDomain,
     NostrDomainHandle, OsDistribution, PaymentMethod, PaymentMethodConfig, Referral,
-    ReferralCostUsage, ReferralPayout, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel,
-    RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
+    ReferralCostUsage, ReferralPayout, Region, Router, RouterBgpRoute, RouterBgpSession,
+    RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
     SubscriptionPaymentWithCompany, User, UserPaymentMethod, UserSshKey, Vm, VmCostPlan,
     VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallPolicy, VmFirewallRule,
-    VmHistory, VmHost, VmHostDisk, VmHostKind, VmHostRegion, VmIpAssignment, VmOsImage, VmTemplate,
+    VmHistory, VmHost, VmHostDisk, VmHostKind, VmIpAssignment, VmOsImage, VmTemplate,
     WebauthnCredential,
 };
 
@@ -25,7 +25,7 @@ use tokio::sync::Mutex;
 
 #[derive(Debug, Clone)]
 pub struct MockDb {
-    pub regions: Arc<Mutex<HashMap<u64, VmHostRegion>>>,
+    pub regions: Arc<Mutex<HashMap<u64, Region>>>,
     pub hosts: Arc<Mutex<HashMap<u64, VmHost>>>,
     pub host_disks: Arc<Mutex<HashMap<u64, VmHostDisk>>>,
     pub users: Arc<Mutex<HashMap<u64, User>>>,
@@ -136,7 +136,7 @@ impl Default for MockDb {
         let mut regions = HashMap::new();
         regions.insert(
             1,
-            VmHostRegion {
+            Region {
                 id: 1,
                 name: "Mock".to_string(),
                 enabled: true,
@@ -757,17 +757,17 @@ impl LNVpsDbBase for MockDb {
             .collect())
     }
 
-    async fn list_host_region(&self) -> DbResult<Vec<VmHostRegion>> {
+    async fn list_host_region(&self) -> DbResult<Vec<Region>> {
         let regions = self.regions.lock().await;
         Ok(regions.values().filter(|r| r.enabled).cloned().collect())
     }
 
-    async fn get_host_region(&self, id: u64) -> DbResult<VmHostRegion> {
+    async fn get_host_region(&self, id: u64) -> DbResult<Region> {
         let regions = self.regions.lock().await;
         Ok(regions.get(&id).ok_or(anyhow!("no region"))?.clone())
     }
 
-    async fn get_host_region_by_name(&self, name: &str) -> DbResult<VmHostRegion> {
+    async fn get_host_region_by_name(&self, name: &str) -> DbResult<Region> {
         let regions = self.regions.lock().await;
         Ok(regions
             .iter()
@@ -798,7 +798,7 @@ impl LNVpsDbBase for MockDb {
         &self,
         limit: u64,
         offset: u64,
-    ) -> DbResult<(Vec<(VmHost, VmHostRegion)>, u64)> {
+    ) -> DbResult<(Vec<(VmHost, Region)>, u64)> {
         let hosts = self.hosts.lock().await;
         let regions = self.regions.lock().await;
         let filtered_hosts: Vec<VmHost> = hosts.values().filter(|h| h.enabled).cloned().collect();
@@ -3297,14 +3297,10 @@ impl lnvps_db::AdminDb for MockDb {
         Ok(None)
     }
 
-    async fn admin_list_regions(
-        &self,
-        limit: u64,
-        offset: u64,
-    ) -> DbResult<(Vec<VmHostRegion>, u64)> {
+    async fn admin_list_regions(&self, limit: u64, offset: u64) -> DbResult<(Vec<Region>, u64)> {
         let regions = self.regions.lock().await;
         let total = regions.len() as u64;
-        let paginated_regions: Vec<VmHostRegion> = regions
+        let paginated_regions: Vec<Region> = regions
             .values()
             .skip(offset as usize)
             .take(limit as usize)
@@ -3322,7 +3318,7 @@ impl lnvps_db::AdminDb for MockDb {
     ) -> DbResult<u64> {
         Ok(1)
     }
-    async fn admin_update_region(&self, _region: &VmHostRegion) -> DbResult<()> {
+    async fn admin_update_region(&self, _region: &Region) -> DbResult<()> {
         Ok(())
     }
     async fn admin_delete_region(&self, _region_id: u64) -> DbResult<()> {

--- a/lnvps_api_common/src/model.rs
+++ b/lnvps_api_common/src/model.rs
@@ -5,9 +5,9 @@ use chrono::{DateTime, Days, Utc};
 use futures::future::join_all;
 use ipnetwork::IpNetwork;
 use lnvps_db::{
-    CpuArch, CpuFeature, CpuMfg, IpRange, LNVpsDb, LNVpsDbBase, Subscription, SubscriptionLineItem,
-    SubscriptionType, Vm, VmCostPlan, VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate,
-    VmHost, VmHostRegion, VmTemplate,
+    CpuArch, CpuFeature, CpuMfg, IpRange, LNVpsDb, LNVpsDbBase, Region, Subscription,
+    SubscriptionLineItem, SubscriptionType, Vm, VmCostPlan, VmCustomPricing, VmCustomPricingDisk,
+    VmCustomTemplate, VmHost, VmTemplate,
 };
 use payments_rs::currency::{Currency, CurrencyAmount};
 use serde::{Deserialize, Serialize};
@@ -165,7 +165,7 @@ impl ApiVmTemplate {
     pub fn from_standard_data(
         template: &VmTemplate,
         cost_plan: &VmCostPlan,
-        region: &VmHostRegion,
+        region: &Region,
     ) -> Result<Self> {
         Ok(Self {
             id: template.id,
@@ -759,7 +759,7 @@ impl ApiCustomTemplateParams {
     pub fn from(
         pricing: &VmCustomPricing,
         disks: &Vec<VmCustomPricingDisk>,
-        region: &VmHostRegion,
+        region: &Region,
     ) -> Self {
         ApiCustomTemplateParams {
             id: pricing.id,

--- a/lnvps_db/migrations/20260724122922_rename_region.sql
+++ b/lnvps_db/migrations/20260724122922_rename_region.sql
@@ -1,0 +1,6 @@
+-- `vm_host_region` holds only {id, name, enabled, company_id} — a neutral
+-- location + billing anchor with no VM-specific columns. Rename it to `region`
+-- so non-VM resources (e.g. app deployments) can share the same location concept
+-- without depending on VM infrastructure. Foreign keys and `region_id` columns
+-- on referencing tables are preserved by RENAME TABLE.
+RENAME TABLE vm_host_region TO region;

--- a/lnvps_db/src/admin.rs
+++ b/lnvps_db/src/admin.rs
@@ -107,7 +107,7 @@ pub trait AdminDb: Send + Sync {
         &self,
         limit: u64,
         offset: u64,
-    ) -> DbResult<(Vec<crate::VmHostRegion>, u64)>;
+    ) -> DbResult<(Vec<crate::Region>, u64)>;
 
     /// Create a new region
     async fn admin_create_region(
@@ -118,7 +118,7 @@ pub trait AdminDb: Send + Sync {
     ) -> DbResult<u64>;
 
     /// Update region information
-    async fn admin_update_region(&self, region: &crate::VmHostRegion) -> DbResult<()>;
+    async fn admin_update_region(&self, region: &crate::Region) -> DbResult<()>;
 
     /// Delete/disable region (only if no hosts assigned)
     async fn admin_delete_region(&self, region_id: u64) -> DbResult<()>;

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -255,13 +255,13 @@ pub trait LNVpsDbBase: Send + Sync {
     async fn list_user_ssh_key(&self, user_id: u64) -> DbResult<Vec<UserSshKey>>;
 
     /// Get VM host regions
-    async fn list_host_region(&self) -> DbResult<Vec<VmHostRegion>>;
+    async fn list_host_region(&self) -> DbResult<Vec<Region>>;
 
     /// Get VM host region by id
-    async fn get_host_region(&self, id: u64) -> DbResult<VmHostRegion>;
+    async fn get_host_region(&self, id: u64) -> DbResult<Region>;
 
     /// Get VM host region by name
-    async fn get_host_region_by_name(&self, name: &str) -> DbResult<VmHostRegion>;
+    async fn get_host_region_by_name(&self, name: &str) -> DbResult<Region>;
 
     /// List VM's owned by a specific user
     async fn list_hosts(&self) -> DbResult<Vec<VmHost>>;
@@ -274,7 +274,7 @@ pub trait LNVpsDbBase: Send + Sync {
         &self,
         limit: u64,
         offset: u64,
-    ) -> DbResult<(Vec<(VmHost, VmHostRegion)>, u64)>;
+    ) -> DbResult<(Vec<(VmHost, Region)>, u64)>;
 
     /// List VM's owned by a specific user
     async fn get_host(&self, id: u64) -> DbResult<VmHost>;

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -551,7 +551,7 @@ impl FromStr for CpuFeature {
 }
 
 #[derive(FromRow, Clone, Debug)]
-pub struct VmHostRegion {
+pub struct Region {
     pub id: u64,
     pub name: String,
     pub enabled: bool,

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -2,11 +2,11 @@ use crate::{
     AccessPolicy, AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, Company, DbError,
     DbResult, DnsServer, IntervalType, IpRange, IpRangeSubscription, IpSpacePricing, LNVpsDbBase,
     PaymentMethod, PaymentMethodConfig, PaymentType, Referral, ReferralCostUsage, ReferralPayout,
-    RegionStats, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel, RouterTunnelTraffic,
-    Subscription, SubscriptionLineItem, SubscriptionPayment, SubscriptionPaymentWithCompany, User,
-    UserPaymentMethod, UserSshKey, Vm, VmCostPlan, VmCustomPricing, VmCustomPricingDisk,
-    VmCustomTemplate, VmFirewallPolicy, VmFirewallRule, VmHistory, VmHost, VmHostDisk,
-    VmHostRegion, VmIpAssignment, VmOsImage, VmTemplate, WebauthnCredential,
+    Region, RegionStats, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel,
+    RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
+    SubscriptionPaymentWithCompany, User, UserPaymentMethod, UserSshKey, Vm, VmCostPlan,
+    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallPolicy, VmFirewallRule,
+    VmHistory, VmHost, VmHostDisk, VmIpAssignment, VmOsImage, VmTemplate, WebauthnCredential,
 };
 #[cfg(feature = "admin")]
 use crate::{AdminDb, AdminRole, AdminRoleAssignment, AdminVmHost};
@@ -523,32 +523,28 @@ impl LNVpsDbBase for LNVpsDbMysql {
         )
     }
 
-    async fn list_host_region(&self) -> DbResult<Vec<VmHostRegion>> {
-        Ok(
-            sqlx::query_as("select * from vm_host_region where enabled=1")
-                .fetch_all(&self.db)
-                .await?,
-        )
+    async fn list_host_region(&self) -> DbResult<Vec<Region>> {
+        Ok(sqlx::query_as("select * from region where enabled=1")
+            .fetch_all(&self.db)
+            .await?)
     }
 
-    async fn get_host_region(&self, id: u64) -> DbResult<VmHostRegion> {
-        Ok(sqlx::query_as("select * from vm_host_region where id=?")
+    async fn get_host_region(&self, id: u64) -> DbResult<Region> {
+        Ok(sqlx::query_as("select * from region where id=?")
             .bind(id)
             .fetch_one(&self.db)
             .await?)
     }
 
-    async fn get_host_region_by_name(&self, name: &str) -> DbResult<VmHostRegion> {
-        Ok(
-            sqlx::query_as("select * from vm_host_region where name like ?")
-                .bind(name)
-                .fetch_one(&self.db)
-                .await?,
-        )
+    async fn get_host_region_by_name(&self, name: &str) -> DbResult<Region> {
+        Ok(sqlx::query_as("select * from region where name like ?")
+            .bind(name)
+            .fetch_one(&self.db)
+            .await?)
     }
 
     async fn list_hosts(&self) -> DbResult<Vec<VmHost>> {
-        Ok(sqlx::query_as("select h.* from vm_host h,vm_host_region hr where h.enabled = 1 and h.region_id = hr.id and hr.enabled = 1")
+        Ok(sqlx::query_as("select h.* from vm_host h,region hr where h.enabled = 1 and h.region_id = hr.id and hr.enabled = 1")
             .fetch_all(&self.db)
             .await?)
     }
@@ -556,14 +552,14 @@ impl LNVpsDbBase for LNVpsDbMysql {
     async fn list_hosts_paginated(&self, limit: u64, offset: u64) -> DbResult<(Vec<VmHost>, u64)> {
         // Get total count
         let total: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM vm_host h, vm_host_region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1"
+            "SELECT COUNT(*) FROM vm_host h, region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1"
         )
         .fetch_one(&self.db)
         .await?;
 
         // Get paginated results
         let hosts = sqlx::query_as(
-            "SELECT h.* FROM vm_host h, vm_host_region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1 ORDER BY h.name LIMIT ? OFFSET ?"
+            "SELECT h.* FROM vm_host h, region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1 ORDER BY h.name LIMIT ? OFFSET ?"
         )
         .bind(limit)
         .bind(offset)
@@ -577,10 +573,10 @@ impl LNVpsDbBase for LNVpsDbMysql {
         &self,
         limit: u64,
         offset: u64,
-    ) -> DbResult<(Vec<(VmHost, VmHostRegion)>, u64)> {
+    ) -> DbResult<(Vec<(VmHost, Region)>, u64)> {
         // Get total count
         let total: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM vm_host h, vm_host_region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1"
+            "SELECT COUNT(*) FROM vm_host h, region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1"
         )
         .fetch_one(&self.db)
         .await?;
@@ -588,7 +584,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         // Get paginated results with region info
         let rows = sqlx::query(
             "SELECT h.*, hr.id as region_id, hr.name as region_name, hr.enabled as region_enabled, hr.company_id as region_company_id 
-             FROM vm_host h, vm_host_region hr 
+             FROM vm_host h, region hr 
              WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1 
              ORDER BY h.name LIMIT ? OFFSET ?"
         )
@@ -622,7 +618,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
                 sunset_date: row.get("sunset_date"),
             };
 
-            let region = VmHostRegion {
+            let region = Region {
                 id: row.get("region_id"),
                 name: row.get("region_name"),
                 enabled: row.get("region_enabled"),
@@ -1839,7 +1835,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
             "SELECT COALESCE(c.base_currency, 'EUR') as base_currency 
              FROM vm v
              JOIN vm_host vh ON v.host_id = vh.id  
-             JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             JOIN region vhr ON vh.region_id = vhr.id
              LEFT JOIN company c ON vhr.company_id = c.id
              WHERE v.id = ?",
         )
@@ -1854,7 +1850,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
             "SELECT vhr.company_id 
              FROM vm v
              JOIN vm_host vh ON v.host_id = vh.id  
-             JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             JOIN region vhr ON vh.region_id = vhr.id
              WHERE v.id = ?",
         )
         .bind(vm_id)
@@ -2544,7 +2540,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
                  AND sli.subscription_type = 3
              LEFT JOIN vm v ON v.subscription_line_item_id = sli.id
              LEFT JOIN vm_host vh ON v.host_id = vh.id
-             LEFT JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             LEFT JOIN region vhr ON vh.region_id = vhr.id
              JOIN company c ON (CASE WHEN vhr.company_id IS NOT NULL
                                      THEN vhr.company_id
                                      ELSE s.company_id END) = c.id
@@ -3516,7 +3512,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
                  WHERE sp2.is_paid = 1
              ) sp ON v.id = sp.vm_id AND sp.rn = 1
              JOIN vm_host vh ON v.host_id = vh.id
-             JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             JOIN region vhr ON vh.region_id = vhr.id
              JOIN company c ON vhr.company_id = c.id
              LEFT JOIN referral r ON r.code = v.ref_code
              WHERE v.ref_code = ?
@@ -3553,7 +3549,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
                  WHERE sp2.is_paid = 1
              ) sp ON v.id = sp.vm_id AND sp.rn = 1
              JOIN vm_host vh ON v.host_id = vh.id
-             JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             JOIN region vhr ON vh.region_id = vhr.id
              JOIN company c ON vhr.company_id = c.id
              LEFT JOIN referral r ON r.code = v.ref_code
              WHERE v.ref_code = ?
@@ -3580,7 +3576,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
                  WHERE sp2.is_paid = 1
              ) sp ON v.id = sp.vm_id AND sp.rn = 1
              JOIN vm_host vh ON v.host_id = vh.id
-             JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             JOIN region vhr ON vh.region_id = vhr.id
              JOIN company c ON vhr.company_id = c.id
              WHERE v.ref_code = ?",
         )
@@ -4304,24 +4300,19 @@ impl AdminDb for LNVpsDbMysql {
         Ok(user)
     }
 
-    async fn admin_list_regions(
-        &self,
-        limit: u64,
-        offset: u64,
-    ) -> DbResult<(Vec<VmHostRegion>, u64)> {
+    async fn admin_list_regions(&self, limit: u64, offset: u64) -> DbResult<(Vec<Region>, u64)> {
         // Get total count
-        let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vm_host_region")
+        let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM region")
             .fetch_one(&self.db)
             .await?;
 
         // Get paginated results
-        let regions = sqlx::query_as::<_, VmHostRegion>(
-            "SELECT * FROM vm_host_region ORDER BY name LIMIT ? OFFSET ?",
-        )
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.db)
-        .await?;
+        let regions =
+            sqlx::query_as::<_, Region>("SELECT * FROM region ORDER BY name LIMIT ? OFFSET ?")
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(&self.db)
+                .await?;
 
         Ok((regions, total as u64))
     }
@@ -4333,7 +4324,7 @@ impl AdminDb for LNVpsDbMysql {
         company_id: u64,
     ) -> DbResult<u64> {
         let id = sqlx::query_scalar::<_, u64>(
-            "INSERT INTO vm_host_region (name, enabled, company_id) VALUES (?, ?, ?) RETURNING id",
+            "INSERT INTO region (name, enabled, company_id) VALUES (?, ?, ?) RETURNING id",
         )
         .bind(name)
         .bind(enabled)
@@ -4344,8 +4335,8 @@ impl AdminDb for LNVpsDbMysql {
         Ok(id)
     }
 
-    async fn admin_update_region(&self, region: &VmHostRegion) -> DbResult<()> {
-        sqlx::query("UPDATE vm_host_region SET name = ?, enabled = ?, company_id = ? WHERE id = ?")
+    async fn admin_update_region(&self, region: &Region) -> DbResult<()> {
+        sqlx::query("UPDATE region SET name = ?, enabled = ?, company_id = ? WHERE id = ?")
             .bind(&region.name)
             .bind(region.enabled)
             .bind(region.company_id)
@@ -4372,7 +4363,7 @@ impl AdminDb for LNVpsDbMysql {
         }
 
         // Disable the region instead of deleting to preserve referential integrity
-        sqlx::query("UPDATE vm_host_region SET enabled = ? WHERE id = ?")
+        sqlx::query("UPDATE region SET enabled = ? WHERE id = ?")
             .bind(false)
             .bind(region_id)
             .execute(&self.db)
@@ -4642,7 +4633,7 @@ impl AdminDb for LNVpsDbMysql {
     ) -> DbResult<(Vec<AdminVmHost>, u64)> {
         // Get total count (including disabled hosts)
         let total: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM vm_host h JOIN vm_host_region hr ON h.region_id = hr.id",
+            "SELECT COUNT(*) FROM vm_host h JOIN region hr ON h.region_id = hr.id",
         )
         .fetch_one(&self.db)
         .await?;
@@ -4656,7 +4647,7 @@ impl AdminDb for LNVpsDbMysql {
                     hr.company_id as region_company_id,
                     COALESCE(vm_counts.active_vm_count, 0) as active_vm_count
              FROM vm_host h 
-             JOIN vm_host_region hr ON h.region_id = hr.id 
+             JOIN region hr ON h.region_id = hr.id 
              LEFT JOIN (
                  SELECT host_id, COUNT(*) as active_vm_count 
                  FROM vm 
@@ -5028,12 +5019,11 @@ impl AdminDb for LNVpsDbMysql {
     }
 
     async fn admin_count_company_regions(&self, company_id: u64) -> DbResult<u64> {
-        let count = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM vm_host_region WHERE company_id = ?",
-        )
-        .bind(company_id)
-        .fetch_one(&self.db)
-        .await?;
+        let count =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM region WHERE company_id = ?")
+                .bind(company_id)
+                .fetch_one(&self.db)
+                .await?;
 
         Ok(count as u64)
     }
@@ -5057,7 +5047,7 @@ impl AdminDb for LNVpsDbMysql {
                  AND sli.subscription_type = 3
              LEFT JOIN vm v ON v.subscription_line_item_id = sli.id
              LEFT JOIN vm_host vh ON v.host_id = vh.id
-             LEFT JOIN vm_host_region vhr ON vh.region_id = vhr.id
+             LEFT JOIN region vhr ON vh.region_id = vhr.id
              JOIN company c ON (CASE WHEN vhr.company_id IS NOT NULL
                                      THEN vhr.company_id
                                      ELSE s.company_id END) = c.id
@@ -5108,7 +5098,7 @@ impl AdminDb for LNVpsDbMysql {
                              WHERE sp2.is_paid = 1
                          ) sp ON v.id = sp.vm_id AND sp.rn = 1
                          JOIN vm_host vh ON v.host_id = vh.id
-                         JOIN vm_host_region vhr ON vh.region_id = vhr.id
+                         JOIN region vhr ON vh.region_id = vhr.id
                          JOIN company c ON vhr.company_id = c.id
                          LEFT JOIN referral r ON r.code = v.ref_code
                          WHERE v.ref_code IS NOT NULL

--- a/lnvps_e2e/src/db.rs
+++ b/lnvps_e2e/src/db.rs
@@ -247,7 +247,7 @@ pub async fn hard_delete_host(pool: &MySqlPool, host_id: u64) -> anyhow::Result<
 
 /// Hard-delete a region (admin DELETE only soft-deletes via `enabled = false`).
 pub async fn hard_delete_region(pool: &MySqlPool, region_id: u64) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM vm_host_region WHERE id = ?")
+    sqlx::query("DELETE FROM region WHERE id = ?")
         .bind(region_id)
         .execute(pool)
         .await?;


### PR DESCRIPTION
## Why

Prep for the App Deployments epic. Apps will run on shared Kubernetes clusters and need a **location + billing anchor** (which company charges the deployment), but they must not depend on VM infrastructure. Today that anchor is `vm_host_region`.

Key observation: **`vm_host_region` holds only `{id, name, enabled, company_id}`** — a neutral location+company row with **zero VM-specific columns**. It's already the shared concept, just named after its first consumer. So instead of overloading it (an `app_cluster → vm_host_region` FK felt wrong) or adding a redundant parent table, we simply rename it to `region`.

## What

- **Migration**: `RENAME TABLE vm_host_region TO region` — foreign keys and the `region_id` columns on referencing tables (`vm_host`, `ip_range`, …) are preserved automatically.
- **Struct/type**: `VmHostRegion` → `Region`, and all internal SQL/type references updated.
- **Public API unchanged**: `ApiVmHostRegion` and the admin region endpoints keep their names/shapes (they now map from the renamed `Region` struct). No client-visible change, no API_CHANGELOG entry.
- DB trait method names (`get_host_region`, …) intentionally left as-is to keep the diff focused; they now return `Region`.

Pure rename, no behaviour change. Full workspace builds; all `lnvps_db` and `lnvps_api_common` tests pass.

Follow-up: `app_cluster.region_id → region` in the App Deployments work.