### PR TITLE
App Deployments (1/N): DB foundation — catalog, clusters, deployments

### DIFF
--- a/lnvps_api/src/api/legal.rs
+++ b/lnvps_api/src/api/legal.rs
@@ -253,6 +253,7 @@ async fn v1_generate_lir_agreement_from_subscription(
             lnvps_db::SubscriptionType::AsnSponsoring => ("AS Number".to_string(), "—".to_string()),
             lnvps_db::SubscriptionType::DnsHosting => ("DNS Hosting".to_string(), "—".to_string()),
             lnvps_db::SubscriptionType::Vps => ("VPS".to_string(), "—".to_string()),
+            lnvps_db::SubscriptionType::App => ("App".to_string(), "—".to_string()),
         };
 
         resources.push(ResourceRequest {

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -3,9 +3,10 @@ use anyhow::{Context, anyhow};
 use chrono::{Days, Months, TimeDelta, Utc};
 use lnvps_db::nostr::LNVPSNostrDb;
 use lnvps_db::{
-    AccessPolicy, AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, Company, CpuArch,
-    CpuMfg, DbError, DbResult, DiskInterface, DiskType, DnsServer, DnsServerKind, IntervalType,
-    IpRange, IpRangeAllocationMode, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, NostrDomain,
+    AccessPolicy, App, AppCluster, AppDeployment, AppDeploymentDesiredState, AppDeploymentStatus,
+    AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, Company, CpuArch, CpuMfg, DbError,
+    DbResult, DiskInterface, DiskType, DnsServer, DnsServerKind, IntervalType, IpRange,
+    IpRangeAllocationMode, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, NostrDomain,
     NostrDomainHandle, OsDistribution, PaymentMethod, PaymentMethodConfig, Referral,
     ReferralCostUsage, ReferralPayout, Region, Router, RouterBgpRoute, RouterBgpSession,
     RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
@@ -60,6 +61,9 @@ pub struct MockDb {
     pub router_bgp_routes: Arc<Mutex<HashMap<u64, RouterBgpRoute>>>,
     pub firewall_rules: Arc<Mutex<HashMap<u64, VmFirewallRule>>>,
     pub webauthn_credentials: Arc<Mutex<HashMap<u64, WebauthnCredential>>>,
+    pub apps: Arc<Mutex<HashMap<u64, App>>>,
+    pub app_clusters: Arc<Mutex<HashMap<u64, AppCluster>>>,
+    pub app_deployments: Arc<Mutex<HashMap<u64, AppDeployment>>>,
 }
 
 impl MockDb {
@@ -343,6 +347,9 @@ impl Default for MockDb {
             router_bgp_routes: Arc::new(Default::default()),
             firewall_rules: Arc::new(Default::default()),
             webauthn_credentials: Arc::new(Default::default()),
+            apps: Arc::new(Default::default()),
+            app_clusters: Arc::new(Default::default()),
+            app_deployments: Arc::new(Default::default()),
         }
     }
 }
@@ -3118,6 +3125,183 @@ impl LNVpsDbBase for MockDb {
             })
             .count() as u64)
     }
