### PR TITLE
docs(apps): add Buzz relay managed-app example

### DIFF
--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -50,6 +50,15 @@ all other hardening (no privilege escalation, drop ALL capabilities, read-only
 root filesystem) stays in force. Only set it where the image genuinely needs
 it.
 
+**Read-only root filesystem** — this applies to *every* service, `user: root`
+included, and only declared `volumes` are writable. An image that writes
+outside its data directory needs either a small volume for that path or an env
+var redirecting it: `postgres` wants `/var/run/postgresql` (postmaster lock +
+unix socket), `redis` wants `/data` (otherwise its bgsave fails and it starts
+refusing writes with `MISCONF`), and an image that logs to a file needs to be
+pointed at stdout. This is not caught at validation time — it shows up as a
+crash loop on first boot.
+
 `user` also accepts a **numeric UID** (e.g. `user: "1000"`), which is required
 when the image's Dockerfile sets `USER` to a *name* rather than a number (e.g.
 `USER nonroot`). The kubelet enforces `runAsNonRoot` by reading the image
@@ -359,6 +368,184 @@ services:
 config:
   - { name: owner_npub, label: "Owner npub", type: string, required: true }
 ```
+
+---
+
+## Buzz — team relay + web UI (+ Postgres, Redis, RustFS)
+
+- **Image:** `ghcr.io/block/buzz` (official, published from the repo by
+  `relay-v*` tags) — <https://github.com/block/buzz/pkgs/container/buzz>, plus
+  `postgres:17-alpine`, `redis:7-alpine` and `rustfs/rustfs`
+  (<https://hub.docker.com/r/rustfs/rustfs>) for object storage.
+- **Repo:** <https://github.com/block/buzz> — a Nostr relay (NIP-29 groups,
+  NIP-42 auth, NIP-17 DMs, NIP-34 git) that also serves the web UI from the
+  same port, so one `expose: ingress` port covers `wss://`, the REST API,
+  media and the browser client. It is *not* a plain relay: it hard-requires
+  Postgres (event store), Redis (pub/sub fan-out, presence, rate limits,
+  NIP-98 replay set) and an S3-compatible bucket (media blobs + git objects).
+  Schema migrations are embedded in the binary and run at startup under a
+  Postgres advisory lock (`BUZZ_AUTO_MIGRATE`).
+- **Identity:** `RELAY_OWNER_PUBKEY` bootstraps the owner into `relay_members`
+  and, with `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`, is the only pubkey that can
+  use the relay until it adds more members. `BUZZ_RELAY_PRIVATE_KEY` is the
+  relay's own signing key — it signs NIP-29 discovery (39000/39001/39002),
+  membership rosters (13534), membership notifications (44100/44101) and
+  system messages. It must be stable: rotating it is a new relay identity.
+- **Notes:**
+  - `RELAY_URL` is used verbatim in NIP-42 auth challenges, so it must be the
+    public `wss://` URL — `wss://${HOSTNAME}`, not the in-namespace name.
+  - The relay runs a startup **A3 conformance probe** against the object store
+    (a linearizable conditional-write race backing git pointer CAS) and
+    *exits* if it fails. RustFS answers the default 32-way race with HTTP 503;
+    a 4-way single-round race passes. Hence `BUZZ_GIT_PROBE_WRITERS=4` /
+    `BUZZ_GIT_PROBE_ROUNDS=1` above — do not remove them, and do not paper
+    over a failure with `BUZZ_GIT_CONFORMANCE_PROBE=false` (that disables the
+    gate, not the requirement).
+  - Every container runs with `readOnlyRootFilesystem`, which is why `db`
+    mounts a small volume at `/var/run/postgresql` (lock file + unix socket)
+    and `s3` overrides `RUSTFS_OBS_LOG_DIRECTORY` (the image logs to `/logs`).
+  - `PGDATA` points at a *subdirectory* of the volume: `initdb` refuses a
+    non-empty directory and a fresh ext4 PVC contains `lost+found`.
+  - Search is Postgres FTS; no Typesense service is needed. Huddle
+    audio/video and the pairing relay are not wired up here (they need raw
+    TCP/UDP).
+  - The ACP agent harness (`buzz-acp`) is a *client* of the relay, not part of
+    this deployment — it runs wherever the customer's agent runs and connects
+    over `wss://` with its own key.
+
+```yaml
+services:
+  db:
+    image: postgres:17-alpine
+    user: root    # postgres' entrypoint starts as root, then drops to `postgres`
+    resources: { cpu: 500m, memory: 1Gi }
+    env:
+      POSTGRES_DB: buzz
+      POSTGRES_USER: buzz
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      # initdb refuses a non-empty directory, and a fresh ext4 PVC has lost+found
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - { name: data, path: /var/lib/postgresql/data, size: 20Gi }
+      # readOnlyRootFilesystem: the postmaster lock + unix socket need a writable dir
+      - { name: run, path: /var/run/postgresql, size: 1Gi }
+    backup:
+      command: ["sh", "-c", "exec pg_dumpall -U buzz"]
+      artifact: buzz.sql
+  redis:
+    image: redis:7-alpine
+    user: root    # redis' entrypoint starts as root, then drops to `redis`
+    resources: { cpu: 250m, memory: 512Mi }
+    volumes:
+      # RDB snapshots; without a writable /data redis fails its bgsave and then
+      # refuses writes with MISCONF
+      - { name: data, path: /data, size: 2Gi }
+  s3:
+    image: rustfs/rustfs:1.0.0-beta.11
+    user: "10001"    # image sets `USER rustfs` (a name); uid 10001 per its Dockerfile
+    resources: { cpu: 500m, memory: 1Gi }
+    ports:
+      - { name: s3, container: 9000, protocol: http, expose: none }
+    env:
+      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY}
+      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY}
+      RUSTFS_VOLUMES: /data
+      RUSTFS_ADDRESS: ":9000"
+      RUSTFS_CONSOLE_ENABLE: "false"
+      # image default is RUSTFS_OBS_LOG_DIRECTORY=/logs, which is unwritable
+      # under readOnlyRootFilesystem — log to stdout instead
+      RUSTFS_OBS_LOG_DIRECTORY: ""
+      RUSTFS_OBS_USE_STDOUT: "true"
+      RUSTFS_OBS_LOGGER_LEVEL: warn
+    volumes:
+      - { name: blobs, path: /data, size: 50Gi }
+    backup:
+      volume: blobs
+  relay:
+    image: ghcr.io/block/buzz:latest
+    user: "1000"    # image sets `USER buzz:buzz` (a name); uid 1000 per its Dockerfile
+    resources: { cpu: 1, memory: 2Gi }
+    depends_on: [db, redis, s3]
+    ports:
+      - { name: http, container: 3000, protocol: http, expose: ingress }
+    env:
+      # --- identity / public URL ---
+      RELAY_URL: "wss://${HOSTNAME}"
+      BUZZ_MEDIA_BASE_URL: "https://${HOSTNAME}"
+      BUZZ_BIND_ADDR: "0.0.0.0:3000"
+      BUZZ_RELAY_PRIVATE_KEY: "${relay_private_key}"
+      RELAY_OWNER_PUBKEY: "${owner_pubkey}"
+      # --- backing services (in-namespace DNS) ---
+      DATABASE_URL: "postgres://buzz:${DB_PASSWORD}@db:5432/buzz"
+      REDIS_URL: "redis://redis:6379"
+      BUZZ_AUTO_MIGRATE: "true"
+      # --- object storage ---
+      BUZZ_S3_ENDPOINT: "http://s3:9000"
+      BUZZ_S3_BUCKET: "buzz-media"
+      BUZZ_S3_REGION: "us-east-1"
+      BUZZ_S3_ACCESS_KEY: "${S3_ACCESS_KEY}"
+      BUZZ_S3_SECRET_KEY: "${S3_SECRET_KEY}"
+      # --- access control ---
+      BUZZ_REQUIRE_AUTH_TOKEN: "true"
+      BUZZ_REQUIRE_RELAY_MEMBERSHIP: "true"
+      BUZZ_ALLOW_NIP_OA_AUTH: "true"
+      BUZZ_PUBKEY_ALLOWLIST: "false"
+      BUZZ_REQUIRE_MEDIA_GET_AUTH: "false"
+      # --- git on object storage ---
+      BUZZ_GIT_REPO_PATH: "/var/lib/buzz/git"
+      BUZZ_GIT_PACK_CACHE_PATH: "/var/cache/buzz/git-packs"
+      BUZZ_GIT_HOOK_HMAC_SECRET: "${GIT_HOOK_HMAC_SECRET}"
+      # RustFS serves 503 under the default 32-way conditional-PUT race; the A3
+      # probe is startup-fatal, so keep the race narrow (verified: 4x1 passes)
+      BUZZ_GIT_PROBE_WRITERS: "4"
+      BUZZ_GIT_PROBE_ROUNDS: "1"
+      # --- capacity / logging ---
+      BUZZ_MAX_CONNECTIONS: "2000"
+      RUST_LOG: "info"
+    volumes:
+      - { name: git, path: /var/lib/buzz/git, size: 20Gi }
+      - { name: packs, path: /var/cache/buzz/git-packs, size: 5Gi }
+secrets:
+  - { name: DB_PASSWORD, generate: password }
+  - { name: S3_ACCESS_KEY, generate: token }
+  - { name: S3_SECRET_KEY, generate: password }
+  - { name: GIT_HOOK_HMAC_SECRET, generate: token }
+config:
+  - { name: owner_pubkey, label: "Owner pubkey (64-char hex)", type: string, required: true }
+  - { name: relay_private_key, label: "Relay signing key (openssl rand -hex 32)", type: string, required: true }
+```
+
+### Before this one can be enabled
+
+Two things in the compose grammar are missing for this app to deploy
+end-to-end. Both are small; until they land, this entry is documentation, not
+a shippable catalog item.
+
+1. **A 32-byte generated secret.** `secrets: generate:` always produces 24
+   random bytes (48 hex chars). `BUZZ_RELAY_PRIVATE_KEY` must be a 32-byte
+   Nostr secret key, and the relay exits with `invalid
+   BUZZ_RELAY_PRIVATE_KEY: Invalid secret key` on anything else. The compose
+   above works around it by asking the customer to paste
+   `openssl rand -hex 32` into a `config:` field — which puts the relay's
+   identity key in the order form. A `bytes:` (or `length:`) option on a
+   secret declaration would let the operator generate it, and the field could
+   then be dropped.
+
+2. **One-shot bucket creation.** The relay never issues `CreateBucket`; it
+   expects `BUZZ_S3_BUCKET` to exist and dies with `NoSuchBucket` in the A3
+   probe otherwise (upstream's Helm chart runs an `mc mb` Job plus a
+   wait-for-bucket init container). RustFS has no "default buckets" env var,
+   and a compose service has no `command`, so nothing in a deployment can
+   create it. Mounting a second volume at `/data/<bucket>` makes RustFS *list*
+   the bucket but writes then fail with `Cross-device link` on its rename out
+   of the drive-root temp area, so that is not a workaround. This needs
+   either an init/`command` hook in the grammar, or an operator-side bucket
+   bootstrap for services that declare one.
+
+Everything else was verified end-to-end against these images (relay reaches
+`buzz-relay TCP listening`, `/_readiness` 200, NIP-11 served, A3 probe
+admitted) with all four containers running read-only-rootfs and non-root
+where the image allows it.
 
 ---
 


