### PR TITLE
fix(apps): declare a non-root uid on the five catalog apps that had none (#256)

### DIFF
--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -73,10 +73,12 @@ otherwise fatal):
 services:
   s3:
     image: rustfs/rustfs:1.0.0-beta.11
+    user: "10001"                     # image sets `USER rustfs`; see `user` above
     ports:
       - { name: s3, container: 9000, protocol: http, expose: none }
   app:
     image: example/app:latest
+    user: "1000"                      # every service needs one — see `user` above
     depends_on: [s3]
     ports:
       - { name: http, container: 3000, protocol: http, expose: ingress }
@@ -153,6 +155,53 @@ for an Alpine `adduser -D nonroot` that is `1000`; for distroless `nonroot`
 it is `65532`. A `user:` that is neither `root`/`0` nor a positive integer is
 rejected when the compose is validated.
 
+**An image that declares no `USER` at all runs as root, and is refused the same
+way** (issue #256):
+
+```
+container has runAsNonRoot and image will run as root
+```
+
+Omitting `user:` is therefore not a neutral default — it is a bet that the image
+declares a numeric non-root `USER`, and most public images do not. Three of the
+five apps in this file shipped enabled and priced without one and could never
+have started. **Check the image before writing the entry, and check it again
+when the tag moves.** Nothing in validation can catch this: the compose is
+well-formed, and the operator only learns the image's `USER` when the kubelet
+refuses the pod.
+
+### Checking an image, and proving the choice works
+
+```bash
+docker pull <image>
+# What the kubelet will read. Empty means root.
+docker inspect -f 'USER={{.Config.User}}' <image>
+# A name (e.g. `appuser`) still needs its number:
+docker run --rm --entrypoint sh <image> -c 'getent passwd appuser'
+```
+
+Then run it the way the operator will — read-only root filesystem, all
+capabilities dropped, as that UID, with only the declared volume writable and
+pre-chowned (standing in for `fsGroup`) and any `files:` mounted read-only:
+
+```bash
+docker volume create smoke && docker run --rm -u 0 -v smoke:/d busybox chown -R 1000:1000 /d
+docker run --rm --read-only --cap-drop ALL --security-opt no-new-privileges \
+  --ulimit nofile=1048576:1048576 --user 1000:1000 \
+  -v smoke:/app/data -v "$PWD/config.yaml:/app/config.yaml:ro" <image>
+```
+
+It has to still be running after ~10s **and** have written into the volume
+(`docker run --rm -u 1000 -v smoke:/d busybox ls -la /d`) — an app that starts
+but cannot write its database only crash-loops later. Set the `nofile` limit:
+containerd's default is 1048576 and Docker's is lower, so an app that raises its
+own limit (strfry asks for 1000000) fails locally for a reason that would not
+apply on the cluster.
+
+This is not a substitute for a real reconcile — it does not exercise the
+ingress, the PVC provisioner or `depends_on` ordering — but it does exercise the
+exact check that refuses these pods.
+
 **Variable references** — every `${NAME}` in `env`, `files[].content` or a
 `content_from` must be declared, either as a `config:` field, a `secrets:` entry,
 or the built-in `HOSTNAME`. This is enforced when an app is created or updated
@@ -199,6 +248,7 @@ Exits non-zero if any document fails to parse or validate.
 services:
   strfry:
     image: dockurr/strfry:latest
+    user: "1000"    # image declares no USER, so it would run as root and be refused
     resources: { cpu: 500m, memory: 512Mi }
     ports:
       - { name: ws, container: 7777, protocol: http, expose: ingress }
@@ -248,6 +298,7 @@ services:
       artifact: route96.sql
   route96:
     image: voidic/route96:latest
+    user: "1000"    # image declares no USER, so it would run as root and be refused
     resources: { cpu: 500m, memory: 512Mi }
     depends_on: [db]
     ports:
@@ -282,6 +333,7 @@ secrets:
 services:
   blossom:
     image: ghcr.io/hzrd149/blossom-server:master
+    user: "1000"    # image declares no USER, so it would run as root and be refused
     resources: { cpu: 250m, memory: 256Mi }
     ports:
       - { name: http, container: 3000, protocol: http, expose: ingress }
@@ -321,6 +373,7 @@ services:
 services:
   relay:
     image: scsibug/nostr-rs-relay:latest
+    user: "1000"    # image sets `USER appuser` (a name); uid 1000 per its /etc/passwd
     resources: { cpu: 250m, memory: 256Mi }
     ports:
       - { name: ws, container: 8080, protocol: http, expose: ingress }
@@ -368,6 +421,7 @@ config:
 services:
   pyramid:
     image: ghcr.io/fiatjaf/pyramid:latest
+    user: "1000"    # image declares no USER, so it would run as root and be refused
     resources: { cpu: 500m, memory: 512Mi }
     ports:
       - { name: http, container: 3334, protocol: http, expose: ingress }

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -2187,10 +2187,37 @@ config:
                     );
                 }
                 let dep = build_deployment(id, sname, svc, &senv, &sfiles, 1, 1, &[]);