+
+    // ----- App catalog -----
+
+    async fn list_apps(&self, enabled_only: bool) -> DbResult<Vec<App>> {
+        let apps = self.apps.lock().await;
+        let mut out: Vec<App> = apps
+            .values()
+            .filter(|a| !enabled_only || a.enabled)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        Ok(out)
+    }
+
+    async fn get_app(&self, id: u64) -> DbResult<App> {
+        self.apps
+            .lock()
+            .await
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| anyhow!("app not found").into())
+    }
+
+    async fn get_app_by_name(&self, name: &str) -> DbResult<App> {
+        self.apps
+            .lock()
+            .await
+            .values()
+            .find(|a| a.name == name)
+            .cloned()
+            .ok_or_else(|| anyhow!("app not found").into())
+    }
+
+    async fn insert_app(&self, app: &App) -> DbResult<u64> {
+        let mut apps = self.apps.lock().await;
+        if apps.values().any(|a| a.name == app.name) {
+            return Err(DbError::Other(anyhow!("app name already exists")));
+        }
+        let new_id = apps.keys().max().copied().unwrap_or(0) + 1;
+        apps.insert(
+            new_id,
+            App {
+                id: new_id,
+                ..app.clone()
+            },
+        );
+        Ok(new_id)
+    }
+
+    async fn update_app(&self, app: &App) -> DbResult<()> {
+        let mut apps = self.apps.lock().await;
+        if let Some(a) = apps.get_mut(&app.id) {
+            *a = app.clone();
+        }
+        Ok(())
+    }
+
+    async fn delete_app(&self, id: u64) -> DbResult<()> {
+        self.apps.lock().await.remove(&id);
+        Ok(())
+    }
+
+    // ----- App clusters -----
+
+    async fn list_app_clusters(&self, enabled_only: bool) -> DbResult<Vec<AppCluster>> {
+        let clusters = self.app_clusters.lock().await;
+        let mut out: Vec<AppCluster> = clusters
+            .values()
+            .filter(|c| !enabled_only || c.enabled)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+
+    async fn get_app_cluster(&self, id: u64) -> DbResult<AppCluster> {
+        self.app_clusters
+            .lock()
+            .await
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| anyhow!("app cluster not found").into())
+    }
+
+    async fn insert_app_cluster(&self, cluster: &AppCluster) -> DbResult<u64> {
+        let mut clusters = self.app_clusters.lock().await;
+        let new_id = clusters.keys().max().copied().unwrap_or(0) + 1;
+        clusters.insert(
+            new_id,
+            AppCluster {
+                id: new_id,
+                ..cluster.clone()
+            },
+        );
+        Ok(new_id)
+    }
+
+    async fn update_app_cluster(&self, cluster: &AppCluster) -> DbResult<()> {
+        let mut clusters = self.app_clusters.lock().await;
+        if let Some(c) = clusters.get_mut(&cluster.id) {
+            *c = cluster.clone();
+        }
+        Ok(())
+    }
+
+    async fn delete_app_cluster(&self, id: u64) -> DbResult<()> {
+        self.app_clusters.lock().await.remove(&id);
+        Ok(())
+    }
+
+    // ----- App deployments -----
+
+    async fn list_user_app_deployments(&self, user_id: u64) -> DbResult<Vec<AppDeployment>> {
+        let d = self.app_deployments.lock().await;
+        let mut out: Vec<AppDeployment> = d
+            .values()
+            .filter(|x| x.user_id == user_id && !x.deleted)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| b.created.cmp(&a.created));
+        Ok(out)
+    }
+
+    async fn list_all_app_deployments(&self) -> DbResult<Vec<AppDeployment>> {
+        let d = self.app_deployments.lock().await;
+        let mut out: Vec<AppDeployment> = d.values().filter(|x| !x.deleted).cloned().collect();
+        out.sort_by_key(|x| x.id);
+        Ok(out)
+    }
+
+    async fn get_app_deployment(&self, id: u64) -> DbResult<AppDeployment> {
+        self.app_deployments
+            .lock()
+            .await
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| anyhow!("app deployment not found").into())
+    }
+
+    async fn get_app_deployment_by_line_item(&self, line_item_id: u64) -> DbResult<AppDeployment> {
+        self.app_deployments
+            .lock()
+            .await
+            .values()
+            .find(|x| x.subscription_line_item_id == line_item_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("app deployment not found").into())
+    }
+
+    async fn insert_app_deployment(&self, deployment: &AppDeployment) -> DbResult<u64> {
+        let mut d = self.app_deployments.lock().await;
+        let new_id = d.keys().max().copied().unwrap_or(0) + 1;
+        d.insert(
+            new_id,
+            AppDeployment {
+                id: new_id,
+                ..deployment.clone()
+            },
+        );
+        Ok(new_id)
+    }
+
+    async fn update_app_deployment(&self, deployment: &AppDeployment) -> DbResult<()> {
+        let mut d = self.app_deployments.lock().await;
+        if let Some(x) = d.get_mut(&deployment.id) {
+            *x = deployment.clone();
+        }
+        Ok(())
+    }
+
+    async fn delete_app_deployment(&self, id: u64) -> DbResult<()> {
+        let mut d = self.app_deployments.lock().await;
+        if let Some(x) = d.get_mut(&id) {
+            x.deleted = true;
+        }
+        Ok(())
+    }
 }
 
 pub struct MockExchangeRate {
@@ -5642,6 +5826,153 @@ mod tests {
             vec![1, 2],
             "active = non-deleted, set-up VMs (incl. expired)"
         );
+    }
+
+    fn mk_app(name: &str) -> App {
+        App {
+            id: 0,
+            name: name.to_string(),
+            display_name: format!("{name} app"),
+            description: None,
+            icon: None,
+            compose: "services: {}".to_string(),
+            amount: 1000,
+            currency: "USD".to_string(),
+            interval_amount: 1,
+            interval_type: IntervalType::Month,
+            setup_amount: 0,
+            enabled: true,
+            created: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_app_catalog_crud() {
+        let db = MockDb::default();
+
+        // Insert two apps; the second disabled.
+        let id1 = db.insert_app(&mk_app("nostr-relay")).await.unwrap();
+        let mut a2 = mk_app("blossom");
+        a2.enabled = false;
+        let id2 = db.insert_app(&a2).await.unwrap();
+
+        // Duplicate name is rejected.
+        assert!(db.insert_app(&mk_app("nostr-relay")).await.is_err());
+
+        // get / get_by_name.
+        assert_eq!(db.get_app(id1).await.unwrap().name, "nostr-relay");
+        assert_eq!(db.get_app_by_name("blossom").await.unwrap().id, id2);
+        assert!(db.get_app(9999).await.is_err());
+
+        // list all vs enabled-only.
+        assert_eq!(db.list_apps(false).await.unwrap().len(), 2);
+        let enabled = db.list_apps(true).await.unwrap();
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].id, id1);
+
+        // update.
+        let mut a1 = db.get_app(id1).await.unwrap();
+        a1.display_name = "Relay!".to_string();
+        db.update_app(&a1).await.unwrap();
+        assert_eq!(db.get_app(id1).await.unwrap().display_name, "Relay!");
+
+        // delete.
+        db.delete_app(id2).await.unwrap();
+        assert!(db.get_app(id2).await.is_err());
+        assert_eq!(db.list_apps(false).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_app_cluster_crud() {
+        let db = MockDb::default();
+        let id = db
+            .insert_app_cluster(&AppCluster {
+                id: 0,
+                name: "eu-1".to_string(),
+                region_id: 1,
+                ingress_domain: "apps.example.com".to_string(),
+                enabled: true,
+                created: Utc::now(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(db.get_app_cluster(id).await.unwrap().name, "eu-1");
+        assert_eq!(db.list_app_clusters(true).await.unwrap().len(), 1);
+
+        // Disable -> excluded from enabled-only listing.
+        let mut c = db.get_app_cluster(id).await.unwrap();
+        c.enabled = false;
+        db.update_app_cluster(&c).await.unwrap();
+        assert_eq!(db.list_app_clusters(true).await.unwrap().len(), 0);
+        assert_eq!(db.list_app_clusters(false).await.unwrap().len(), 1);
+
+        db.delete_app_cluster(id).await.unwrap();
+        assert!(db.get_app_cluster(id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_app_deployment_crud() {
+        let db = MockDb::default();
+        let app_id = db.insert_app(&mk_app("relay")).await.unwrap();
+        let cluster_id = db
+            .insert_app_cluster(&AppCluster {
+                id: 0,
+                name: "c1".to_string(),
+                region_id: 1,
+                ingress_domain: "apps.example.com".to_string(),
+                enabled: true,
+                created: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let mk_dep = |user: u64, li: u64, name: &str| AppDeployment {
+            id: 0,
+            user_id: user,
+            app_id,
+            cluster_id,
+            subscription_line_item_id: li,
+            name: name.to_string(),
+            namespace: format!("app-{name}"),
+            hostname: None,
+            config: None,
+            desired_state: AppDeploymentDesiredState::Running,
+            status: AppDeploymentStatus::Pending,
+            status_message: None,
+            created: Utc::now(),
+            deleted: false,
+        };
+
+        let d1 = db.insert_app_deployment(&mk_dep(1, 10, "a")).await.unwrap();
+        let _d2 = db.insert_app_deployment(&mk_dep(1, 11, "b")).await.unwrap();
+        let _d3 = db.insert_app_deployment(&mk_dep(2, 12, "c")).await.unwrap();
+
+        // Per-user listing.
+        assert_eq!(db.list_user_app_deployments(1).await.unwrap().len(), 2);
+        assert_eq!(db.list_user_app_deployments(2).await.unwrap().len(), 1);
+        // Operator listing sees all non-deleted.
+        assert_eq!(db.list_all_app_deployments().await.unwrap().len(), 3);
+
+        // Resolve by line item.
+        assert_eq!(
+            db.get_app_deployment_by_line_item(11).await.unwrap().name,
+            "b"
+        );
+
+        // Status write-back.
+        let mut dep = db.get_app_deployment(d1).await.unwrap();
+        dep.status = AppDeploymentStatus::Running;
+        dep.hostname = Some("a.apps.example.com".to_string());
+        db.update_app_deployment(&dep).await.unwrap();
+        let reloaded = db.get_app_deployment(d1).await.unwrap();
+        assert_eq!(reloaded.status, AppDeploymentStatus::Running);
+        assert_eq!(reloaded.hostname.as_deref(), Some("a.apps.example.com"));
+
+        // Soft delete removes it from both listings but the row still exists.
+        db.delete_app_deployment(d1).await.unwrap();
+        assert_eq!(db.list_user_app_deployments(1).await.unwrap().len(), 1);
+        assert_eq!(db.list_all_app_deployments().await.unwrap().len(), 2);
+        assert!(db.get_app_deployment(d1).await.unwrap().deleted);
     }
 }
 

--- a/lnvps_api_common/src/model.rs
+++ b/lnvps_api_common/src/model.rs
@@ -828,6 +828,9 @@ pub enum ApiSubscriptionLineItemResource {
     /// A sponsored AS number.
     #[serde(rename = "asn")]
     Asn { asn_subscription_id: u64 },
+    /// A managed app deployment.
+    #[serde(rename = "app")]
+    App { app_deployment_id: u64 },
 }
 
 impl ApiSubscriptionLineItemResource {
@@ -860,6 +863,13 @@ impl ApiSubscriptionLineItemResource {
                 .and_then(|subs| subs.into_iter().next())
                 .map(|sub| Self::Asn {
                     asn_subscription_id: sub.id,
+                }),
+            SubscriptionType::App => db
+                .get_app_deployment_by_line_item(line_item.id)
+                .await
+                .ok()
+                .map(|d| Self::App {
+                    app_deployment_id: d.id,
                 }),
             SubscriptionType::DnsHosting => None,
         }

--- a/lnvps_db/migrations/20260724123500_app_deployments.sql
+++ b/lnvps_db/migrations/20260724123500_app_deployments.sql
@@ -1,0 +1,75 @@
+-- App catalog: predefined managed applications offered on shared k8s infra.
+-- Each app is defined by a docker-compose-style YAML blob; the operator
+-- translates it (merged with a deployment's config) into Kubernetes objects.
+CREATE TABLE app
+(
+    id              INTEGER UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name            VARCHAR(64)      NOT NULL,
+    display_name    VARCHAR(200)     NOT NULL,
+    description     TEXT             NULL DEFAULT NULL,
+    icon            VARCHAR(500)     NULL DEFAULT NULL,
+    -- docker-compose-style YAML (image / ports / env / volumes)
+    compose         MEDIUMTEXT       NOT NULL,
+    -- recurring price in the smallest currency unit (cents / millisats)
+    amount          BIGINT UNSIGNED  NOT NULL,
+    currency        VARCHAR(10)      NOT NULL,
+    interval_amount BIGINT UNSIGNED  NOT NULL,
+    interval_type   SMALLINT UNSIGNED NOT NULL,
+    setup_amount    BIGINT UNSIGNED  NOT NULL DEFAULT 0,
+    enabled         BIT(1)           NOT NULL DEFAULT 1,
+    created         TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_app_name UNIQUE (name)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+-- A Kubernetes cluster where apps can be deployed. Linked to a region so
+-- location / company / tax / currency resolve exactly like VMs. The operator
+-- that runs *inside* a cluster is configured with its own cluster id and only
+-- reconciles that cluster's deployments; no kube credentials are stored here.
+CREATE TABLE app_cluster
+(
+    id             INTEGER UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name           VARCHAR(100)     NOT NULL,
+    region_id      INTEGER UNSIGNED NOT NULL,
+    -- wildcard base domain for ingress hostnames on this cluster
+    -- (hostname = "{deployment.name}.{ingress_domain}")
+    ingress_domain VARCHAR(255)     NOT NULL,
+    enabled        BIT(1)           NOT NULL DEFAULT 1,
+    created        TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_app_cluster_region FOREIGN KEY (region_id) REFERENCES region (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+-- A customer's running instance of an app, billed via the subscription engine
+-- (subscription_line_item_id, type=App) and reconciled into its own namespace
+-- on the chosen cluster.
+CREATE TABLE app_deployment
+(
+    id                        INTEGER UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id                   INTEGER UNSIGNED NOT NULL,
+    app_id                    INTEGER UNSIGNED NOT NULL,
+    cluster_id                INTEGER UNSIGNED NOT NULL,
+    subscription_line_item_id INTEGER UNSIGNED NOT NULL,
+    name                      VARCHAR(64)      NOT NULL,
+    namespace                 VARCHAR(64)      NOT NULL,
+    hostname                  VARCHAR(255)     NULL DEFAULT NULL,
+    -- encrypted JSON of resolved per-deployment config (env values, secrets);
+    -- EncryptedString serializes as an encoded string, so store as TEXT
+    config                    TEXT             NULL DEFAULT NULL,
+    desired_state             SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+    status                    SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+    status_message            VARCHAR(500)     NULL DEFAULT NULL,
+    created                   TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted                   BIT(1)           NOT NULL DEFAULT 0,
+    CONSTRAINT fk_app_deployment_user FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_app_deployment_app FOREIGN KEY (app_id) REFERENCES app (id),
+    CONSTRAINT fk_app_deployment_cluster FOREIGN KEY (cluster_id) REFERENCES app_cluster (id),
+    CONSTRAINT fk_app_deployment_line_item FOREIGN KEY (subscription_line_item_id) REFERENCES subscription_line_item (id),
+    CONSTRAINT uq_app_deployment_namespace UNIQUE (namespace)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+CREATE INDEX ix_app_deployment_user ON app_deployment (user_id);
+CREATE INDEX ix_app_deployment_app ON app_deployment (app_id);
+CREATE INDEX ix_app_deployment_cluster ON app_deployment (cluster_id);
+CREATE INDEX ix_app_deployment_line_item ON app_deployment (subscription_line_item_id);

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -984,6 +984,42 @@ pub trait LNVpsDbBase: Send + Sync {
 
     /// Count VMs that used this referral code but have never made a paid subscription payment.
     async fn count_failed_referrals(&self, code: &str) -> DbResult<u64>;
+
+    // ----- App catalog -----
+
+    /// List catalog apps. When `enabled_only` is set, only apps offered in the
+    /// catalog are returned (for the customer-facing listing).
+    async fn list_apps(&self, enabled_only: bool) -> DbResult<Vec<App>>;
+    async fn get_app(&self, id: u64) -> DbResult<App>;
+    async fn get_app_by_name(&self, name: &str) -> DbResult<App>;
+    async fn insert_app(&self, app: &App) -> DbResult<u64>;
+    async fn update_app(&self, app: &App) -> DbResult<()>;
+    async fn delete_app(&self, id: u64) -> DbResult<()>;
+
+    // ----- App clusters -----
+
+    /// List app clusters. When `enabled_only` is set, only clusters that accept
+    /// new deployments are returned.
+    async fn list_app_clusters(&self, enabled_only: bool) -> DbResult<Vec<AppCluster>>;
+    async fn get_app_cluster(&self, id: u64) -> DbResult<AppCluster>;
+    async fn insert_app_cluster(&self, cluster: &AppCluster) -> DbResult<u64>;
+    async fn update_app_cluster(&self, cluster: &AppCluster) -> DbResult<()>;
+    async fn delete_app_cluster(&self, id: u64) -> DbResult<()>;
+
+    // ----- App deployments -----
+
+    /// List a user's app deployments (excludes soft-deleted rows).
+    async fn list_user_app_deployments(&self, user_id: u64) -> DbResult<Vec<AppDeployment>>;
+    /// List every non-deleted app deployment (used by the operator to reconcile).
+    async fn list_all_app_deployments(&self) -> DbResult<Vec<AppDeployment>>;
+    async fn get_app_deployment(&self, id: u64) -> DbResult<AppDeployment>;
+    /// Resolve the deployment billed by a given subscription line item.
+    async fn get_app_deployment_by_line_item(&self, line_item_id: u64) -> DbResult<AppDeployment>;
+    async fn insert_app_deployment(&self, deployment: &AppDeployment) -> DbResult<u64>;
+    async fn update_app_deployment(&self, deployment: &AppDeployment) -> DbResult<()>;
+    /// Soft-delete a deployment (sets `deleted = 1`); the operator tears down
+    /// the Kubernetes resources on its next reconcile.
+    async fn delete_app_deployment(&self, id: u64) -> DbResult<()>;
 }
 
 /// Super trait that combines all database functionality based on enabled features

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -2090,6 +2090,7 @@ pub enum SubscriptionType {
     AsnSponsoring = 1, // ASN sponsoring services
     DnsHosting = 2,    // DNS hosting services
     Vps = 3,           // VM (links to vm table via vm.subscription_line_item_id)
+    App = 4, // Managed app deployment (links via app_deployment.subscription_line_item_id)
 }
 
 impl Display for SubscriptionType {
@@ -2099,6 +2100,7 @@ impl Display for SubscriptionType {
             SubscriptionType::AsnSponsoring => write!(f, "ASN Sponsoring"),
             SubscriptionType::DnsHosting => write!(f, "DNS Hosting"),
             SubscriptionType::Vps => write!(f, "VPS"),
+            SubscriptionType::App => write!(f, "App"),
         }
     }
 }
@@ -3061,4 +3063,145 @@ impl PaymentMethodConfig {
             modified: Utc::now(),
         }
     }
+}
+
+/// A predefined managed application in the catalog.
+///
+/// Each app is defined by a **docker-compose-style YAML** blob (`compose`) that
+/// describes the container image(s), ports, environment and volumes. The
+/// customer UI renders forms from that spec, and `lnvps_operator` translates it
+/// (merged with a deployment's chosen config) into Kubernetes objects. Apps are
+/// billed through the subscription engine using the inline pricing fields
+/// (`amount`/`currency`/`interval_*`, matching [`VmCostPlan`]).
+#[derive(FromRow, Clone, Debug)]
+pub struct App {
+    pub id: u64,
+    /// URL/DNS-safe slug (e.g. `nostr-relay`); unique.
+    pub name: String,
+    /// Human-friendly catalog name.
+    pub display_name: String,
+    pub description: Option<String>,
+    /// Optional icon/logo URL for the catalog UI.
+    pub icon: Option<String>,
+    /// Docker-compose-style YAML defining the app (image, ports, env, volumes).
+    pub compose: String,
+    /// Recurring price in the smallest currency unit (cents / millisats).
+    pub amount: u64,
+    pub currency: String,
+    /// Billing interval, e.g. `1` `Month`.
+    pub interval_amount: u64,
+    pub interval_type: IntervalType,
+    /// One-off setup fee in the smallest currency unit (0 = none).
+    pub setup_amount: u64,
+    /// Whether the app is offered in the catalog.
+    pub enabled: bool,
+    pub created: DateTime<Utc>,
+}
+
+/// A Kubernetes cluster where apps can be deployed.
+///
+/// Linked to a [`Region`] so location, company, tax and currency resolve
+/// exactly like VMs (`region.company_id`). The `lnvps_operator` instance that
+/// runs inside a cluster is configured with its own cluster id and reconciles
+/// only that cluster's deployments — no kube credentials are stored in the DB.
+#[derive(FromRow, Clone, Debug)]
+pub struct AppCluster {
+    pub id: u64,
+    pub name: String,
+    /// Region this cluster belongs to (drives company / tax / currency).
+    pub region_id: u64,
+    /// Wildcard base domain for ingress hostnames on this cluster; a
+    /// deployment's host is `"{deployment.name}.{ingress_domain}"`.
+    pub ingress_domain: String,
+    pub enabled: bool,
+    pub created: DateTime<Utc>,
+}
+
+/// Desired run state of a deployment, set by the customer and honoured by the
+/// operator (scale to 0 replicas when `Stopped`).
+#[derive(Clone, Copy, Debug, sqlx::Type, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[repr(u8)]
+#[serde(rename_all = "snake_case")]
+pub enum AppDeploymentDesiredState {
+    #[default]
+    Running = 0,
+    Stopped = 1,
+}
+
+impl Display for AppDeploymentDesiredState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppDeploymentDesiredState::Running => write!(f, "running"),
+            AppDeploymentDesiredState::Stopped => write!(f, "stopped"),
+        }
+    }
+}
+
+/// Observed status of a deployment, written back by the operator as it
+/// reconciles the Kubernetes resources.
+#[derive(Clone, Copy, Debug, sqlx::Type, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[repr(u8)]
+#[serde(rename_all = "snake_case")]
+pub enum AppDeploymentStatus {
+    /// Created in the DB but not yet reconciled / not yet ready.
+    #[default]
+    Pending = 0,
+    /// Reconciled and the workload is running.
+    Running = 1,
+    /// Scaled to zero at the customer's request.
+    Stopped = 2,
+    /// Reconciliation failed; see `status_message`.
+    Error = 3,
+    /// Being torn down.
+    Deleting = 4,
+}
+
+impl Display for AppDeploymentStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppDeploymentStatus::Pending => write!(f, "pending"),
+            AppDeploymentStatus::Running => write!(f, "running"),
+            AppDeploymentStatus::Stopped => write!(f, "stopped"),
+            AppDeploymentStatus::Error => write!(f, "error"),
+            AppDeploymentStatus::Deleting => write!(f, "deleting"),
+        }
+    }
+}
+
+/// A customer's running instance of an [`App`].
+///
+/// Billed via the subscription engine: `subscription_line_item_id` links to a
+/// [`SubscriptionLineItem`] of type [`SubscriptionType::App`], mirroring how
+/// `vm.subscription_line_item_id` works. Reconciled into its own Kubernetes
+/// namespace (`namespace`) by `lnvps_operator`.
+#[derive(FromRow, Clone, Debug)]
+pub struct AppDeployment {
+    pub id: u64,
+    pub user_id: u64,
+    /// Catalog app being deployed.
+    pub app_id: u64,
+    /// Cluster this deployment runs on (drives placement + billing region).
+    pub cluster_id: u64,
+    /// Billing back-reference (subscription line item of type `App`).
+    pub subscription_line_item_id: u64,
+    /// User-chosen, DNS-safe instance name (used for the subdomain/host).
+    pub name: String,
+    /// Dedicated Kubernetes namespace for this deployment (isolation boundary).
+    pub namespace: String,
+    /// Public ingress hostname once assigned (e.g. `name.apps.lnvps.tld`).
+    pub hostname: Option<String>,
+    /// Resolved per-deployment configuration (env values etc.), stored as an
+    /// encrypted JSON blob so secret values are protected at rest. `None` until
+    /// the customer supplies configuration.
+    pub config: Option<EncryptedString>,
+    /// Desired run state (customer-controlled).
+    pub desired_state: AppDeploymentDesiredState,
+    /// Observed status (operator-controlled).
+    pub status: AppDeploymentStatus,
+    /// Optional human-readable status/error detail from the operator.
+    pub status_message: Option<String>,
+    pub created: DateTime<Utc>,
+    /// Soft-delete flag; a deleted deployment is torn down by the operator and
+    /// retained only for accounting.
+    pub deleted: bool,
 }

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -1,12 +1,13 @@
 use crate::{
-    AccessPolicy, AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, Company, DbError,
-    DbResult, DnsServer, IntervalType, IpRange, IpRangeSubscription, IpSpacePricing, LNVpsDbBase,
-    PaymentMethod, PaymentMethodConfig, PaymentType, Referral, ReferralCostUsage, ReferralPayout,
-    Region, RegionStats, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel,
-    RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
-    SubscriptionPaymentWithCompany, User, UserPaymentMethod, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallPolicy, VmFirewallRule,
-    VmHistory, VmHost, VmHostDisk, VmIpAssignment, VmOsImage, VmTemplate, WebauthnCredential,
+    AccessPolicy, App, AppCluster, AppDeployment, AsnSubscription, AsnSubscriptionStatus,
+    AvailableIpSpace, Company, DbError, DbResult, DnsServer, IntervalType, IpRange,
+    IpRangeSubscription, IpSpacePricing, LNVpsDbBase, PaymentMethod, PaymentMethodConfig,
+    PaymentType, Referral, ReferralCostUsage, ReferralPayout, Region, RegionStats, Router,
+    RouterBgpRoute, RouterBgpSession, RouterTunnel, RouterTunnelTraffic, Subscription,
+    SubscriptionLineItem, SubscriptionPayment, SubscriptionPaymentWithCompany, User,
+    UserPaymentMethod, UserSshKey, Vm, VmCostPlan, VmCustomPricing, VmCustomPricingDisk,
+    VmCustomTemplate, VmFirewallPolicy, VmFirewallRule, VmHistory, VmHost, VmHostDisk,
+    VmIpAssignment, VmOsImage, VmTemplate, WebauthnCredential,
 };
 #[cfg(feature = "admin")]
 use crate::{AdminDb, AdminRole, AdminRoleAssignment, AdminVmHost};
@@ -3603,6 +3604,223 @@ impl LNVpsDbBase for LNVpsDbMysql {
         .fetch_one(&self.db)
         .await?;
         Ok(count as u64)
+    }
+
+    // ----- App catalog -----
+
+    async fn list_apps(&self, enabled_only: bool) -> DbResult<Vec<App>> {
+        let sql = if enabled_only {
+            "SELECT * FROM app WHERE enabled = 1 ORDER BY display_name"
+        } else {
+            "SELECT * FROM app ORDER BY display_name"
+        };
+        Ok(sqlx::query_as(sql).fetch_all(&self.db).await?)
+    }
+
+    async fn get_app(&self, id: u64) -> DbResult<App> {
+        Ok(sqlx::query_as("SELECT * FROM app WHERE id = ?")
+            .bind(id)
+            .fetch_one(&self.db)
+            .await?)
+    }
+
+    async fn get_app_by_name(&self, name: &str) -> DbResult<App> {
+        Ok(sqlx::query_as("SELECT * FROM app WHERE name = ?")
+            .bind(name)
+            .fetch_one(&self.db)
+            .await?)
+    }
+
+    async fn insert_app(&self, app: &App) -> DbResult<u64> {
+        let res = sqlx::query(
+            "INSERT INTO app (name, display_name, description, icon, compose, amount, currency, \
+             interval_amount, interval_type, setup_amount, enabled) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id",
+        )
+        .bind(&app.name)
+        .bind(&app.display_name)
+        .bind(&app.description)
+        .bind(&app.icon)
+        .bind(&app.compose)
+        .bind(app.amount)
+        .bind(&app.currency)
+        .bind(app.interval_amount)
+        .bind(app.interval_type)
+        .bind(app.setup_amount)
+        .bind(app.enabled)
+        .fetch_one(&self.db)
+        .await?;
+        Ok(res.try_get(0)?)
+    }
+
+    async fn update_app(&self, app: &App) -> DbResult<()> {
+        sqlx::query(
+            "UPDATE app SET name = ?, display_name = ?, description = ?, icon = ?, compose = ?, \
+             amount = ?, currency = ?, interval_amount = ?, interval_type = ?, setup_amount = ?, \
+             enabled = ? WHERE id = ?",
+        )
+        .bind(&app.name)
+        .bind(&app.display_name)
+        .bind(&app.description)
+        .bind(&app.icon)
+        .bind(&app.compose)
+        .bind(app.amount)
+        .bind(&app.currency)
+        .bind(app.interval_amount)
+        .bind(app.interval_type)
+        .bind(app.setup_amount)
+        .bind(app.enabled)
+        .bind(app.id)
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
+    async fn delete_app(&self, id: u64) -> DbResult<()> {
+        sqlx::query("DELETE FROM app WHERE id = ?")
+            .bind(id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    // ----- App clusters -----
+
+    async fn list_app_clusters(&self, enabled_only: bool) -> DbResult<Vec<AppCluster>> {
+        let sql = if enabled_only {
+            "SELECT * FROM app_cluster WHERE enabled = 1 ORDER BY name"
+        } else {
+            "SELECT * FROM app_cluster ORDER BY name"
+        };
+        Ok(sqlx::query_as(sql).fetch_all(&self.db).await?)
+    }
+
+    async fn get_app_cluster(&self, id: u64) -> DbResult<AppCluster> {
+        Ok(sqlx::query_as("SELECT * FROM app_cluster WHERE id = ?")
+            .bind(id)
+            .fetch_one(&self.db)
+            .await?)
+    }
+
+    async fn insert_app_cluster(&self, cluster: &AppCluster) -> DbResult<u64> {
+        let res = sqlx::query(
+            "INSERT INTO app_cluster (name, region_id, ingress_domain, enabled) \
+             VALUES (?, ?, ?, ?) returning id",
+        )
+        .bind(&cluster.name)
+        .bind(cluster.region_id)
+        .bind(&cluster.ingress_domain)
+        .bind(cluster.enabled)
+        .fetch_one(&self.db)
+        .await?;
+        Ok(res.try_get(0)?)
+    }
+
+    async fn update_app_cluster(&self, cluster: &AppCluster) -> DbResult<()> {
+        sqlx::query(
+            "UPDATE app_cluster SET name = ?, region_id = ?, ingress_domain = ?, enabled = ? \
+             WHERE id = ?",
+        )
+        .bind(&cluster.name)
+        .bind(cluster.region_id)
+        .bind(&cluster.ingress_domain)
+        .bind(cluster.enabled)
+        .bind(cluster.id)
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
+    async fn delete_app_cluster(&self, id: u64) -> DbResult<()> {
+        sqlx::query("DELETE FROM app_cluster WHERE id = ?")
+            .bind(id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    // ----- App deployments -----
+
+    async fn list_user_app_deployments(&self, user_id: u64) -> DbResult<Vec<AppDeployment>> {
+        Ok(sqlx::query_as(
+            "SELECT * FROM app_deployment WHERE user_id = ? AND deleted = 0 ORDER BY created DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.db)
+        .await?)
+    }
+
+    async fn list_all_app_deployments(&self) -> DbResult<Vec<AppDeployment>> {
+        Ok(
+            sqlx::query_as("SELECT * FROM app_deployment WHERE deleted = 0 ORDER BY id")
+                .fetch_all(&self.db)
+                .await?,
+        )
+    }
+
+    async fn get_app_deployment(&self, id: u64) -> DbResult<AppDeployment> {
+        Ok(sqlx::query_as("SELECT * FROM app_deployment WHERE id = ?")
+            .bind(id)
+            .fetch_one(&self.db)
+            .await?)
+    }
+
+    async fn get_app_deployment_by_line_item(&self, line_item_id: u64) -> DbResult<AppDeployment> {
+        Ok(
+            sqlx::query_as("SELECT * FROM app_deployment WHERE subscription_line_item_id = ?")
+                .bind(line_item_id)
+                .fetch_one(&self.db)
+                .await?,
+        )
+    }
+
+    async fn insert_app_deployment(&self, deployment: &AppDeployment) -> DbResult<u64> {
+        let res = sqlx::query(
+            "INSERT INTO app_deployment (user_id, app_id, cluster_id, subscription_line_item_id, \
+             name, namespace, hostname, config, desired_state, status, status_message) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id",
+        )
+        .bind(deployment.user_id)
+        .bind(deployment.app_id)
+        .bind(deployment.cluster_id)
+        .bind(deployment.subscription_line_item_id)
+        .bind(&deployment.name)
+        .bind(&deployment.namespace)
+        .bind(&deployment.hostname)
+        .bind(&deployment.config)
+        .bind(deployment.desired_state)
+        .bind(deployment.status)
+        .bind(&deployment.status_message)
+        .fetch_one(&self.db)
+        .await?;
+        Ok(res.try_get(0)?)
+    }
+
+    async fn update_app_deployment(&self, deployment: &AppDeployment) -> DbResult<()> {
+        sqlx::query(
+            "UPDATE app_deployment SET name = ?, namespace = ?, hostname = ?, config = ?, \
+             desired_state = ?, status = ?, status_message = ?, deleted = ? WHERE id = ?",
+        )
+        .bind(&deployment.name)
+        .bind(&deployment.namespace)
+        .bind(&deployment.hostname)
+        .bind(&deployment.config)
+        .bind(deployment.desired_state)
+        .bind(deployment.status)
+        .bind(&deployment.status_message)
+        .bind(deployment.deleted)
+        .bind(deployment.id)
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
+    async fn delete_app_deployment(&self, id: u64) -> DbResult<()> {
+        sqlx::query("UPDATE app_deployment SET deleted = 1 WHERE id = ?")
+            .bind(id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
     }
 }
 

--- a/work/app-deployments.md
+++ b/work/app-deployments.md
@@ -1,0 +1,104 @@
+# App Deployments (managed apps on shared k8s infra)
+
+**Status:** in-progress
+**Started:** 2026-07-24
+**Last updated:** 2026-07-24
+
+## Goal
+
+Offer pre-defined "apps" (Nostr relay, Blossom server, …) as managed deployments on
+the existing shared Kubernetes cluster (no per-user VMs / no IP-space usage). A generic
+catalog (`app`) defines each app as a docker-compose-style YAML blob (image / ports /
+env / volumes); user instances (`app_deployment`) are billed through the existing
+subscription engine and reconciled into k8s by `lnvps_operator` (Deployment + Service +
+Ingress + PVC + Secret), one namespace per deployment for isolation. Future: user-defined
+images (higher isolation risk — design the boundary in now).
+
+## Decisions (from user)
+
+- **Billing:** reuse the subscription engine — add `SubscriptionType::App = 4`; deployments
+  link via `app_deployment.subscription_line_item_id` exactly like `vm.subscription_line_item_id`.
+- **Catalog schema:** a **docker-compose-style YAML blob** on the `app` row. The UI renders
+  standard forms (add/remove ports + env) that serialize into that YAML; the operator parses
+  the YAML back into k8s objects.
+- **Isolation:** **namespace per deployment** (`app-{id}`) with default-deny NetworkPolicy,
+  ResourceQuota/LimitRange, restricted PodSecurity, and a locked-down pod securityContext.
+  Predefined apps are low-risk; keep the boundary so user-defined images later is a tightening
+  (runtimeClass/egress), not a redesign.
+- Scope now: **predefined apps only**.
+
+## Findings
+
+- `lnvps_operator` (kube 1.1 + k8s-openapi 0.25) already runs a periodic DB→k8s reconcile loop
+  (`src/main.rs`) and builds cert-manager/nginx **Ingress** for nostr domains
+  (`src/nostr_domains.rs`). App reconcile is the same pattern + Deployment/Service/PVC/Secret.
+- Billing pattern to mirror: `Subscription` → `SubscriptionLineItem` (`subscription_type`) →
+  product back-ref table (`vm.subscription_line_item_id`). Pricing shape = `VmCostPlan`
+  (amount/currency/interval_amount/interval_type:`IntervalType{Day,Month,Year}`).
+- `EncryptedString` (`lnvps_db::encrypted_string`) for secret-at-rest columns (used by `user.email`).
+- `SubscriptionType`: IpRange=0, AsnSponsoring=1, DnsHosting=2, Vps=3 → **App=4** next.
+
+## Tasks
+
+### Increment 0 — prep: rename vm_host_region -> region (DONE, PR #213 merged)
+- [x] Neutral `region` table + `Region` struct; API kept stable (`ApiVmHostRegion`).
+
+### Increment 1 — DB foundation (this PR)
+- [x] Migration: `app` catalog + `app_cluster` + `app_deployment` tables (cluster FK -> region).
+- [x] `SubscriptionType::App = 4` (Display + repr) + `ApiSubscriptionLineItemResource::App`.
+- [x] Model: `App`, `AppCluster`, `AppDeployment`, `AppDeploymentStatus`,
+      `AppDeploymentDesiredState`.
+- [x] DB trait methods (app catalog CRUD; app_cluster CRUD; deployment CRUD;
+      `list_user_app_deployments`, `get_app_deployment_by_line_item`,
+      `list_all_app_deployments` for the operator).
+- [x] mysql impl + MockDb impl.
+- [x] Unit tests (mock CRUD round-trips: catalog, cluster, deployment).
+
+### Increment 2 — Admin catalog API
+- [ ] `lnvps_api_admin` CRUD for `app` (compose YAML validation), `AdminResource::App` + RBAC migration.
+- [ ] Admin model + tests + ADMIN_API_ENDPOINTS.md.
+
+### Increment 3 — Customer API
+- [ ] `GET /api/v1/apps` (catalog), create deployment (→ subscription + line item + invoice,
+      mirroring VM order), list/get/delete deployments, status + endpoint.
+- [ ] Validate submitted env/config against the app's compose env schema.
+- [ ] Tests + API_DOCUMENTATION.md + API_CHANGELOG.md.
+
+### Increment 4 — Operator reconcile
+- [ ] `lnvps_operator/src/app_deployments.rs`: parse compose YAML + deployment config →
+      Namespace + Deployment + Service + Ingress + PVC + Secret + NetworkPolicy + ResourceQuota,
+      locked-down securityContext; status write-back to DB. Wire into the reconcile loop.
+
+### Increment 5 — Seed launch apps
+- [ ] Seed Nostr relay + Blossom apps (compose YAML) via migration or admin seed.
+- [ ] Integration/e2e coverage where feasible.
+
+## Compose port → k8s mapping (increment 4)
+
+Ingress is opt-in per port. Every declared port becomes a ClusterIP Service port;
+external exposure is driven by an explicit `expose` field:
+
+```yaml
+services:
+  relay:
+    image: ghcr.io/hoytech/strfry:latest
+    ports:
+      - { name: ws, container: 7777, protocol: http, expose: ingress, path: / }
+```
+
+| `expose` | k8s objects | Host/TLS | Notes |
+|---|---|---|---|
+| `none` (default) | ClusterIP Service only | no | internal/sidecar/DB |
+| `ingress` | Service + nginx Ingress + cert-manager TLS | yes (`name.apps.lnvps.tld`) | **http only** (WS rides http → wss/relay/blossom). Operator rejects `ingress` on tcp/udp. |
+| `tcp`/`udp` | Service via ingress-controller TCP/UDP ConfigMap (or NodePort) | no (L4) | follow-up; not in MVP |
+
+- MVP supports `none` + `ingress` only (both launch apps are http ingress). `tcp`/`udp` later.
+- `app_deployment.hostname` is `Option` precisely because apps without an `ingress` port
+  have no public HTTP host — no schema change needed for ingress-less apps.
+
+## Notes
+
+- Deployment `config` stored encrypted (EncryptedString over JSON) so secret env values are
+  protected at rest.
+- Keep resource sizing in the app's compose for now (flat per-catalog pricing); per-deployment
+  resource overrides can come later.


### PR DESCRIPTION
First increment of the managed **App Deployments** epic (see `work/app-deployments.md`): predefined apps (Nostr relay, Blossom, …) run on shared Kubernetes infra — no per-user VMs, no IP-space usage. This PR is the **DB layer only** (no API/operator yet).

## Design (agreed)
- **Billing:** reuse the subscription engine — `SubscriptionType::App = 4`; deployments link via `subscription_line_item_id` like VMs.
- **Catalog:** each app is a **docker-compose-style YAML** blob (image/ports/env/volumes). The UI builds forms → YAML; the operator will map YAML → k8s.
- **Placement:** deployments target an `app_cluster`, which references a neutral **`region`** (location + billing company) — decoupled from VM infra (see the `vm_host_region → region` rename in #213). The in-cluster operator is keyed by `cluster_id`; **no kube credentials in the DB**.
- **Isolation:** namespace per deployment (enforced later by the operator).

## This PR
- Migration adds `app`, `app_cluster`, `app_deployment` (cluster FK → `region`).
- `SubscriptionType::App` + `ApiSubscriptionLineItemResource::App`.
- Model structs + status/desired-state enums; `config` stored as an encrypted JSON blob (`EncryptedString`).
- DB trait methods + mysql + MockDb impls.
- Unit tests: catalog / cluster / deployment CRUD (per-user vs operator listing, line-item resolution, status write-back, soft delete).

## Next increments
2) admin catalog API · 3) customer API (order → subscription/invoice) · 4) operator reconcile (Deployment/Service/Ingress/PVC/Secret, namespace + securityContext) · 5) seed relay + Blossom.