### PR DESCRIPTION
Adds a `Buzz` entry to `docs/managed-app-examples.md`.

[Buzz](https://github.com/block/buzz) is a Nostr relay (NIP-29 groups, NIP-42 auth, NIP-17 DMs, NIP-34 git) that also serves its own web UI on the same port, so one `expose: ingress` port covers `wss://`, the REST API, media and the browser client. Unlike the existing relay entries it is not self-contained — it hard-requires Postgres, Redis and an S3-compatible bucket — so the compose is a four-service document (`db`, `redis`, `s3` via RustFS, `relay`).

### Verified, not guessed

Everything in the entry was checked against the real images before writing it:

- Relay reaches `buzz-relay TCP listening`, `/_readiness` returns 200, NIP-11 doc is served, and the git object-store **A3 conformance probe** is admitted against RustFS.
- All four containers were run with a read-only root filesystem and non-root UIDs where the image allows, matching what the operator renders.
- `compose-validate` passes: `4 service(s), cpu=2250m memory=4.50 GiB storage=98.00 GiB`.

Findings that are baked into the compose:

- RustFS answers the relay's default 32-way conditional-PUT race with HTTP 503 and the probe is startup-fatal → `BUZZ_GIT_PROBE_WRITERS=4` / `BUZZ_GIT_PROBE_ROUNDS=1` (4x1 passes).
- `postgres` needs a small volume at `/var/run/postgresql` under `readOnlyRootFilesystem`, and `PGDATA` must be a subdirectory (`initdb` refuses a PVC containing `lost+found`).
- `redis` needs `/data` writable or its bgsave fails and it starts refusing writes with `MISCONF`.
- `rustfs` logs to `/logs` by default, which is unwritable → redirected to stdout; its image `USER` is a name, so `user: "10001"` is required (same for the relay at `1000`).

### Two grammar gaps this surfaced

Documented in the entry under "Before this one can be enabled" — the app is not deployable end-to-end until one of each is addressed:

Tracked separately: #243 and #244.

1. **32-byte generated secret.** `secrets: generate:` always emits 24 random bytes (48 hex). `BUZZ_RELAY_PRIVATE_KEY` must be a 32-byte Nostr key; the relay exits with `invalid BUZZ_RELAY_PRIVATE_KEY: Invalid secret key` otherwise. The compose works around it with a customer-supplied `config:` field, which puts the relay identity key in the order form. A `bytes:`/`length:` option on a secret declaration would fix it properly — #243.
2. **One-shot bucket creation.** The relay never issues `CreateBucket` and dies with `NoSuchBucket`; RustFS has no default-buckets env var and services have no `command`, so nothing in a deployment can create it. (Mounting a volume at `/data/<bucket>` makes RustFS list the bucket but writes fail with `Cross-device link` — not a workaround.) Needs an init hook in the grammar or an operator-side bucket bootstrap — #244.

### Also

Adds a general note to the grammar recap that `readOnlyRootFilesystem` applies to *every* service including `user: root`, with the postgres/redis writable-path cases — it is not caught at validation time and shows up as a first-boot crash loop.

Docs only; no code changes.