-                let image = dep.spec.unwrap().template.spec.unwrap().containers[0]
-                    .image
-                    .clone();
-                assert_eq!(image.as_deref(), Some(svc.image.as_str()));
+                let pod = dep.spec.unwrap().template.spec.unwrap();
+                let ctr = &pod.containers[0];
+                assert_eq!(ctr.image.as_deref(), Some(svc.image.as_str()));
+
+                // Every documented service must resolve to a user the kubelet
+                // will accept (#256). Under the default restricted path the pod
+                // asks for `runAsNonRoot` with no `runAsUser`, which leaves the
+                // kubelet to read the image's own `USER` — and it refuses both
+                // an image that declares none (it would run as root) and one
+                // that declares a *name* it cannot resolve to a number. Neither
+                // is visible to validation, so three of these examples shipped
+                // enabled, priced, and incapable of starting. An example must
+                // therefore either opt into root explicitly or name a numeric
+                // UID.
+                let sc = ctr.security_context.as_ref().expect("security context");
+                assert!(
+                    svc.runs_as_root() || sc.run_as_user.is_some(),
+                    "{name}/{sname}: no `user:` — the kubelet cannot verify the image's \
+                     USER, so this pod is refused. Set a numeric uid (check the image with \
+                     `docker inspect -f '{{{{.Config.User}}}}'`), or `user: root` if the \
+                     entrypoint genuinely needs it"
+                );
+                if let Some(uid) = sc.run_as_user {
+                    // fsGroup follows runAsUser, otherwise a fresh PVC stays
+                    // root-owned 0755 and the process cannot write its data.
+                    assert_eq!(
+                        pod.security_context.as_ref().and_then(|p| p.fs_group),
+                        Some(uid),
+                        "{name}/{sname}: fsGroup must match runAsUser"
+                    );
+                }
                 assert_eq!(
                     build_service(id, sname, svc).is_some(),
                     !svc.ports.is_empty(),


### PR DESCRIPTION
Fixes #256.

## What was wrong

`Service::runs_as_root()` (`lnvps_compose/src/lib.rs:190`) is true only for `user: root`/`0`, so a service with **no `user:` at all** takes the restricted path — `runAsNonRoot: true` with no `runAsUser`. The kubelet then reads the image's own `USER` and refuses it if it is root, or if it is a name it cannot resolve to a number. Validation cannot see any of this: the compose is well-formed, and the failure exists only at reconcile.

## Verified, not inferred

The issue's audit was read from registry config blobs and explicitly asked for confirmation. `docker inspect` on all five agrees with it:

| image | `Config.User` |
|---|---|
| `dockurr/strfry:latest` | *(empty → root)* |
| `voidic/route96:latest` | *(empty → root)* |
| `ghcr.io/hzrd149/blossom-server:master` | *(empty → root)* |
| `ghcr.io/fiatjaf/pyramid:latest` | *(empty → root)* |
| `scsibug/nostr-rs-relay:latest` | `appuser` → **uid 1000** (`getent passwd appuser`) |

Then I ran each the way the operator runs it — read-only rootfs, `--cap-drop ALL`, `no-new-privileges`, `--user 1000:1000`, only the declared volume writable and pre-chowned (standing in for `fsGroup`), `files:` mounted read-only:

| app | result as uid 1000 |
|---|---|
| strfry | websocket server on `0.0.0.0:7777`; wrote `data.mdb` + `lock.mdb` into the PVC |
| route96 | **HTTP 200** on `:8000`, against a real `mariadb:11` on the same network |
| blossom-server | ready; wrote `sqlite.db` + `blobs/` into the PVC |
| nostr-rs-relay | listening on `0.0.0.0:8080`; migrated its SQLite schema to v18 |
| pyramid | `running on http://0.0.0.0:3334` |

So `user: "1000"` is correct for all five — each starts non-root **and** writes into its volume. An app that starts but cannot write only crash-loops later, so I checked the volume contents rather than just the process staying up.

**Scope of the claim:** this is not a cluster reconcile. It does not exercise the ingress, the PVC provisioner or `depends_on` ordering. It does exercise the exact check that refuses these pods.

One trap worth recording: strfry first failed with `Unable to set NOFILES limit to 1000000, exceeds max of 524288`. That is Docker's default hard limit, not the cluster's (containerd: 1048576), so the documented recipe pins it — otherwise you get a failure that would not happen in production and draw the wrong conclusion.

## The part that stops it recurring

`documented_examples_map_to_k8s` now asserts every documented service resolves to a user the kubelet will accept — a numeric `runAsUser`, or explicit `user: root` — and that `fsGroup` follows `runAsUser` so a fresh PVC is actually writable. It fails with the fix for whoever trips it. Two apps have now shipped enabled, priced and unable to start, both found by a customer rather than by us; "remember to check the image" is not a control.

The docs gain the check itself: how to read an image's `USER`, how to resolve a name to a uid, and the smoke-run recipe above.

## Still broken after this merges

**The live catalog rows are unchanged and still cannot start.** This PR fixes the documented composes. Patching the five app rows needs admin credentials I do not have — same shape as #248. @Kieran: for each of the five apps, the compose needs the one `user:` line shown in `docs/managed-app-examples.md`; the diff here is exactly what to paste.

I have not filed the "make `enabled` conditional on an observed reconcile" issue — Alejandra flagged it as a catalog policy decision, and I agree it is yours to make rather than mine to file as a bug.

## Verification

- `cargo test --workspace --no-fail-fast` at `6868da1`: all pass except `lnvps_e2e`, which needs its harness (no e2e-reachable behaviour changes here — the diff is a doc and an operator unit test).
- All 8 compose blocks in `docs/managed-app-examples.md` through `compose-validate`: exit 0.
- `cargo clippy --workspace --all-targets` and `cargo fmt --check`: no new warnings or diffs in the touched files.
- Commit is **unsigned** — gpg-agent's passphrase cache expired in this session and pinentry has no tty.

Originating channel: `lnvps` (#f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1).
