### PR TITLE
docs(apps): supply the 13 env vars HAVEN requires to start (#248)

### DIFF
--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -30,6 +30,15 @@ You also need at least one **app cluster** with capacity in a region
 (`POST /api/admin/v1/app_clusters`), and the operator for that cluster must run
 with the matching `app_cluster_id`.
 
+**Validation cannot tell you the app will start.** It checks the document's own
+grammar and computes a footprint; it has no way to know what a third-party image
+requires, so an entry can validate cleanly, price correctly and still be
+incapable of booting. Before enabling one, read the image's config loader for
+values that are required *without a default* and confirm the compose supplies
+every one — HAVEN shipped enabled with 11 of its 21 required env vars absent
+(#248), and because it aborts on the first missing one it reports them a single
+variable at a time.
+
 ## Compose grammar recap
 
 Top-level keys: `services`, `secrets` (operator-generated, injected as
@@ -346,10 +355,30 @@ services:
       RELAY_BIND_ADDRESS: "0.0.0.0"
       DB_ENGINE: "badger"
       BLOSSOM_PATH: "blossom/"
+      # Every var below down to IMPORT_START_DATE is read with HAVEN's `getEnv`,
+      # which is `log.Fatalf` on unset — one at a time, so a missing one looks
+      # like an endless queue of missing ones rather than a single fault (#248).
+      PRIVATE_RELAY_NAME: "${private_relay_name}"
       PRIVATE_RELAY_NPUB: "${owner_npub}"
+      PRIVATE_RELAY_DESCRIPTION: "${private_relay_description}"
+      PRIVATE_RELAY_ICON: ""
+      CHAT_RELAY_NAME: "Chat relay"
       CHAT_RELAY_NPUB: "${owner_npub}"
+      CHAT_RELAY_DESCRIPTION: "Private chats for ${HOSTNAME}"
+      CHAT_RELAY_ICON: ""
+      OUTBOX_RELAY_NAME: "Outbox relay"
       OUTBOX_RELAY_NPUB: "${owner_npub}"
+      OUTBOX_RELAY_DESCRIPTION: "Public messages and media for ${HOSTNAME}"
+      OUTBOX_RELAY_ICON: ""
+      INBOX_RELAY_NAME: "Inbox relay"
       INBOX_RELAY_NPUB: "${owner_npub}"
+      INBOX_RELAY_DESCRIPTION: "Interactions for ${HOSTNAME}"
+      INBOX_RELAY_ICON: ""
+      # Bounds how far back the owner's history imports. Not startup-fatal if
+      # unparseable (import.go prints and returns), which is why it is a fixed
+      # default rather than an order-form field: a bad value silently imports
+      # nothing.
+      IMPORT_START_DATE: "2023-01-01"
       IMPORT_SEED_RELAYS_FILE: "relays_import.json"
       BLASTR_RELAYS_FILE: "relays_blastr.json"
       WHITELISTED_NPUBS_FILE: ""
@@ -367,6 +396,12 @@ services:
       - { name: blossom, path: /app/blossom, size: 20Gi }
 config:
   - { name: owner_npub, label: "Owner npub", type: string, required: true }
+  # The private relay's name and description are served as NIP-11 metadata, so
+  # they are customer-visible. The chat/outbox/inbox sets are functional relays
+  # rather than branding surfaces and stay fixed — eight more order-form fields
+  # would undo the one-click point of the catalog.
+  - { name: private_relay_name, label: "Relay name", type: string, default: "My private relay" }
+  - { name: private_relay_description, label: "Relay description", type: string, default: "A HAVEN relay" }
 ```
 
 ---


### PR DESCRIPTION
Fixes #248 for the documented example. **The live catalog row is not fixed by this PR** — see below.

## What was wrong

HAVEN reads 21 env vars through `getEnv`, which is `log.Fatalf` on unset, and `loadConfig` is a single composite literal evaluated in lexical order — so it names one missing variable, dies, and names the next one on restart. The documented compose supplied 8 of the 21.

I re-derived the required set from `config.go` at tag `v1.2.2` (the tag the documented image is pinned to) rather than taking the issue's list on faith; it matches: 21 `getEnv` calls, 13 absent from the doc. The `S3_*` vars are also `getEnv` but only inside `getS3Config()` behind `BACKUP_PROVIDER == "s3"`, and the compose sets `"none"`, so they correctly stay out.

## Calls made (both overridable)

- **`""` is legal but not always right.** `os.LookupEnv` tests presence, not emptiness, so `""` satisfies `getEnv` — used for the four `*_ICON` vars. The names and descriptions are served as NIP-11 metadata and are customer-visible on a relay someone paid for, so those get real values.
- **Only the private relay's name/description are customer-configurable** (`config:` fields, defaulted). The chat/outbox/inbox relays are functional, not branding surfaces; eight more order-form fields would undo the one-click point of the catalog.
- **`IMPORT_START_DATE` is a fixed `2023-01-01`.** A bad value is not startup-fatal (`import.go` prints and returns) — it silently bounds how far back the owner's history imports, which is worse than a crash and not a question to put to a customer at order time.

## The audit Alejandra asked for

Checked the other five documented examples for the same class of defect — config required *without a default* that the compose does not supply:

| App | Config surface | Required-without-default | Result |
|---|---|---|---|
| strfry | `strfry.conf` | none — `golpe.yaml` defaults every key | OK |
| route96 | `config.yaml` (serde) | `storage_dir`, `database`, `max_upload_bytes`, `public_url` | all four supplied — OK |
| blossom-server | `config.yml` | none | OK |
| nostr-rs-relay | `config.toml` merged over `Settings::default()` | none | OK |
| Pyramid | envconfig | none — every tag carries a default | OK |

HAVEN was the only one. The Buzz entry is documentation-only and carries its own "before this can be enabled" section, so I did not re-verify it.

Also records in "How to add one" that validation cannot tell you an app will start — that is the gap this fell through, and it is cheap to say where someone will read it.

## Still to do, needs admin credentials (not mine)

The live row (`GET https://api.lnvps.net/api/v1/apps/5`) is **enabled and orderable at €2.00/mo and cannot boot**. It needs the same 11 additions (it already has `PRIVATE_RELAY_NAME`/`_DESCRIPTION` as `config:` fields). @v0l — disable it first, then patch the compose with the block from this PR:

```yaml
      PRIVATE_RELAY_ICON: ""
      CHAT_RELAY_NAME: "Chat relay"
      CHAT_RELAY_DESCRIPTION: "Private chats for ${HOSTNAME}"
      CHAT_RELAY_ICON: ""
      OUTBOX_RELAY_NAME: "Outbox relay"
      OUTBOX_RELAY_DESCRIPTION: "Public messages and media for ${HOSTNAME}"
      OUTBOX_RELAY_ICON: ""
      INBOX_RELAY_NAME: "Inbox relay"
      INBOX_RELAY_DESCRIPTION: "Interactions for ${HOSTNAME}"
      INBOX_RELAY_ICON: ""
      IMPORT_START_DATE: "2023-01-01"
```

## Verification

- `cargo test --workspace` at `44745ad`: every crate passes (`lnvps_e2e` needs its harness; this change is docs-only and touches no HTTP surface). `documented_examples_map_to_k8s` covers the edited compose — it parses, validates, satisfies the declaration rule with the two new `config:` fields, and renders.

Originating channel: `lnvps` (#f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1).