### PR TITLE
fix(catalog): buzz-relay's media base URL must end with /media (#269)

### DIFF
--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -792,7 +792,11 @@ services:
     env:
       # --- identity / public URL ---
       RELAY_URL: "wss://${HOSTNAME}"
-      BUZZ_MEDIA_BASE_URL: "https://${HOSTNAME}"
+      # The relay validates this at startup and exits 1 on anything that does
+      # not end with /media — "invalid media config: public_base_url must end
+      # with /media" (#269). It is the public prefix it hands out for blobs,
+      # not the host it binds.
+      BUZZ_MEDIA_BASE_URL: "https://${HOSTNAME}/media"
       BUZZ_BIND_ADDR: "0.0.0.0:3000"
       BUZZ_RELAY_PRIVATE_KEY: "${BUZZ_RELAY_PRIVATE_KEY}"
       RELAY_OWNER_PUBKEY: "${owner_pubkey}"


### PR DESCRIPTION
Closes #269.

`BUZZ_MEDIA_BASE_URL: "https://${HOSTNAME}"` is rejected by the relay at startup:

```
Error: invalid media config: public_base_url must end with /media: got 'https://localhost'
```

It is the public prefix the relay hands out for blobs, not the address it binds. The check rejects every value the operator can produce for the old form — `${HOSTNAME}` is `{name}.{apps-domain}` in a deployment and never ends in `/media` — so the app was priced, enabled and incapable of starting.

## Verified by starting it

`compose-to-docker` (#268) against the corrected document, under the cluster's hardening:

```
db: Up          redis: Up          s3: Up
relay-init-create-media-bucket: Exited (0)
relay: Up
  git object-store backend admitted: A3 conformance probe passed
  buzz-relay TCP listening addr=0.0.0.0:3000
```

Before the change the same run gave `relay: Exited (1)` with everything else up.

## Still needed after merge

The live `app.compose` row needs the same one-line edit — no migration touches it, same as the `scratch:` backfill from #264. @Kieran's PATCH, not something this PR can do.

`cargo test --workspace` green at `914ea4a` (the doc is parsed and rendered by `documented_examples_map_to_k8s`).

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
