### PR TITLE
feat(admin): paginate/filter app listings, add deployment delete + purge

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -781,7 +781,18 @@ DELETE /api/admin/v1/subscriptions/{id}
 
 Required Permission: `subscriptions::delete`
 
-**Note:** Cannot delete subscriptions with paid payments. Returns error if paid payments exist.
+Request body (optional):
+
+```json
+{
+  "purge": false
+  // Optional (default false). Permanently remove the subscription along with
+  // its line items and payment history, bypassing the paid-payments guard.
+  // super_admin only.
+}
+```
+
+**Note:** Without `purge`, a subscription with paid payments cannot be deleted — the request returns an error naming the paid-payment count. `purge: true` requires the `super_admin` role (`403` otherwise, checked before the lookup) and cascades line items and payments. It is refused while a VM or app deployment still references one of the subscription's line items — delete those resources first.
 
 Response:
 
@@ -3619,7 +3630,18 @@ GET /api/admin/v1/apps
 GET /api/admin/v1/apps/{id}
 ```
 
-Required Permission: `app::view`. Returns `AdminAppInfo` object(s):
+Required Permission: `app::view`. The list returns the standard paginated envelope (`{ data, total, limit, offset }`); the single `GET` returns `{ data }`. Query parameters on the list (all optional, combined with AND):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | int | Page size (default `50`, max `100`) |
+| `offset` | int | Rows to skip (default `0`) |
+| `enabled` | bool | Only catalog-enabled (`true`) or disabled (`false`) apps; omit for all |
+| `search` | string | Case-insensitive substring match on `name`, `display_name`, `description` |
+
+Ordered `id DESC`. `app` has no soft-delete, so there is no `include_deleted` here — `enabled` is the only visibility filter.
+
+`AdminAppInfo` object(s):
 
 ```json
 {
@@ -3695,9 +3717,10 @@ Required Permission: `app::delete`. Rejected while the app still has deployments
 #### App Deployments
 
 ```
-GET   /api/admin/v1/app-deployments
-GET   /api/admin/v1/app-deployments/{id}
-PATCH /api/admin/v1/app-deployments/{id}
+GET    /api/admin/v1/app-deployments
+GET    /api/admin/v1/app-deployments/{id}
+PATCH  /api/admin/v1/app-deployments/{id}
+DELETE /api/admin/v1/app-deployments/{id}
 ```
 
 These use the dedicated **`app_deployment`** RBAC resource (distinct from the catalog `app` resource). `AdminAppDeploymentInfo`:
@@ -3718,13 +3741,29 @@ These use the dedicated **`app_deployment`** RBAC resource (distinct from the ca
   "status": "running",
   "status_message": null,
   "config": { "relay_name": "My relay" },
-  "created": "2026-07-25T10:00:00Z"
+  "created": "2026-07-25T10:00:00Z",
+  "deleted": false
 }
 ```
 
 `resource_multiplier` is the deployment's size as a multiple of the catalog app's base footprint and price (`1` = base). The customer raises it via `POST /api/v1/app-deployments/{id}/upgrade`, which is applied only once the prorated upgrade payment settles. It is read-only here — the admin `PATCH` does not accept it, because changing it without a payment would desynchronise the billed price from the provisioned size.
 
-**List** — `GET /api/admin/v1/app-deployments`. Required Permission: `app_deployment::view`. Lists every non-deleted app deployment across all users and clusters, for oversight/support. Excludes the per-deployment `config` (omitted).
+**List** — `GET /api/admin/v1/app-deployments`. Required Permission: `app_deployment::view`. Lists app deployments across all users and clusters, for oversight/support. Excludes the per-deployment `config` (omitted). Returns the standard paginated envelope (`{ data, total, limit, offset }`), ordered `id DESC`. Query parameters (all optional, combined with AND):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | int | Page size (default `50`, max `100`) |
+| `offset` | int | Rows to skip (default `0`) |
+| `user_id` | int | Only this customer's deployments |
+| `app_id` | int | Only deployments of this catalog app |
+| `cluster_id` | int | Only deployments on this cluster |
+| `region_id` | int | Only deployments on any cluster in this region |
+| `status` | string | Observed status: `pending`, `running`, `stopped`, `error`, `deleting` |
+| `desired_state` | string | Desired run state: `running`, `stopped` |
+| `search` | string | Case-insensitive substring match on `name`, `hostname`, `custom_domain` |
+| `include_deleted` | bool | Include soft-deleted deployments (default `false`) |
+
+Deletion is a soft delete, so `include_deleted=true` is the only way to inspect a torn-down deployment or confirm the teardown happened. Rows returned that way carry `"deleted": true`.
 
 **Get** — `GET /api/admin/v1/app-deployments/{id}`. Required Permission: `app_deployment::view`. Returns a single deployment **including its decrypted `config`** map (which may hold secret values — admin-only). `404` if not found.
 
@@ -3740,6 +3779,24 @@ These use the dedicated **`app_deployment`** RBAC resource (distinct from the ca
 
 Returns the updated `AdminAppDeploymentInfo` (including decrypted `config`). `400` for an invalid `name`, a name already in use on the cluster, an invalid `custom_domain`, or missing-required/unknown `config` fields; `404` if not found.
 
+**Delete** — `DELETE /api/admin/v1/app-deployments/{id}`. Required Permission: `app_deployment::delete`. The admin equivalent of the customer delete: the subscription is deactivated (billing and auto-renewal off) and the deployment soft-deleted, and the operator tears down the namespace and its volumes on its next reconcile. Request body (optional):
+
+```json
+{
+  "purge": false
+  // Optional (default false). Permanently remove the deployment row along with
+  // its subscription, line items and payment history. super_admin only.
+}
+```
+
+- A deployment whose **first payment was never confirmed** carries no billing history and is removed entirely by a plain delete — the same rule VMs use. `purge` is only needed for a deployment that has been paid.
+- `purge: true` requires the `super_admin` role and is rejected `403` for everyone else. The check runs **before** the lookup, so an unknown id still returns `403`.
+- An already soft-deleted deployment can still be purged; a plain delete of one returns `409`.
+- A deployment normally owns its subscription outright. In the rare case that the subscription also bills another resource, the billing rows are kept and only the deployment row is removed.
+- Purging does not orphan Kubernetes resources: the operator garbage-collects any `app-{id}` namespace whose deployment is absent from its active set, and a purged row is absent exactly like a soft-deleted one.
+
+Returns `{ "data": true }`. `404` if not found.
+
 #### App Clusters
 
 ```
@@ -3750,7 +3807,19 @@ PATCH  /api/admin/v1/app_clusters/{id}
 DELETE /api/admin/v1/app_clusters/{id}
 ```
 
-Required Permissions: `app::view` / `app::create` / `app::update` / `app::delete`. `AdminAppClusterInfo` / create body:
+Required Permissions: `app::view` / `app::create` / `app::update` / `app::delete`. The list returns the standard paginated envelope (`{ data, total, limit, offset }`), ordered `id DESC`. Query parameters on the list (all optional, combined with AND):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | int | Page size (default `50`, max `100`) |
+| `offset` | int | Rows to skip (default `0`) |
+| `enabled` | bool | Only clusters accepting new deployments (`true`) or not (`false`) |
+| `region_id` | int | Only clusters in this region |
+| `search` | string | Case-insensitive substring match on `name`, `ingress_domain` |
+
+`app_cluster` has no soft-delete, so there is no `include_deleted` here.
+
+`AdminAppClusterInfo` / create body:
 
 ```json
 {

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -22,9 +22,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Admin app listings are paginated and filterable** (issue #235) — **breaking response-shape change for admin clients.** `GET /api/admin/v1/apps`, `GET /api/admin/v1/app_clusters` and `GET /api/admin/v1/app-deployments` previously returned every row as a bare `{ "data": [...] }` with no query parameters at all. They now accept `limit`/`offset` (default 50, max 100) and return the standard `ApiPaginatedData` envelope (`{ data, total, limit, offset }`) used by every other admin list endpoint, so the admin dashboard's shared paginated table can drive them and report a total. Results are ordered `id DESC`.
+
+  Filters are pushed down into SQL rather than applied in the handler. Deployments accept `user_id`, `app_id`, `cluster_id`, `region_id` (matches any cluster in the region), `status`, `desired_state`, `search` (substring on `name`/`hostname`/`custom_domain`) and `include_deleted`; apps accept `enabled` and `search` (`name`/`display_name`/`description`); clusters accept `enabled`, `region_id` and `search` (`name`/`ingress_domain`). All combine with AND.
+
+  Because deployment deletion is a soft delete, a deleted deployment was previously invisible to admins entirely — `include_deleted=true` (default `false`) is now the way to inspect a customer's torn-down deployment or confirm a teardown happened, and `AdminAppDeploymentInfo` gains a `deleted` boolean. `app` and `app_cluster` have no soft-delete, so `include_deleted` does not apply to those two — `enabled` is their only visibility filter.
+
 - **App catalog is now public** (issue #227) — `GET /api/v1/apps`, `GET /api/v1/apps/{id}` and `GET /api/v1/apps/{id}/regions` no longer require `Nip98Auth`, mirroring `GET /api/v1/vm/templates`. The catalog is a shopping/marketing surface, so anonymous visitors and SSR homepages can browse offered apps (and per-region availability) without logging in. All user-owned deployment endpoints (`/api/v1/app-deployments...`) remain authenticated.
 
 ### Added
+
+- **Admin delete & purge for app deployments and subscriptions** (issue #234) — there was previously no way for an admin to remove an app deployment at all, and no way to remove a subscription that had ever been paid, so test/demo data and orphaned billing rows accumulated permanently.
+
+  New `DELETE /api/admin/v1/app-deployments/{id}` (`app_deployment::delete`) is the admin equivalent of the customer delete: it deactivates billing and soft-deletes the deployment, and the operator tears down the namespace and its volumes on the next reconcile. Following the VM rule, a deployment whose **first payment was never confirmed** carries no billing history and is removed entirely instead. An optional `{ "purge": true }` body hard-deletes the `app_deployment` row together with its `subscription`, `subscription_line_item` and payment rows in one transaction; it requires the `super_admin` role (`403` for everyone else, checked before the lookup, exactly like the VM purge). An already soft-deleted deployment can still be purged; a plain delete of one returns `409`. Purging does not orphan Kubernetes resources — the operator garbage-collects any `app-{id}` namespace whose deployment is absent from its active set, and a purged row is absent exactly like a soft-deleted one.
+
+  `DELETE /api/admin/v1/subscriptions/{id}` gains the same optional `{ "purge": true }` body, again `super_admin`-only: it bypasses the "N paid payments exist" guard and cascades line items and payments. It is refused while a VM or app deployment still references one of the subscription's line items — those resources must be deleted first. Regular deletes keep today's guard and behaviour unchanged.
+
+  No migration is needed: the `app_deployment` permission set (including `delete`) was already seeded for `super_admin`.
 
 - **Managed app deployments — resource upgrades** — a deployment now carries a `resource_multiplier`: its size as a multiple of the catalog app's base footprint *and* price (`1` = the base app, which is what every existing deployment is). The operator multiplies every container's CPU/memory limits and every PVC's size by it, cluster capacity accounting counts the multiplied footprint, and the subscription line item is priced at `app.amount x resource_multiplier`.
 

--- a/lnvps_api_admin/src/admin/apps.rs
+++ b/lnvps_api_admin/src/admin/apps.rs
@@ -5,11 +5,15 @@ use crate::admin::model::{
     AdminCreateAppRequest, AdminUpdateAppClusterRequest, AdminUpdateAppDeploymentRequest,
     AdminUpdateAppRequest,
 };
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
-use lnvps_api_common::{ApiData, ApiResult};
-use lnvps_db::{AdminAction, AdminResource, App, AppCluster};
+use lnvps_api_common::{ApiData, ApiPaginatedData, ApiPaginatedResult, ApiResult, PageQuery};
+use lnvps_db::{
+    AdminAction, AdminResource, App, AppCluster, AppDeploymentDesiredState, AppDeploymentFilter,
+    AppDeploymentStatus,
+};
+use serde::Deserialize;
 
 pub fn router() -> Router<RouterState> {
     Router::new()
@@ -29,7 +33,9 @@ pub fn router() -> Router<RouterState> {
         )
         .route(
             "/api/admin/v1/app-deployments/{id}",
-            get(admin_get_app_deployment).patch(admin_update_app_deployment),
+            get(admin_get_app_deployment)
+                .patch(admin_update_app_deployment)
+                .delete(admin_delete_app_deployment),
         )
         .route(
             "/api/admin/v1/app_clusters",
@@ -107,13 +113,39 @@ fn compose_footprint(
         .map_err(|e| lnvps_api_common::ApiError::new(format!("invalid compose resources: {e}")))
 }
 
+/// Query parameters for the catalog app listing. `app` has no soft-delete, so
+/// there is no `include_deleted` here — `enabled` is the only visibility filter.
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct AppQuery {
+    #[serde(flatten)]
+    page: PageQuery,
+    /// Filter by catalog-enabled flag; omit for all.
+    enabled: Option<bool>,
+    /// Case-insensitive substring match against name, display_name, description.
+    search: Option<String>,
+}
+
 async fn admin_list_apps(
     auth: AdminAuth,
     State(this): State<RouterState>,
-) -> ApiResult<Vec<AdminAppInfo>> {
+    Query(params): Query<AppQuery>,
+) -> ApiPaginatedResult<AdminAppInfo> {
     auth.require_permission(AdminResource::App, AdminAction::View)?;
-    let apps = this.db.list_apps(false).await?;
-    ApiData::ok(apps.into_iter().map(Into::into).collect())
+
+    let limit = params.page.limit.unwrap_or(50).min(100);
+    let offset = params.page.offset.unwrap_or(0);
+
+    let (apps, total) = this
+        .db
+        .admin_list_apps_filtered(limit, offset, params.enabled, params.search.as_deref())
+        .await?;
+    ApiPaginatedData::ok(
+        apps.into_iter().map(Into::into).collect(),
+        total,
+        limit,
+        offset,
+    )
 }
 
 async fn admin_get_app(
@@ -242,15 +274,65 @@ async fn admin_delete_app(
 
 // ----- App deployments -----
 
-/// List every (non-deleted) app deployment across all users and clusters, for
-/// admin oversight and support. Excludes the encrypted per-deployment config.
+/// Query parameters for the deployment listing. All filters are optional and
+/// combine with AND.
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct AppDeploymentQuery {
+    #[serde(flatten)]
+    page: PageQuery,
+    #[serde(deserialize_with = "lnvps_api_common::deserialize_from_str_optional")]
+    user_id: Option<u64>,
+    #[serde(deserialize_with = "lnvps_api_common::deserialize_from_str_optional")]
+    app_id: Option<u64>,
+    #[serde(deserialize_with = "lnvps_api_common::deserialize_from_str_optional")]
+    cluster_id: Option<u64>,
+    /// Matches deployments on any cluster in this region.
+    #[serde(deserialize_with = "lnvps_api_common::deserialize_from_str_optional")]
+    region_id: Option<u64>,
+    /// Observed status: `pending`, `running`, `stopped`, `error`, `deleting`.
+    status: Option<AppDeploymentStatus>,
+    /// Desired run state: `running` or `stopped`.
+    desired_state: Option<AppDeploymentDesiredState>,
+    /// Case-insensitive substring match against name, hostname, custom_domain.
+    search: Option<String>,
+    /// Include soft-deleted deployments (default `false`). Deletion is a soft
+    /// delete, so this is the only way to inspect a torn-down deployment.
+    include_deleted: bool,
+}
+
+/// List app deployments across all users and clusters, for admin oversight and
+/// support. Excludes the encrypted per-deployment config.
 async fn admin_list_app_deployments(
     auth: AdminAuth,
     State(this): State<RouterState>,
-) -> ApiResult<Vec<AdminAppDeploymentInfo>> {
+    Query(params): Query<AppDeploymentQuery>,
+) -> ApiPaginatedResult<AdminAppDeploymentInfo> {
     auth.require_permission(AdminResource::AppDeployment, AdminAction::View)?;
-    let deployments = this.db.list_all_app_deployments().await?;
-    ApiData::ok(deployments.into_iter().map(Into::into).collect())
+
+    let limit = params.page.limit.unwrap_or(50).min(100);
+    let offset = params.page.offset.unwrap_or(0);
+
+    let filter = AppDeploymentFilter {
+        user_id: params.user_id,
+        app_id: params.app_id,
+        cluster_id: params.cluster_id,
+        region_id: params.region_id,
+        status: params.status,
+        desired_state: params.desired_state,
+        search: params.search,
+        include_deleted: params.include_deleted,
+    };
+    let (deployments, total) = this
+        .db
+        .admin_list_app_deployments_filtered(limit, offset, &filter)
+        .await?;
+    ApiPaginatedData::ok(
+        deployments.into_iter().map(Into::into).collect(),
+        total,
+        limit,
+        offset,
+    )
 }
 
 /// Decrypt and parse a deployment's stored config JSON into a flat map.
@@ -337,15 +419,116 @@ async fn admin_update_app_deployment(
     ApiData::ok(info)
 }
 
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct AdminDeleteAppDeploymentRequest {
+    /// Permanently purge the deployment and all of its billing records
+    /// (subscription, line items and payments) from the database, even if it
+    /// has payment history. Requires the `super_admin` role. Never-paid
+    /// deployments are purged regardless of this flag.
+    purge: Option<bool>,
+}
+
+/// Delete an app deployment (`app_deployment::delete`).
+///
+/// The admin equivalent of the customer delete: billing is deactivated and the
+/// row soft-deleted, and the operator tears the namespace and its volumes down
+/// on its next reconcile. Teardown is driven by the deployment's absence from
+/// the operator's active set, so a purged row is collected exactly like a
+/// soft-deleted one — a purge does not orphan Kubernetes resources.
+async fn admin_delete_app_deployment(
+    auth: AdminAuth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+    body: Option<Json<AdminDeleteAppDeploymentRequest>>,
+) -> ApiResult<bool> {
+    auth.require_permission(AdminResource::AppDeployment, AdminAction::Delete)?;
+
+    // Purging a deployment with payment history is destructive and
+    // irreversible, so it is restricted to super-admins. Authorize before
+    // looking the deployment up, matching the VM purge.
+    let purge = body.and_then(|b| b.purge).unwrap_or(false);
+    if purge && !auth.is_super_admin(&this.db).await? {
+        return Err(lnvps_api_common::ApiError::forbidden(
+            "Only super admins can permanently purge an app deployment",
+        ));
+    }
+
+    let deployment = this.db.get_app_deployment(id).await?;
+
+    // An already-deleted deployment can still be purged (that is the point of a
+    // purge). Only reject a plain delete of an already-deleted deployment.
+    if deployment.deleted && !purge {
+        return Err(lnvps_api_common::ApiError::conflict(
+            "Deployment is already deleted",
+        ));
+    }
+
+    // A deployment whose first payment was never confirmed carries no billing
+    // history, so it is removed entirely — the same rule VMs use.
+    let subscription = this
+        .db
+        .get_subscription_by_line_item_id(deployment.subscription_line_item_id)
+        .await;
+    let ever_paid = subscription.as_ref().map(|s| s.is_setup).unwrap_or(false);
+
+    if purge || !ever_paid {
+        this.db.hard_delete_app_deployment(id).await?;
+    } else {
+        // Stop billing, then soft-delete.
+        if let Ok(mut sub) = subscription {
+            sub.is_active = false;
+            sub.auto_renewal_enabled = false;
+            this.db.update_subscription(&sub).await?;
+        }
+        this.db.delete_app_deployment(id).await?;
+    }
+    ApiData::ok(true)
+}
+
 // ----- App clusters -----
+
+/// Query parameters for the cluster listing. `app_cluster` has no soft-delete,
+/// so `enabled` is the only visibility filter.
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct AppClusterQuery {
+    #[serde(flatten)]
+    page: PageQuery,
+    /// Filter by accepting-new-deployments flag; omit for all.
+    enabled: Option<bool>,
+    #[serde(deserialize_with = "lnvps_api_common::deserialize_from_str_optional")]
+    region_id: Option<u64>,
+    /// Case-insensitive substring match against name and ingress_domain.
+    search: Option<String>,
+}
 
 async fn admin_list_app_clusters(
     auth: AdminAuth,
     State(this): State<RouterState>,
-) -> ApiResult<Vec<AdminAppClusterInfo>> {
+    Query(params): Query<AppClusterQuery>,
+) -> ApiPaginatedResult<AdminAppClusterInfo> {
     auth.require_permission(AdminResource::App, AdminAction::View)?;
-    let clusters = this.db.list_app_clusters(false).await?;
-    ApiData::ok(clusters.into_iter().map(Into::into).collect())
+
+    let limit = params.page.limit.unwrap_or(50).min(100);
+    let offset = params.page.offset.unwrap_or(0);
+
+    let (clusters, total) = this
+        .db
+        .admin_list_app_clusters_filtered(
+            limit,
+            offset,
+            params.enabled,
+            params.region_id,
+            params.search.as_deref(),
+        )
+        .await?;
+    ApiPaginatedData::ok(
+        clusters.into_iter().map(Into::into).collect(),
+        total,
+        limit,
+        offset,
+    )
 }
 
 async fn admin_get_app_cluster(

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -4619,6 +4619,10 @@ pub struct AdminAppDeploymentInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<std::collections::BTreeMap<String, String>>,
     pub created: DateTime<Utc>,
+    /// Soft-deleted: the operator has torn the workload down and the row is
+    /// retained only for accounting. Only ever `true` in listings requested
+    /// with `include_deleted=true`.
+    pub deleted: bool,
 }
 
 impl From<lnvps_db::AppDeployment> for AdminAppDeploymentInfo {
@@ -4639,6 +4643,7 @@ impl From<lnvps_db::AppDeployment> for AdminAppDeploymentInfo {
             status_message: d.status_message,
             config: None, // filled in by the single-GET handler (decrypted)
             created: d.created,
+            deleted: d.deleted,
         }
     }
 }

--- a/lnvps_api_admin/src/admin/subscriptions.rs
+++ b/lnvps_api_admin/src/admin/subscriptions.rs
@@ -275,16 +275,47 @@ async fn admin_update_subscription(
     ApiData::ok(info)
 }
 
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct AdminDeleteSubscriptionRequest {
+    /// Permanently purge the subscription along with its line items and payment
+    /// history, bypassing the paid-payments guard. Requires the `super_admin`
+    /// role. Without it a subscription that was ever paid can never be removed
+    /// (regtest/e2e and demo data included).
+    purge: Option<bool>,
+}
+
 /// Delete subscription
 async fn admin_delete_subscription(
     auth: AdminAuth,
     State(this): State<RouterState>,
     Path(id): Path<u64>,
+    body: Option<Json<AdminDeleteSubscriptionRequest>>,
 ) -> ApiResult<serde_json::Value> {
     auth.require_permission(AdminResource::Subscriptions, AdminAction::Delete)?;
 
+    // Purging payment history is destructive and irreversible, so it is
+    // restricted to super-admins. Authorize before the lookup, matching the VM
+    // and app-deployment purges.
+    let purge = body.and_then(|b| b.purge).unwrap_or(false);
+    if purge && !auth.is_super_admin(&this.db).await? {
+        return Err(ApiError::forbidden(
+            "Only super admins can permanently purge a subscription",
+        ));
+    }
+
     // Check if subscription exists
     let _subscription = this.db.get_subscription(id).await?;
+
+    if purge {
+        // Cascades line items and payments; refuses while a VM or app
+        // deployment still references one of the line items.
+        this.db.hard_delete_subscription(id).await?;
+        return ApiData::ok(serde_json::json!({
+            "success": true,
+            "message": "Subscription purged successfully"
+        }));
+    }
 
     // Check if subscription has payments
     let payments = this.db.list_subscription_payments(id).await?;
@@ -292,7 +323,7 @@ async fn admin_delete_subscription(
 
     if paid_payment_count > 0 {
         return Err(anyhow::anyhow!(
-            "Cannot delete subscription: {} paid payments exist. Consider deactivating instead.",
+            "Cannot delete subscription: {} paid payments exist. Consider deactivating instead, or purge as a super admin.",
             paid_payment_count
         )
         .into());

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -3,11 +3,11 @@ use anyhow::{Context, anyhow};
 use chrono::{Days, Months, TimeDelta, Utc};
 use lnvps_db::nostr::LNVPSNostrDb;
 use lnvps_db::{
-    AccessPolicy, App, AppCluster, AppDeployment, AppDeploymentDesiredState, AppDeploymentStatus,
-    AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, Company, CpuArch, CpuMfg, DbError,
-    DbResult, DiskInterface, DiskType, DnsServer, DnsServerKind, IntervalType, IpRange,
-    IpRangeAllocationMode, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, NostrDomain,
-    NostrDomainHandle, OsDistribution, PaymentMethod, PaymentMethodConfig, Referral,
+    AccessPolicy, App, AppCluster, AppDeployment, AppDeploymentDesiredState, AppDeploymentFilter,
+    AppDeploymentStatus, AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, Company,
+    CpuArch, CpuMfg, DbError, DbResult, DiskInterface, DiskType, DnsServer, DnsServerKind,
+    IntervalType, IpRange, IpRangeAllocationMode, IpRangeSubscription, IpSpacePricing, LNVpsDbBase,
+    NostrDomain, NostrDomainHandle, OsDistribution, PaymentMethod, PaymentMethodConfig, Referral,
     ReferralCostUsage, ReferralPayout, Region, Router, RouterBgpRoute, RouterBgpSession,
     RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
     SubscriptionPaymentWithCompany, User, UserPaymentMethod, UserSshKey, Vm, VmCostPlan,
@@ -23,6 +23,19 @@ use std::collections::HashMap;
 use std::ops::Add;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+/// Take one page out of an already-filtered and sorted set, returning
+/// `(page, total)` the way the paginated DB queries do. In-memory skip/take is
+/// fine here — the real implementations push `LIMIT`/`OFFSET` into SQL.
+fn paginate<T>(all: Vec<T>, limit: u64, offset: u64) -> (Vec<T>, u64) {
+    let total = all.len() as u64;
+    let page = all
+        .into_iter()
+        .skip(offset as usize)
+        .take(limit as usize)
+        .collect();
+    (page, total)
+}
 
 #[derive(Debug, Clone)]
 pub struct MockDb {
@@ -2155,6 +2168,54 @@ impl LNVpsDbBase for MockDb {
         Ok(())
     }
 
+    async fn hard_delete_subscription(&self, id: u64) -> DbResult<()> {
+        let line_item_ids: Vec<u64> = self
+            .subscription_line_items
+            .lock()
+            .await
+            .values()
+            .filter(|li| li.subscription_id == id)
+            .map(|li| li.id)
+            .collect();
+
+        // Guard: refuse while a VM or app deployment still references a line item.
+        let attached_vms = self
+            .vms
+            .lock()
+            .await
+            .values()
+            .filter(|v| line_item_ids.contains(&v.subscription_line_item_id))
+            .count();
+        if attached_vms > 0 {
+            return Err(DbError::Other(anyhow!(
+                "Cannot purge subscription with {attached_vms} attached VM(s); delete them first"
+            )));
+        }
+        let attached_deployments = self
+            .app_deployments
+            .lock()
+            .await
+            .values()
+            .filter(|d| line_item_ids.contains(&d.subscription_line_item_id))
+            .count();
+        if attached_deployments > 0 {
+            return Err(DbError::Other(anyhow!(
+                "Cannot purge subscription with {attached_deployments} attached app deployment(s); delete them first"
+            )));
+        }
+
+        self.subscription_payments
+            .lock()
+            .await
+            .retain(|p| p.subscription_id != id);
+        self.subscription_line_items
+            .lock()
+            .await
+            .retain(|_, li| li.subscription_id != id);
+        self.subscriptions.lock().await.remove(&id);
+        Ok(())
+    }
+
     async fn get_subscription_base_currency(&self, subscription_id: u64) -> DbResult<String> {
         // Get currency from the subscription itself
         let subscriptions = self.subscriptions.lock().await;
@@ -3139,6 +3200,36 @@ impl LNVpsDbBase for MockDb {
         Ok(out)
     }
 
+    async fn admin_list_apps_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        enabled: Option<bool>,
+        search: Option<&str>,
+    ) -> DbResult<(Vec<App>, u64)> {
+        let search = search
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
+        let apps = self.apps.lock().await;
+        let mut all: Vec<App> = apps
+            .values()
+            .filter(|a| enabled.is_none_or(|e| a.enabled == e))
+            .filter(|a| {
+                search.as_ref().is_none_or(|q| {
+                    a.name.to_lowercase().contains(q)
+                        || a.display_name.to_lowercase().contains(q)
+                        || a.description
+                            .as_ref()
+                            .is_some_and(|d| d.to_lowercase().contains(q))
+                })
+            })
+            .cloned()
+            .collect();
+        all.sort_by(|a, b| b.id.cmp(&a.id));
+        Ok(paginate(all, limit, offset))
+    }
+
     async fn get_app(&self, id: u64) -> DbResult<App> {
         self.apps
             .lock()
@@ -3200,6 +3291,34 @@ impl LNVpsDbBase for MockDb {
         Ok(out)
     }
 
+    async fn admin_list_app_clusters_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        enabled: Option<bool>,
+        region_id: Option<u64>,
+        search: Option<&str>,
+    ) -> DbResult<(Vec<AppCluster>, u64)> {
+        let search = search
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
+        let clusters = self.app_clusters.lock().await;
+        let mut all: Vec<AppCluster> = clusters
+            .values()
+            .filter(|c| enabled.is_none_or(|e| c.enabled == e))
+            .filter(|c| region_id.is_none_or(|r| c.region_id == r))
+            .filter(|c| {
+                search.as_ref().is_none_or(|q| {
+                    c.name.to_lowercase().contains(q) || c.ingress_domain.to_lowercase().contains(q)
+                })
+            })
+            .cloned()
+            .collect();
+        all.sort_by(|a, b| b.id.cmp(&a.id));
+        Ok(paginate(all, limit, offset))
+    }
+
     async fn get_app_cluster(&self, id: u64) -> DbResult<AppCluster> {
         self.app_clusters
             .lock()
@@ -3253,6 +3372,64 @@ impl LNVpsDbBase for MockDb {
         let mut out: Vec<AppDeployment> = d.values().filter(|x| !x.deleted).cloned().collect();
         out.sort_by_key(|x| x.id);
         Ok(out)
+    }
+
+    async fn admin_list_app_deployments_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        filter: &AppDeploymentFilter,
+    ) -> DbResult<(Vec<AppDeployment>, u64)> {
+        // Resolve the region filter to cluster ids first, so the clusters lock
+        // is released before the deployments lock is taken.
+        let region_clusters: Option<Vec<u64>> = match filter.region_id {
+            Some(region_id) => Some(
+                self.app_clusters
+                    .lock()
+                    .await
+                    .values()
+                    .filter(|c| c.region_id == region_id)
+                    .map(|c| c.id)
+                    .collect(),
+            ),
+            None => None,
+        };
+        let search = filter
+            .search
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
+
+        let deployments = self.app_deployments.lock().await;
+        let mut all: Vec<AppDeployment> = deployments
+            .values()
+            .filter(|d| filter.include_deleted || !d.deleted)
+            .filter(|d| filter.user_id.is_none_or(|u| d.user_id == u))
+            .filter(|d| filter.app_id.is_none_or(|a| d.app_id == a))
+            .filter(|d| filter.cluster_id.is_none_or(|c| d.cluster_id == c))
+            .filter(|d| {
+                region_clusters
+                    .as_ref()
+                    .is_none_or(|ids| ids.contains(&d.cluster_id))
+            })
+            .filter(|d| filter.status.is_none_or(|s| d.status == s))
+            .filter(|d| filter.desired_state.is_none_or(|s| d.desired_state == s))
+            .filter(|d| {
+                search.as_ref().is_none_or(|q| {
+                    d.name.to_lowercase().contains(q)
+                        || d.hostname
+                            .as_ref()
+                            .is_some_and(|h| h.to_lowercase().contains(q))
+                        || d.custom_domain
+                            .as_ref()
+                            .is_some_and(|c| c.to_lowercase().contains(q))
+                })
+            })
+            .cloned()
+            .collect();
+        all.sort_by(|a, b| b.id.cmp(&a.id));
+        Ok(paginate(all, limit, offset))
     }
 
     async fn get_app_deployment(&self, id: u64) -> DbResult<AppDeployment> {
@@ -3313,6 +3490,57 @@ impl LNVpsDbBase for MockDb {
         let mut d = self.app_deployments.lock().await;
         if let Some(x) = d.get_mut(&id) {
             x.deleted = true;
+        }
+        Ok(())
+    }
+
+    async fn hard_delete_app_deployment(&self, id: u64) -> DbResult<()> {
+        let Some(deployment) = self.app_deployments.lock().await.remove(&id) else {
+            return Ok(());
+        };
+
+        // Remove the billing records the deployment was attached to.
+        let subscription_id = self
+            .subscription_line_items
+            .lock()
+            .await
+            .get(&deployment.subscription_line_item_id)
+            .map(|li| li.subscription_id);
+        if let Some(subscription_id) = subscription_id {
+            // Keep the billing rows if the subscription still bills something
+            // else (a VM or another deployment).
+            let line_item_ids: Vec<u64> = self
+                .subscription_line_items
+                .lock()
+                .await
+                .values()
+                .filter(|li| li.subscription_id == subscription_id)
+                .map(|li| li.id)
+                .collect();
+            let still_billed = self
+                .vms
+                .lock()
+                .await
+                .values()
+                .any(|v| line_item_ids.contains(&v.subscription_line_item_id))
+                || self
+                    .app_deployments
+                    .lock()
+                    .await
+                    .values()
+                    .any(|d| line_item_ids.contains(&d.subscription_line_item_id));
+
+            if !still_billed {
+                self.subscription_payments
+                    .lock()
+                    .await
+                    .retain(|p| p.subscription_id != subscription_id);
+                self.subscription_line_items
+                    .lock()
+                    .await
+                    .retain(|_, li| li.subscription_id != subscription_id);
+                self.subscriptions.lock().await.remove(&subscription_id);
+            }
         }
         Ok(())
     }
@@ -5999,6 +6227,505 @@ mod tests {
         assert_eq!(db.list_user_app_deployments(1).await.unwrap().len(), 1);
         assert_eq!(db.list_all_app_deployments().await.unwrap().len(), 2);
         assert!(db.get_app_deployment(d1).await.unwrap().deleted);
+    }
+
+    fn mk_cluster(name: &str, region_id: u64) -> AppCluster {
+        AppCluster {
+            id: 0,
+            name: name.to_string(),
+            region_id,
+            ingress_domain: format!("{name}.apps.example.com"),
+            enabled: true,
+            capacity_cpu_milli: 100_000,
+            capacity_memory_bytes: 100u64 * 1024 * 1024 * 1024,
+            capacity_storage_bytes: 1024u64 * 1024 * 1024 * 1024,
+            created: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_admin_list_apps_filtered() {
+        let db = MockDb::default();
+        let relay = db.insert_app(&mk_app("nostr-relay")).await.unwrap();
+        let mut blossom = mk_app("blossom");
+        blossom.enabled = false;
+        blossom.description = Some("media server".to_string());
+        let blossom = db.insert_app(&blossom).await.unwrap();
+        let mailer = db.insert_app(&mk_app("mailer")).await.unwrap();
+
+        // No filters: everything, newest first, with the unfiltered total.
+        let (page, total) = db
+            .admin_list_apps_filtered(50, 0, None, None)
+            .await
+            .unwrap();
+        assert_eq!(total, 3);
+        assert_eq!(
+            page.iter().map(|a| a.id).collect::<Vec<_>>(),
+            vec![mailer, blossom, relay]
+        );
+
+        // enabled filter.
+        let (page, total) = db
+            .admin_list_apps_filtered(50, 0, Some(false), None)
+            .await
+            .unwrap();
+        assert_eq!((page.len(), total), (1, 1));
+        assert_eq!(page[0].id, blossom);
+
+        // search matches name, display_name and description, case-insensitively.
+        let (page, _) = db
+            .admin_list_apps_filtered(50, 0, None, Some("RELAY"))
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 1, "matched by name");
+        let (page, _) = db
+            .admin_list_apps_filtered(50, 0, None, Some("media"))
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, blossom, "matched by description");
+        let (page, _) = db
+            .admin_list_apps_filtered(50, 0, None, Some("nothing-matches"))
+            .await
+            .unwrap();
+        assert!(page.is_empty());
+
+        // A blank search is ignored rather than matching nothing.
+        let (_, total) = db
+            .admin_list_apps_filtered(50, 0, None, Some("   "))
+            .await
+            .unwrap();
+        assert_eq!(total, 3);
+
+        // Pagination: total stays the filtered total, not the page size.
+        let (page, total) = db.admin_list_apps_filtered(2, 2, None, None).await.unwrap();
+        assert_eq!((page.len(), total), (1, 3));
+        assert_eq!(page[0].id, relay);
+    }
+
+    #[tokio::test]
+    async fn test_admin_list_app_clusters_filtered() {
+        let db = MockDb::default();
+        let eu = db.insert_app_cluster(&mk_cluster("eu-1", 1)).await.unwrap();
+        let us = db.insert_app_cluster(&mk_cluster("us-1", 2)).await.unwrap();
+        let mut disabled = mk_cluster("eu-2", 1);
+        disabled.enabled = false;
+        let eu2 = db.insert_app_cluster(&disabled).await.unwrap();
+
+        let (page, total) = db
+            .admin_list_app_clusters_filtered(50, 0, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(total, 3);
+        assert_eq!(page[0].id, eu2, "newest first");
+
+        // enabled + region filters combine with AND.
+        let (page, total) = db
+            .admin_list_app_clusters_filtered(50, 0, Some(true), Some(1), None)
+            .await
+            .unwrap();
+        assert_eq!((page.len(), total), (1, 1));
+        assert_eq!(page[0].id, eu);
+
+        let (page, _) = db
+            .admin_list_app_clusters_filtered(50, 0, None, Some(2), None)
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, us);
+
+        // search matches name and ingress domain.
+        let (page, _) = db
+            .admin_list_app_clusters_filtered(50, 0, None, None, Some("US-1"))
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, us);
+        let (page, _) = db
+            .admin_list_app_clusters_filtered(50, 0, None, None, Some("apps.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 3, "every cluster shares the ingress suffix");
+
+        // Pagination.
+        let (page, total) = db
+            .admin_list_app_clusters_filtered(1, 0, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!((page.len(), total), (1, 3));
+    }
+
+    #[tokio::test]
+    async fn test_admin_list_app_deployments_filtered() {
+        let db = MockDb::default();
+        let relay = db.insert_app(&mk_app("relay")).await.unwrap();
+        let blossom = db.insert_app(&mk_app("blossom")).await.unwrap();
+        let eu = db.insert_app_cluster(&mk_cluster("eu-1", 1)).await.unwrap();
+        let us = db.insert_app_cluster(&mk_cluster("us-1", 2)).await.unwrap();
+
+        let mk_dep = |user: u64, app_id: u64, cluster_id: u64, name: &str| AppDeployment {
+            id: 0,
+            user_id: user,
+            app_id,
+            cluster_id,
+            resource_multiplier: 1,
+            subscription_line_item_id: 0,
+            name: name.to_string(),
+            namespace: format!("app-{name}"),
+            hostname: Some(format!("{name}.apps.example.com")),
+            custom_domain: None,
+            config: None,
+            desired_state: AppDeploymentDesiredState::Running,
+            status: AppDeploymentStatus::Pending,
+            status_message: None,
+            created: Utc::now(),
+            deleted: false,
+        };
+
+        let d1 = db
+            .insert_app_deployment(&mk_dep(1, relay, eu, "alpha"))
+            .await
+            .unwrap();
+        let d2 = db
+            .insert_app_deployment(&mk_dep(2, blossom, us, "beta"))
+            .await
+            .unwrap();
+        let mut third = mk_dep(1, relay, us, "gamma");
+        third.status = AppDeploymentStatus::Error;
+        third.desired_state = AppDeploymentDesiredState::Stopped;
+        third.custom_domain = Some("blog.example.org".to_string());
+        let d3 = db.insert_app_deployment(&third).await.unwrap();
+
+        let all = AppDeploymentFilter::default;
+
+        // Default: all live deployments, newest first.
+        let (page, total) = db
+            .admin_list_app_deployments_filtered(50, 0, &all())
+            .await
+            .unwrap();
+        assert_eq!(total, 3);
+        assert_eq!(
+            page.iter().map(|d| d.id).collect::<Vec<_>>(),
+            vec![d3, d2, d1]
+        );
+
+        // Each filter on its own.
+        let by_user = AppDeploymentFilter {
+            user_id: Some(1),
+            ..all()
+        };
+        let (page, total) = db
+            .admin_list_app_deployments_filtered(50, 0, &by_user)
+            .await
+            .unwrap();
+        assert_eq!((page.len(), total), (2, 2));
+
+        let by_app = AppDeploymentFilter {
+            app_id: Some(blossom),
+            ..all()
+        };
+        let (page, _) = db
+            .admin_list_app_deployments_filtered(50, 0, &by_app)
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, d2);
+
+        let by_cluster = AppDeploymentFilter {
+            cluster_id: Some(eu),
+            ..all()
+        };
+        let (page, _) = db
+            .admin_list_app_deployments_filtered(50, 0, &by_cluster)
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, d1);
+
+        // region resolves through the cluster.
+        let by_region = AppDeploymentFilter {
+            region_id: Some(2),
+            ..all()
+        };
+        let (page, total) = db
+            .admin_list_app_deployments_filtered(50, 0, &by_region)
+            .await
+            .unwrap();
+        assert_eq!(total, 2, "both us-1 deployments");
+        assert!(page.iter().all(|d| d.cluster_id == us));
+
+        let by_status = AppDeploymentFilter {
+            status: Some(AppDeploymentStatus::Error),
+            ..all()
+        };
+        let (page, _) = db
+            .admin_list_app_deployments_filtered(50, 0, &by_status)
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, d3);
+
+        let by_desired = AppDeploymentFilter {
+            desired_state: Some(AppDeploymentDesiredState::Stopped),
+            ..all()
+        };
+        let (page, _) = db
+            .admin_list_app_deployments_filtered(50, 0, &by_desired)
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, d3);
+
+        // search covers name, hostname and custom_domain.
+        for term in ["ALPHA", "alpha.apps.example.com"] {
+            let f = AppDeploymentFilter {
+                search: Some(term.to_string()),
+                ..all()
+            };
+            let (page, _) = db
+                .admin_list_app_deployments_filtered(50, 0, &f)
+                .await
+                .unwrap();
+            assert_eq!(page[0].id, d1, "search term {term}");
+        }
+        let f = AppDeploymentFilter {
+            search: Some("blog.example.org".to_string()),
+            ..all()
+        };
+        let (page, _) = db
+            .admin_list_app_deployments_filtered(50, 0, &f)
+            .await
+            .unwrap();
+        assert_eq!(page[0].id, d3, "matched by custom_domain");
+
+        // Filters combine with AND.
+        let combined = AppDeploymentFilter {
+            user_id: Some(1),
+            cluster_id: Some(us),
+            ..all()
+        };
+        let (page, total) = db
+            .admin_list_app_deployments_filtered(50, 0, &combined)
+            .await
+            .unwrap();
+        assert_eq!((page.len(), total), (1, 1));
+        assert_eq!(page[0].id, d3);
+
+        // Soft-deleted rows are hidden by default and only surface with
+        // include_deleted — the whole point of the flag.
+        db.delete_app_deployment(d1).await.unwrap();
+        let (_, total) = db
+            .admin_list_app_deployments_filtered(50, 0, &all())
+            .await
+            .unwrap();
+        assert_eq!(total, 2);
+        let with_deleted = AppDeploymentFilter {
+            include_deleted: true,
+            ..all()
+        };
+        let (page, total) = db
+            .admin_list_app_deployments_filtered(50, 0, &with_deleted)
+            .await
+            .unwrap();
+        assert_eq!(total, 3);
+        assert!(page.iter().any(|d| d.id == d1 && d.deleted));
+
+        // Pagination.
+        let (page, total) = db
+            .admin_list_app_deployments_filtered(1, 1, &with_deleted)
+            .await
+            .unwrap();
+        assert_eq!((page.len(), total), (1, 3));
+        assert_eq!(page[0].id, d2);
+    }
+
+    /// Seed `subscription` + `subscription_line_item` + one paid payment for an
+    /// app deployment, returning `(subscription_id, line_item_id)`.
+    async fn seed_app_subscription(db: &MockDb, user_id: u64) -> (u64, u64) {
+        let sub_id = db
+            .insert_subscription(&Subscription {
+                id: 0,
+                user_id,
+                company_id: 1,
+                name: "app sub".to_string(),
+                description: None,
+                created: Utc::now(),
+                expires: None,
+                is_active: true,
+                is_setup: true,
+                currency: "EUR".to_string(),
+                interval_amount: 1,
+                interval_type: IntervalType::Month,
+                setup_fee: 0,
+                auto_renewal_enabled: true,
+                external_id: None,
+            })
+            .await
+            .unwrap();
+        let li_id = db
+            .insert_subscription_line_item(&SubscriptionLineItem {
+                id: 0,
+                subscription_id: sub_id,
+                subscription_type: lnvps_db::SubscriptionType::App,
+                name: "app".to_string(),
+                description: None,
+                amount: 1000,
+                setup_amount: 0,
+                configuration: None,
+            })
+            .await
+            .unwrap();
+        let mut payment = make_payment(sub_id, None);
+        payment.user_id = user_id;
+        payment.is_paid = true;
+        db.insert_subscription_payment(&payment).await.unwrap();
+        (sub_id, li_id)
+    }
+
+    #[tokio::test]
+    async fn test_hard_delete_app_deployment() {
+        let db = MockDb::default();
+        // subscription_payment inserts validate the owning user exists.
+        let uid = db.upsert_user(&[7u8; 32]).await.unwrap();
+        let app_id = db.insert_app(&mk_app("relay")).await.unwrap();
+        let cluster_id = db.insert_app_cluster(&mk_cluster("eu-1", 1)).await.unwrap();
+        let (sub_id, li_id) = seed_app_subscription(&db, uid).await;
+
+        let dep_id = db
+            .insert_app_deployment(&AppDeployment {
+                id: 0,
+                user_id: uid,
+                app_id,
+                cluster_id,
+                resource_multiplier: 1,
+                subscription_line_item_id: li_id,
+                name: "alpha".to_string(),
+                namespace: "app-alpha".to_string(),
+                hostname: None,
+                custom_domain: None,
+                config: None,
+                desired_state: AppDeploymentDesiredState::Running,
+                status: AppDeploymentStatus::Running,
+                status_message: None,
+                created: Utc::now(),
+                deleted: false,
+            })
+            .await
+            .unwrap();
+
+        db.hard_delete_app_deployment(dep_id).await.unwrap();
+
+        // The row is gone, not soft-deleted, and takes its billing with it.
+        assert!(db.get_app_deployment(dep_id).await.is_err());
+        assert!(db.get_subscription(sub_id).await.is_err());
+        assert!(db.get_subscription_line_item(li_id).await.is_err());
+        assert!(
+            db.list_subscription_payments(sub_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // Purging an unknown id is a no-op rather than an error, so a repeated
+        // purge does not 500.
+        db.hard_delete_app_deployment(dep_id).await.unwrap();
+
+        // A subscription that still bills something else keeps its billing
+        // rows. The default MockDb has subscription 1 with Vps line item 1,
+        // which mock_vm points at; hang a deployment off the same line item.
+        db.insert_vm(&Vm {
+            ssh_key_id: None,
+            ..MockDb::mock_vm()
+        })
+        .await
+        .unwrap();
+        let shared_sub = db.get_subscription_by_line_item_id(1).await.unwrap().id;
+        let shared_dep = db
+            .insert_app_deployment(&AppDeployment {
+                id: 0,
+                user_id: uid,
+                app_id,
+                cluster_id,
+                resource_multiplier: 1,
+                subscription_line_item_id: 1,
+                name: "shared".to_string(),
+                namespace: "app-shared".to_string(),
+                hostname: None,
+                custom_domain: None,
+                config: None,
+                desired_state: AppDeploymentDesiredState::Running,
+                status: AppDeploymentStatus::Running,
+                status_message: None,
+                created: Utc::now(),
+                deleted: false,
+            })
+            .await
+            .unwrap();
+
+        db.hard_delete_app_deployment(shared_dep).await.unwrap();
+        assert!(db.get_app_deployment(shared_dep).await.is_err());
+        assert!(
+            db.get_subscription(shared_sub).await.is_ok(),
+            "the VM's billing survives the deployment purge"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hard_delete_subscription() {
+        let db = MockDb::default();
+        let uid = db.upsert_user(&[7u8; 32]).await.unwrap();
+
+        // Refuses while a VM still references a line item. The default MockDb
+        // has subscription 1 with Vps line item 1, which mock_vm points at.
+        db.insert_vm(&Vm {
+            ssh_key_id: None,
+            ..MockDb::mock_vm()
+        })
+        .await
+        .unwrap();
+        let vm_sub_id = db.get_subscription_by_line_item_id(1).await.unwrap().id;
+        let err = db.hard_delete_subscription(vm_sub_id).await.unwrap_err();
+        assert!(
+            err.to_string().contains("VM"),
+            "error names the blocking resource: {err}"
+        );
+
+        // Same for an app deployment.
+        let (sub_id, li_id) = seed_app_subscription(&db, uid).await;
+        let app_id = db.insert_app(&mk_app("relay")).await.unwrap();
+        let cluster_id = db.insert_app_cluster(&mk_cluster("eu-1", 1)).await.unwrap();
+        let dep_id = db
+            .insert_app_deployment(&AppDeployment {
+                id: 0,
+                user_id: uid,
+                app_id,
+                cluster_id,
+                resource_multiplier: 1,
+                subscription_line_item_id: li_id,
+                name: "alpha".to_string(),
+                namespace: "app-alpha".to_string(),
+                hostname: None,
+                custom_domain: None,
+                config: None,
+                desired_state: AppDeploymentDesiredState::Running,
+                status: AppDeploymentStatus::Running,
+                status_message: None,
+                created: Utc::now(),
+                deleted: false,
+            })
+            .await
+            .unwrap();
+        let err = db.hard_delete_subscription(sub_id).await.unwrap_err();
+        assert!(
+            err.to_string().contains("app deployment"),
+            "error names the blocking resource: {err}"
+        );
+
+        // With nothing attached the purge succeeds, cascading the line items and
+        // paid payments that `delete_subscription` would have left behind.
+        db.app_deployments.lock().await.remove(&dep_id);
+        db.hard_delete_subscription(sub_id).await.unwrap();
+        assert!(db.get_subscription(sub_id).await.is_err());
+        assert!(db.get_subscription_line_item(li_id).await.is_err());
+        assert!(
+            db.list_subscription_payments(sub_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -720,6 +720,14 @@ pub trait LNVpsDbBase: Send + Sync {
     ) -> DbResult<(u64, Vec<u64>)>;
     async fn update_subscription(&self, subscription: &Subscription) -> DbResult<()>;
     async fn delete_subscription(&self, id: u64) -> DbResult<()>;
+    /// Permanently remove a subscription along with its line items and payment
+    /// history, in one transaction. Unlike [`Self::delete_subscription`] this
+    /// clears `subscription_payment` rows (which have no ON DELETE CASCADE), so
+    /// a subscription that has been paid can be removed.
+    ///
+    /// Refuses while a VM or app deployment still references one of the
+    /// subscription's line items — those resources must be deleted first.
+    async fn hard_delete_subscription(&self, id: u64) -> DbResult<()>;
     async fn get_subscription_base_currency(&self, subscription_id: u64) -> DbResult<String>;
 
     // Subscription Line Items
@@ -990,6 +998,19 @@ pub trait LNVpsDbBase: Send + Sync {
     /// List catalog apps. When `enabled_only` is set, only apps offered in the
     /// catalog are returned (for the customer-facing listing).
     async fn list_apps(&self, enabled_only: bool) -> DbResult<Vec<App>>;
+    /// Admin listing of catalog apps with database-level pagination. Filters are
+    /// optional and combine with AND: `enabled` filters on the catalog flag,
+    /// `search` is a case-insensitive substring match against name, display name
+    /// and description. Returns `(rows, total_count)` where the count reflects
+    /// the filtered set. `app` has no soft-delete, so there is nothing to
+    /// include or exclude beyond `enabled`.
+    async fn admin_list_apps_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        enabled: Option<bool>,
+        search: Option<&str>,
+    ) -> DbResult<(Vec<App>, u64)>;
     async fn get_app(&self, id: u64) -> DbResult<App>;
     async fn get_app_by_name(&self, name: &str) -> DbResult<App>;
     async fn insert_app(&self, app: &App) -> DbResult<u64>;
@@ -1001,6 +1022,19 @@ pub trait LNVpsDbBase: Send + Sync {
     /// List app clusters. When `enabled_only` is set, only clusters that accept
     /// new deployments are returned.
     async fn list_app_clusters(&self, enabled_only: bool) -> DbResult<Vec<AppCluster>>;
+    /// Admin listing of app clusters with database-level pagination. Filters are
+    /// optional and combine with AND: `enabled` filters on the accepting-new-
+    /// deployments flag, `region_id` restricts to one region, `search` is a
+    /// case-insensitive substring match against name and ingress domain. Returns
+    /// `(rows, total_count)`. `app_cluster` has no soft-delete.
+    async fn admin_list_app_clusters_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        enabled: Option<bool>,
+        region_id: Option<u64>,
+        search: Option<&str>,
+    ) -> DbResult<(Vec<AppCluster>, u64)>;
     async fn get_app_cluster(&self, id: u64) -> DbResult<AppCluster>;
     async fn insert_app_cluster(&self, cluster: &AppCluster) -> DbResult<u64>;
     async fn update_app_cluster(&self, cluster: &AppCluster) -> DbResult<()>;
@@ -1012,6 +1046,15 @@ pub trait LNVpsDbBase: Send + Sync {
     async fn list_user_app_deployments(&self, user_id: u64) -> DbResult<Vec<AppDeployment>>;
     /// List every non-deleted app deployment (used by the operator to reconcile).
     async fn list_all_app_deployments(&self) -> DbResult<Vec<AppDeployment>>;
+    /// Admin listing of app deployments with database-level pagination and
+    /// filtering (see [`AppDeploymentFilter`]). Returns `(rows, total_count)`
+    /// where the count reflects the filtered set.
+    async fn admin_list_app_deployments_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        filter: &AppDeploymentFilter,
+    ) -> DbResult<(Vec<AppDeployment>, u64)>;
     async fn get_app_deployment(&self, id: u64) -> DbResult<AppDeployment>;
     /// Resolve the deployment billed by a given subscription line item.
     async fn get_app_deployment_by_line_item(&self, line_item_id: u64) -> DbResult<AppDeployment>;
@@ -1028,6 +1071,14 @@ pub trait LNVpsDbBase: Send + Sync {
     /// Soft-delete a deployment (sets `deleted = 1`); the operator tears down
     /// the Kubernetes resources on its next reconcile.
     async fn delete_app_deployment(&self, id: u64) -> DbResult<()>;
+    /// Permanently remove a deployment and its billing records (subscription,
+    /// line items and payment history) in one transaction. The billing rows are
+    /// kept if the subscription still bills another resource.
+    ///
+    /// Kubernetes teardown is unaffected: the operator garbage-collects any
+    /// `app-{id}` namespace whose deployment is no longer in its active set, and
+    /// a purged row is absent from that set exactly like a soft-deleted one.
+    async fn hard_delete_app_deployment(&self, id: u64) -> DbResult<()>;
 }
 
 /// Super trait that combines all database functionality based on enabled features

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -3255,3 +3255,23 @@ pub struct AppDeployment {
     /// retained only for accounting.
     pub deleted: bool,
 }
+
+/// Optional filters for the admin app-deployment listing. Every field is
+/// combined with `AND`; `None` means "don't filter on this". Passed as a struct
+/// rather than positional arguments because the set is open-ended.
+#[derive(Clone, Debug, Default)]
+pub struct AppDeploymentFilter {
+    pub user_id: Option<u64>,
+    pub app_id: Option<u64>,
+    pub cluster_id: Option<u64>,
+    /// Matches deployments on any cluster in this region.
+    pub region_id: Option<u64>,
+    pub status: Option<AppDeploymentStatus>,
+    pub desired_state: Option<AppDeploymentDesiredState>,
+    /// Case-insensitive substring match against `name`, `hostname` and
+    /// `custom_domain`.
+    pub search: Option<String>,
+    /// Include soft-deleted deployments. Deletion is a soft delete, so an
+    /// admin needs this to inspect or confirm a teardown.
+    pub include_deleted: bool,
+}

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AccessPolicy, App, AppCluster, AppDeployment, AsnSubscription, AsnSubscriptionStatus,
-    AvailableIpSpace, Company, DbError, DbResult, DnsServer, IntervalType, IpRange,
-    IpRangeSubscription, IpSpacePricing, LNVpsDbBase, PaymentMethod, PaymentMethodConfig,
+    AccessPolicy, App, AppCluster, AppDeployment, AppDeploymentFilter, AsnSubscription,
+    AsnSubscriptionStatus, AvailableIpSpace, Company, DbError, DbResult, DnsServer, IntervalType,
+    IpRange, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, PaymentMethod, PaymentMethodConfig,
     PaymentType, Referral, ReferralCostUsage, ReferralPayout, Region, RegionStats, Router,
     RouterBgpRoute, RouterBgpSession, RouterTunnel, RouterTunnelTraffic, Subscription,
     SubscriptionLineItem, SubscriptionPayment, SubscriptionPaymentWithCompany, User,
@@ -37,6 +37,111 @@ impl LNVpsDbMysql {
 
     pub fn pool(&self) -> &MySqlPool {
         &self.db
+    }
+}
+
+/// A paired `COUNT(*)` / `SELECT *` query over the same table, so a filtered
+/// listing builds its row page and its total from one set of conditions.
+///
+/// [`Self::next`] emits `WHERE` for the first condition and `AND` for every
+/// one after it, then hands back both builders so the caller pushes the same
+/// fragment (and its binds) into each.
+struct FilteredQuery<'a> {
+    count: QueryBuilder<'a, sqlx::MySql>,
+    data: QueryBuilder<'a, sqlx::MySql>,
+    has_conditions: bool,
+}
+
+impl<'a> FilteredQuery<'a> {
+    fn new(table: &str) -> Self {
+        let mut count = QueryBuilder::new("SELECT COUNT(*) FROM ");
+        count.push(table);
+        let mut data = QueryBuilder::new("SELECT * FROM ");
+        data.push(table);
+        Self {
+            count,
+            data,
+            has_conditions: false,
+        }
+    }
+
+    fn next(
+        &mut self,
+    ) -> (
+        &mut QueryBuilder<'a, sqlx::MySql>,
+        &mut QueryBuilder<'a, sqlx::MySql>,
+    ) {
+        let keyword = if self.has_conditions {
+            " AND "
+        } else {
+            " WHERE "
+        };
+        self.has_conditions = true;
+        self.count.push(keyword);
+        self.data.push(keyword);
+        (&mut self.count, &mut self.data)
+    }
+
+    /// Add an `x = ?` equality condition to both queries.
+    fn eq<T>(&mut self, column: &str, value: T)
+    where
+        T: 'a + Clone + Send + sqlx::Type<sqlx::MySql> + sqlx::Encode<'a, sqlx::MySql>,
+    {
+        let (count, data) = self.next();
+        count.push(column).push(" = ").push_bind(value.clone());
+        data.push(column).push(" = ").push_bind(value);
+    }
+
+    /// Add a case-insensitive `LIKE %term%` condition across `columns`, OR'd
+    /// together. LIKE wildcards in `term` are escaped so it matches literally.
+    /// `NULL` columns are treated as empty strings rather than dropping the row.
+    fn search(&mut self, columns: &[&str], term: &str) {
+        let escaped = term
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("%{}%", escaped.to_lowercase());
+
+        let (count, data) = self.next();
+        for query in [count, data] {
+            query.push("(");
+            for (i, column) in columns.iter().enumerate() {
+                if i > 0 {
+                    query.push(" OR ");
+                }
+                query
+                    .push("LOWER(COALESCE(")
+                    .push(column)
+                    .push(", '')) LIKE ")
+                    .push_bind(pattern.clone());
+            }
+            query.push(")");
+        }
+    }
+
+    /// Run the count, then the ordered page, and return `(rows, total)`.
+    async fn fetch<T>(
+        mut self,
+        pool: &sqlx::MySqlPool,
+        order_by: &str,
+        limit: u64,
+        offset: u64,
+    ) -> DbResult<(Vec<T>, u64)>
+    where
+        T: for<'r> sqlx::FromRow<'r, sqlx::mysql::MySqlRow> + Send + Unpin,
+    {
+        let total: i64 = self.count.build_query_scalar().fetch_one(pool).await?;
+
+        self.data
+            .push(" ORDER BY ")
+            .push(order_by)
+            .push(" LIMIT ")
+            .push_bind(limit)
+            .push(" OFFSET ")
+            .push_bind(offset);
+        let rows: Vec<T> = self.data.build_query_as().fetch_all(pool).await?;
+
+        Ok((rows, total as u64))
     }
 }
 
@@ -2347,6 +2452,46 @@ impl LNVpsDbBase for LNVpsDbMysql {
         Ok(())
     }
 
+    async fn hard_delete_subscription(&self, id: u64) -> DbResult<()> {
+        // Guard: a VM or app deployment still pointing at one of the line items
+        // would be orphaned (and the FK would reject the delete anyway), so
+        // refuse with a message that says which resource is in the way.
+        for (table, label) in [("vm", "VM"), ("app_deployment", "app deployment")] {
+            let referencing: i64 = sqlx::query_scalar(&format!(
+                "select count(*) from {table} r \
+                 join subscription_line_item li on li.id = r.subscription_line_item_id \
+                 where li.subscription_id = ?"
+            ))
+            .bind(id)
+            .fetch_one(&self.db)
+            .await?;
+            if referencing > 0 {
+                return Err(DbError::Source(
+                    anyhow!(
+                        "Cannot purge subscription with {referencing} attached {label}(s); delete them first"
+                    )
+                    .into_boxed_dyn_error(),
+                ));
+            }
+        }
+
+        let mut tx = self.db.begin().await?;
+
+        // subscription_payment has no ON DELETE CASCADE so it must be cleared
+        // first; subscription_line_item does cascade from subscription.
+        sqlx::query("delete from subscription_payment where subscription_id = ?")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("delete from subscription where id = ?")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
     async fn get_subscription_base_currency(&self, subscription_id: u64) -> DbResult<String> {
         let result: (String,) = sqlx::query_as(
             "SELECT c.base_currency 
@@ -3617,6 +3762,23 @@ impl LNVpsDbBase for LNVpsDbMysql {
         Ok(sqlx::query_as(sql).fetch_all(&self.db).await?)
     }
 
+    async fn admin_list_apps_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        enabled: Option<bool>,
+        search: Option<&str>,
+    ) -> DbResult<(Vec<App>, u64)> {
+        let mut query = FilteredQuery::new("app");
+        if let Some(enabled) = enabled {
+            query.eq("enabled", enabled);
+        }
+        if let Some(term) = search.map(str::trim).filter(|s| !s.is_empty()) {
+            query.search(&["name", "display_name", "description"], term);
+        }
+        query.fetch(&self.db, "id DESC", limit, offset).await
+    }
+
     async fn get_app(&self, id: u64) -> DbResult<App> {
         Ok(sqlx::query_as("SELECT * FROM app WHERE id = ?")
             .bind(id)
@@ -3705,6 +3867,27 @@ impl LNVpsDbBase for LNVpsDbMysql {
         Ok(sqlx::query_as(sql).fetch_all(&self.db).await?)
     }
 
+    async fn admin_list_app_clusters_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        enabled: Option<bool>,
+        region_id: Option<u64>,
+        search: Option<&str>,
+    ) -> DbResult<(Vec<AppCluster>, u64)> {
+        let mut query = FilteredQuery::new("app_cluster");
+        if let Some(enabled) = enabled {
+            query.eq("enabled", enabled);
+        }
+        if let Some(region_id) = region_id {
+            query.eq("region_id", region_id);
+        }
+        if let Some(term) = search.map(str::trim).filter(|s| !s.is_empty()) {
+            query.search(&["name", "ingress_domain"], term);
+        }
+        query.fetch(&self.db, "id DESC", limit, offset).await
+    }
+
     async fn get_app_cluster(&self, id: u64) -> DbResult<AppCluster> {
         Ok(sqlx::query_as("SELECT * FROM app_cluster WHERE id = ?")
             .bind(id)
@@ -3774,6 +3957,52 @@ impl LNVpsDbBase for LNVpsDbMysql {
                 .fetch_all(&self.db)
                 .await?,
         )
+    }
+
+    async fn admin_list_app_deployments_filtered(
+        &self,
+        limit: u64,
+        offset: u64,
+        filter: &AppDeploymentFilter,
+    ) -> DbResult<(Vec<AppDeployment>, u64)> {
+        let mut query = FilteredQuery::new("app_deployment");
+        if !filter.include_deleted {
+            query.eq("deleted", false);
+        }
+        if let Some(user_id) = filter.user_id {
+            query.eq("user_id", user_id);
+        }
+        if let Some(app_id) = filter.app_id {
+            query.eq("app_id", app_id);
+        }
+        if let Some(cluster_id) = filter.cluster_id {
+            query.eq("cluster_id", cluster_id);
+        }
+        if let Some(region_id) = filter.region_id {
+            // A deployment's region comes from its cluster, so match against
+            // every cluster in the region rather than joining.
+            let (count, data) = query.next();
+            for q in [count, data] {
+                q.push("cluster_id IN (SELECT id FROM app_cluster WHERE region_id = ")
+                    .push_bind(region_id)
+                    .push(")");
+            }
+        }
+        if let Some(status) = filter.status {
+            query.eq("status", status);
+        }
+        if let Some(desired_state) = filter.desired_state {
+            query.eq("desired_state", desired_state);
+        }
+        if let Some(term) = filter
+            .search
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            query.search(&["name", "hostname", "custom_domain"], term);
+        }
+        query.fetch(&self.db, "id DESC", limit, offset).await
     }
 
     async fn get_app_deployment(&self, id: u64) -> DbResult<AppDeployment> {
@@ -3856,6 +4085,63 @@ impl LNVpsDbBase for LNVpsDbMysql {
             .bind(id)
             .execute(&self.db)
             .await?;
+        Ok(())
+    }
+
+    async fn hard_delete_app_deployment(&self, id: u64) -> DbResult<()> {
+        let mut tx = self.db.begin().await?;
+
+        // Resolve the deployment's subscription (via its line item) before the
+        // row goes, so the billing records can be cleaned up too.
+        let subscription_id: Option<u64> = sqlx::query_scalar(
+            "select li.subscription_id from app_deployment d \
+             join subscription_line_item li on li.id = d.subscription_line_item_id \
+             where d.id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        // Delete the deployment first — it holds the FK to subscription_line_item.
+        sqlx::query("delete from app_deployment where id = ?")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+        if let Some(subscription_id) = subscription_id {
+            // A deployment normally owns its subscription outright. If the
+            // subscription also bills something else (a VM or another
+            // deployment), leave the billing rows alone rather than destroying
+            // another resource's billing — and its FK — with it.
+            let still_billed: i64 = sqlx::query_scalar(
+                "select (select count(*) from vm v \
+                         join subscription_line_item li on li.id = v.subscription_line_item_id \
+                         where li.subscription_id = ?) \
+                      + (select count(*) from app_deployment d \
+                         join subscription_line_item li on li.id = d.subscription_line_item_id \
+                         where li.subscription_id = ?)",
+            )
+            .bind(subscription_id)
+            .bind(subscription_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            // subscription_payment has no ON DELETE CASCADE so it must be
+            // cleared first; subscription_line_item does cascade from
+            // subscription.
+            if still_billed == 0 {
+                sqlx::query("delete from subscription_payment where subscription_id = ?")
+                    .bind(subscription_id)
+                    .execute(&mut *tx)
+                    .await?;
+                sqlx::query("delete from subscription where id = ?")
+                    .bind(subscription_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+
+        tx.commit().await?;
         Ok(())
     }
 }

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -742,7 +742,489 @@ mod tests {
         assert_eq!(found["user_id"].as_u64(), Some(uid));
         assert!(!found["namespace"].as_str().unwrap().is_empty());
         assert!(!found["status"].as_str().unwrap().is_empty());
+        // Standard paginated envelope.
+        assert!(body["total"].as_u64().unwrap() >= 1);
+        assert_eq!(body["limit"].as_u64(), Some(50));
+        assert_eq!(body["offset"].as_u64(), Some(0));
 
+        pool.close().await;
+    }
+
+    /// Filters and pagination on the admin deployment listing (#235).
+    #[tokio::test]
+    async fn test_admin_list_app_deployments_filters() {
+        let client = setup().await;
+        let pool = crate::db::connect().await.unwrap();
+        let keys = nostr::Keys::generate();
+        let uid = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let (app_id, cluster_id, dep_id) =
+            crate::db::seed_app_deployment(&pool, uid, "filter-target")
+                .await
+                .unwrap();
+        // A second deployment for the same user, on its own app + cluster.
+        let (other_app, other_cluster, other_dep) =
+            crate::db::seed_app_deployment(&pool, uid, "filter-other")
+                .await
+                .unwrap();
+
+        let ids = |body: &Value| -> Vec<u64> {
+            body["data"]
+                .as_array()
+                .expect("data array")
+                .iter()
+                .filter_map(|d| d["id"].as_u64())
+                .collect()
+        };
+
+        // user_id: both, and nothing belonging to anyone else.
+        let resp = client
+            .get_auth(&format!("/api/admin/v1/app-deployments?user_id={uid}"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(2));
+        let mut found = ids(&body);
+        found.sort_unstable();
+        let mut expected = vec![dep_id, other_dep];
+        expected.sort_unstable();
+        assert_eq!(found, expected);
+
+        // app_id / cluster_id narrow to the one deployment.
+        for query in [
+            format!("app_id={app_id}"),
+            format!("cluster_id={cluster_id}"),
+        ] {
+            let resp = client
+                .get_auth(&format!("/api/admin/v1/app-deployments?{query}"))
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+            assert_eq!(ids(&body), vec![dep_id], "filter {query}");
+        }
+
+        // search matches the deployment name.
+        let resp = client
+            .get_auth("/api/admin/v1/app-deployments?search=filter-target")
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(ids(&body), vec![dep_id]);
+
+        // status: seeded deployments are pending; `running` excludes them.
+        let resp = client
+            .get_auth(&format!(
+                "/api/admin/v1/app-deployments?user_id={uid}&status=pending"
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(2));
+        let resp = client
+            .get_auth(&format!(
+                "/api/admin/v1/app-deployments?user_id={uid}&status=running"
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(0));
+
+        // limit/offset page through the filtered set; total stays the full count.
+        let resp = client
+            .get_auth(&format!(
+                "/api/admin/v1/app-deployments?user_id={uid}&limit=1&offset=1"
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(2));
+        assert_eq!(body["limit"].as_u64(), Some(1));
+        assert_eq!(body["offset"].as_u64(), Some(1));
+        assert_eq!(
+            ids(&body),
+            vec![dep_id],
+            "id DESC, so offset 1 is the older"
+        );
+
+        // include_deleted is the only way to see a torn-down deployment.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp = client
+            .get_auth(&format!("/api/admin/v1/app-deployments?user_id={uid}"))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(ids(&body), vec![other_dep], "deleted row is hidden");
+        let resp = client
+            .get_auth(&format!(
+                "/api/admin/v1/app-deployments?user_id={uid}&include_deleted=true"
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(2));
+        let deleted = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|d| d["id"].as_u64() == Some(dep_id))
+            .expect("deleted deployment is listed");
+        assert_eq!(deleted["deleted"].as_bool(), Some(true));
+
+        // Cleanup: purge both, then the catalog rows they pinned.
+        for id in [dep_id, other_dep] {
+            let resp = client
+                .delete_auth_body(
+                    &format!("/api/admin/v1/app-deployments/{id}"),
+                    &serde_json::json!({ "purge": true }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+        for id in [cluster_id, other_cluster] {
+            let _ = client
+                .delete_auth(&format!("/api/admin/v1/app_clusters/{id}"))
+                .await;
+        }
+        for id in [app_id, other_app] {
+            let _ = client
+                .delete_auth(&format!("/api/admin/v1/apps/{id}"))
+                .await;
+        }
+
+        pool.close().await;
+    }
+
+    /// Paginated envelope + filters on the catalog app listing (#235).
+    #[tokio::test]
+    async fn test_admin_list_apps_paginated() {
+        let client = setup().await;
+        let pool = crate::db::connect().await.unwrap();
+        let keys = nostr::Keys::generate();
+        let uid = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let (app_id, cluster_id, dep_id) = crate::db::seed_app_deployment(&pool, uid, "apps-page")
+            .await
+            .unwrap();
+        let app_name: String = sqlx::query_scalar("SELECT name FROM app WHERE id = ?")
+            .bind(app_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let resp = client.get_auth("/api/admin/v1/apps?limit=1").await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["data"].as_array().unwrap().len(), 1);
+        assert!(body["total"].as_u64().unwrap() >= 1);
+        assert_eq!(body["limit"].as_u64(), Some(1));
+
+        // search finds the seeded app; enabled=false excludes it (seeded enabled).
+        let resp = client
+            .get_auth(&format!("/api/admin/v1/apps?search={app_name}"))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["data"][0]["id"].as_u64(), Some(app_id));
+        let resp = client
+            .get_auth(&format!(
+                "/api/admin/v1/apps?search={app_name}&enabled=false"
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(0));
+
+        // Clusters list carries the same envelope and a region filter.
+        let region_id: u64 = sqlx::query_scalar("SELECT region_id FROM app_cluster WHERE id = ?")
+            .bind(cluster_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let resp = client
+            .get_auth(&format!("/api/admin/v1/app_clusters?region_id={region_id}"))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(1));
+        assert_eq!(body["data"][0]["id"].as_u64(), Some(cluster_id));
+
+        // Cleanup.
+        let _ = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({ "purge": true }),
+            )
+            .await;
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/app_clusters/{cluster_id}"))
+            .await;
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await;
+
+        pool.close().await;
+    }
+
+    /// Admin delete of an ever-paid deployment soft-deletes and stops billing;
+    /// a repeat delete conflicts; `purge` removes the row and its billing (#234).
+    #[tokio::test]
+    async fn test_admin_delete_and_purge_app_deployment() {
+        let client = setup().await;
+        let pool = crate::db::connect().await.unwrap();
+        let keys = nostr::Keys::generate();
+        let uid = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let (app_id, cluster_id, dep_id) = crate::db::seed_app_deployment(&pool, uid, "purge-me")
+            .await
+            .unwrap();
+        // seed_app_deployment marks the subscription set up (ever paid).
+        let sub_id: u64 = sqlx::query_scalar(
+            "SELECT li.subscription_id FROM app_deployment d \
+             JOIN subscription_line_item li ON li.id = d.subscription_line_item_id \
+             WHERE d.id = ?",
+        )
+        .bind(dep_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Plain delete: soft-delete + billing deactivated, row retained.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let (deleted, is_active, auto_renew): (bool, bool, bool) = sqlx::query_as(
+            "SELECT d.deleted, s.is_active, s.auto_renewal_enabled FROM app_deployment d \
+             JOIN subscription s ON s.id = ? WHERE d.id = ?",
+        )
+        .bind(sub_id)
+        .bind(dep_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(deleted, "soft-deleted");
+        assert!(!is_active, "billing deactivated");
+        assert!(!auto_renew, "auto-renewal off");
+
+        // Deleting again without purge conflicts.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        // Purge: an already soft-deleted deployment can still be purged, and it
+        // takes its subscription and line items with it.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({ "purge": true }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM app_deployment WHERE id = ?")
+            .bind(dep_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, 0, "row purged");
+        let subs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM subscription WHERE id = ?")
+            .bind(sub_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(subs, 0, "subscription purged");
+        let items: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM subscription_line_item WHERE subscription_id = ?",
+        )
+        .bind(sub_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(items, 0, "line items cascaded");
+
+        // A purged deployment is gone even with include_deleted.
+        let resp = client
+            .get_auth(&format!(
+                "/api/admin/v1/app-deployments?user_id={uid}&include_deleted=true"
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["total"].as_u64(), Some(0));
+
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/app_clusters/{cluster_id}"))
+            .await;
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await;
+        pool.close().await;
+    }
+
+    /// A deployment whose first payment was never confirmed is removed entirely
+    /// by a plain delete — the same never-paid rule VMs use (#234).
+    #[tokio::test]
+    async fn test_admin_delete_never_paid_app_deployment_purges() {
+        let client = setup().await;
+        let pool = crate::db::connect().await.unwrap();
+        let keys = nostr::Keys::generate();
+        let uid = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let (app_id, cluster_id, dep_id) = crate::db::seed_app_deployment(&pool, uid, "never-paid")
+            .await
+            .unwrap();
+        let sub_id: u64 = sqlx::query_scalar(
+            "SELECT li.subscription_id FROM app_deployment d \
+             JOIN subscription_line_item li ON li.id = d.subscription_line_item_id \
+             WHERE d.id = ?",
+        )
+        .bind(dep_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // Never paid: the first payment was never confirmed.
+        sqlx::query("UPDATE subscription SET is_setup = 0 WHERE id = ?")
+            .bind(sub_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM app_deployment WHERE id = ?")
+            .bind(dep_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, 0, "never-paid deployment is purged, not soft-deleted");
+        let subs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM subscription WHERE id = ?")
+            .bind(sub_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(subs, 0);
+
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/app_clusters/{cluster_id}"))
+            .await;
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await;
+        pool.close().await;
+    }
+
+    /// `purge` bypasses the paid-payments guard on subscription delete (#234).
+    #[tokio::test]
+    async fn test_admin_purge_subscription_with_paid_payments() {
+        let client = setup().await;
+        let pool = crate::db::connect().await.unwrap();
+        let keys = nostr::Keys::generate();
+        let uid = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let (app_id, cluster_id, dep_id) = crate::db::seed_app_deployment(&pool, uid, "sub-purge")
+            .await
+            .unwrap();
+        let sub_id: u64 = sqlx::query_scalar(
+            "SELECT li.subscription_id FROM app_deployment d \
+             JOIN subscription_line_item li ON li.id = d.subscription_line_item_id \
+             WHERE d.id = ?",
+        )
+        .bind(dep_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO subscription_payment (id, subscription_id, user_id, created, expires, \
+                 amount, currency, payment_method, payment_type, external_data, is_paid, rate, \
+                 tax, processing_fee) \
+             VALUES (?, ?, ?, NOW(), DATE_ADD(NOW(), INTERVAL 1 HOUR), 1000, 'EUR', 0, 0, '', 1, 1.0, 0, 0)",
+        )
+        .bind(vec![9u8; 16])
+        .bind(sub_id)
+        .bind(uid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The deployment still references a line item, so a purge is refused.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/subscriptions/{sub_id}"),
+                &serde_json::json!({ "purge": true }),
+            )
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), StatusCode::OK);
+        assert!(resp.text().await.unwrap().contains("app deployment"));
+
+        // Soft-delete the deployment row out of the way (the purge guard looks
+        // at the FK, so the row itself must go).
+        sqlx::query("DELETE FROM app_deployment WHERE id = ?")
+            .bind(dep_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Without purge the paid payment still blocks the delete.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/subscriptions/{sub_id}"),
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), StatusCode::OK);
+        assert!(resp.text().await.unwrap().contains("paid payments exist"));
+
+        // With purge it goes, taking payments and line items with it.
+        let resp = client
+            .delete_auth_body(
+                &format!("/api/admin/v1/subscriptions/{sub_id}"),
+                &serde_json::json!({ "purge": true }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        for (table, column) in [
+            ("subscription", "id"),
+            ("subscription_line_item", "subscription_id"),
+            ("subscription_payment", "subscription_id"),
+        ] {
+            let rows: i64 =
+                sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {table} WHERE {column} = ?"))
+                    .bind(sub_id)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(rows, 0, "{table} purged");
+        }
+
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/app_clusters/{cluster_id}"))
+            .await;
+        let _ = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await;
         pool.close().await;
     }
 

--- a/lnvps_e2e/src/rbac.rs
+++ b/lnvps_e2e/src/rbac.rs
@@ -297,4 +297,64 @@ mod tests {
         let body = resp.text().await.unwrap();
         assert!(body.contains("Insufficient permissions"));
     }
+
+    /// `app_deployment::delete` is enough to delete a deployment but not to
+    /// purge one — that stays super_admin-only. Like the VM purge, the check
+    /// runs before the lookup, so a non-existent id still yields 403.
+    #[tokio::test]
+    async fn test_app_deleter_cannot_purge_app_deployment() {
+        setup_rbac().await;
+
+        // A role that can delete deployments but is not super_admin.
+        let admin = admin_client_with_keys(super_admin_keys().clone());
+        let role_name = "e2e-app-deleter";
+        let create = serde_json::json!({
+            "name": role_name,
+            "description": "E2E: delete but not purge deployments",
+            "permissions": ["app_deployment::view", "app_deployment::delete"]
+        });
+        let resp = admin
+            .post_auth("/api/admin/v1/roles", &create)
+            .await
+            .unwrap();
+        // The role survives between runs against the same database.
+        assert!(
+            resp.status() == StatusCode::OK || resp.status() == StatusCode::BAD_REQUEST,
+            "unexpected role create status: {}",
+            resp.status()
+        );
+
+        let keys = Keys::generate();
+        let pool = db::connect().await.unwrap();
+        db::ensure_user_with_role(&pool, &keys, role_name)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        let client = admin_client_with_keys(keys);
+        let resp = client
+            .delete_auth_body(
+                "/api/admin/v1/app-deployments/999999999",
+                &serde_json::json!({ "purge": true }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(
+            resp.text()
+                .await
+                .unwrap()
+                .contains("Only super admins can permanently purge")
+        );
+
+        // The same role reaches the lookup on a plain delete (404, not 403).
+        let resp = client
+            .delete_auth_body(
+                "/api/admin/v1/app-deployments/999999999",
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
 }


### PR DESCRIPTION
Fixes #234
Fixes #235

Both issues land in one branch because they rewrite the same three DB query paths — doing them separately means rewriting `list_all_app_deployments` twice.

## #235 — pagination, filters, `include_deleted`

`GET /api/admin/v1/apps`, `/app_clusters` and `/app-deployments` previously returned every row as a bare `{"data": [...]}` with no query parameters at all. They now accept `limit`/`offset` (default 50, max 100) and return the standard `ApiPaginatedData` envelope used by every other admin list, ordered `id DESC`.

Filters are pushed into SQL rather than applied in the handler, via a new `FilteredQuery` helper (`lnvps_db/src/mysql.rs`) that builds the `COUNT(*)` and the row page from one set of conditions:

| Endpoint | Filters |
|---|---|
| `/app-deployments` | `user_id`, `app_id`, `cluster_id`, `region_id`, `status`, `desired_state`, `search`, `include_deleted` |
| `/apps` | `enabled`, `search` |
| `/app_clusters` | `enabled`, `region_id`, `search` |

`region_id` on deployments resolves through the cluster. `search` is a case-insensitive substring match with LIKE wildcards escaped so the term matches literally.

Because deployment deletion is a soft delete, a deleted deployment was previously invisible to admins entirely. `include_deleted=true` (default `false`) now surfaces it, and `AdminAppDeploymentInfo` gains a `deleted` boolean.

**Breaking for admin clients.** The response shape of all three listings changes from `{data}` to `{data, total, limit, offset}`. The issue explicitly asks for the standard envelope so the dashboard's shared paginated table can drive these lists, so this takes the break rather than versioning the endpoints. Called out in `API_CHANGELOG.md`.

## #234 — delete and purge

New `DELETE /api/admin/v1/app-deployments/{id}` (`app_deployment::delete`): deactivates billing and soft-deletes, and the operator tears down the namespace and volumes on its next reconcile. Following the rule VMs already use, a deployment whose **first payment was never confirmed** carries no billing history and is removed entirely instead.

Optional `{"purge": true}` hard-deletes the row together with its `subscription`, `subscription_line_item` and payment rows in one transaction. `super_admin` only, rejected `403` for everyone else, authorized **before** the lookup — exactly like the VM purge. An already soft-deleted deployment can still be purged; a plain delete of one returns `409`.

The same `purge` flag is added to `DELETE /api/admin/v1/subscriptions/{id}`, bypassing the "N paid payments exist" guard and cascading line items and payments. Regular deletes keep today's behaviour.

## Three decisions that differ from the issue text

**1. The purge/teardown concern does not apply.** #234 asks that a purge be "rejected (or deferred) until the operator has actually torn the namespace/PVCs down, so we don't orphan Kubernetes resources." It doesn't need to be. `gc_namespaces` (`lnvps_operator/src/app_deployments.rs:1167`) collects any `app-{id}` namespace whose id is absent from the set of live deployments — and a hard-deleted row is absent from that set exactly like a soft-deleted one. The namespace and its PVCs are torn down on the next reconcile either way. No deferral, no orphans.

**2. No migration.** #234 asks for the `app_deployment::delete` permission to be seeded. `20260725150000_app_deployment_rbac_permissions.sql` already grants actions 0–3 on resource 27 to `super_admin`.

**3. `include_deleted` only exists on deployments.** #234 asks for it on all three listings, but `app` and `app_cluster` have no `deleted` column — only `enabled`, and the admin listings already returned disabled rows. A parameter that silently does nothing is worse than not having it, so those two get `enabled` and the docs say why.

## Guards worth reviewing

- `hard_delete_app_deployment` keeps the subscription if it still bills another resource, so a mixed subscription cannot take a VM's billing (and its FK) down with the deployment.
- `hard_delete_subscription` refuses while a VM or app deployment still references one of the subscription's line items, and names which resource is in the way.

## Adjacent pre-existing bug, deliberately not fixed here

`admin_delete_app` and `admin_delete_app_cluster` guard on `list_all_app_deployments()`, which excludes soft-deleted rows — but a soft-deleted deployment still holds the FK to `app` / `app_cluster`. Deleting an app whose only deployments are soft-deleted passes the guard and then fails on the foreign key as a 500. Customers could already reach that state via the customer delete before this PR, so it is not new; left alone rather than widening scope. Happy to file it separately.

## Testing

734 unit tests pass (`cargo test --workspace --exclude lnvps_e2e -- --test-threads=1`) at `fce5788`, working tree clean. `cargo clippy` is clean on every file touched.

New coverage:

- **5 mock tests** (`lnvps_api_common/src/mock.rs`) — every filter on all three listings, pagination totals versus page size, blank-search handling, `include_deleted`, both hard-delete cascades, the mixed-subscription carve-out, and both purge guards.
- **5 e2e tests** (`lnvps_e2e/src/admin_api.rs`, `rbac.rs`) — the paginated envelope, filters and `include_deleted` over HTTP, the soft-delete → 409 → purge sequence with DB assertions, the never-paid purge, the subscription purge including the refusal paths, and 403 for a role that holds `app_deployment::delete` but is not `super_admin`.

⚠️ **The e2e tests compile but have not been run.** Docker was not available in the environment this was developed in, so they have never executed against MariaDB. They need a CI run (or `docker compose up -d` locally) before this merges.

Two build failures in that environment are pre-existing and reproduce on `master`: `lnvps_health` does not build on macOS (Linux-only `libc` MTU constants) and `lnvps_api --all-features` has a `BitvoraNode` trait error.

---

Opened from the `general` Buzz channel (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
