### PR TITLE
feat(apps): enforce config field types, and let a field declare a pattern (#271)

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -34,6 +34,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Per-response currency conversion arrays** (follows #230) — `other_price[]` on VM cost plans (`VmCostPlan`) and custom VM prices (`CustomVmPrice`), and `other_price[]` / `other_setup_fee[]` on `IpSpacePricing`, are now deprecated in favour of the single `GET /api/v1/exchange-rate` feed. They are still populated for backward compatibility but will be removed in a future release. Clients should compute conversions from the exchange-rate endpoint (`rates[B] / rates[A]`), which uses the same conversion source and precision.
 
+### Changed
+
+- **Managed app config fields are validated against their declared `type`, and may declare a `pattern`** (issue #271) — **stricter validation on `POST /api/v1/app-deployments`, `PATCH /api/v1/app-deployments/{id}` and the admin app create/update endpoints.** An order that previously succeeded with a garbage value now returns `400`.
+
+  `resolve_config` enforced `required` and unknown keys and never looked at `type`, so an `int` field accepted `abc`, a `bool` field accepted `maybe`, and a `string` field accepted anything at all. That is only a validation gap until an app is strict about the value: HAVEN panics on an `owner_npub` that is not an npub, so a single mistyped character was accepted at order time, charged for, and became a deployment that restarted forever with nothing on screen naming the field.
+
+  `int` must now parse as a whole number and `bool` must be `true` or `false`. A field may also declare `pattern`, a regex the value must match **in full** (it is anchored automatically, so `npub1…` cannot admit a value with junk on the end); `type: file` is exempt, being arbitrary content by definition. Errors name the field's **label** — what the customer sees on the form — not its internal name.
+
+  An empty submitted value for an `int` or `bool` field is treated as "not supplied" — it falls back to the field's default, or errors as required — because a form that posts every field sends `""` for the boxes nobody touched, and refusing those would fail an order over a field the app has a default for. An empty **string** is unchanged: blank is a legitimate value there.
+
+  A `pattern` is compiled when the app is created or updated, so an invalid regex is the catalog author's error rather than a customer's failed order, and a declared `default` is checked against its own field at the same point. Existing app definitions are unaffected: no field declares a `pattern` yet, and the documented `owner_npub` (HAVEN) and `owner_pubkey` (Buzz) fields gain one in this release — the live catalog rows need the same edit, which no migration performs.
+
 ### Added
 
 - **`billing_state` on an app deployment — `unpaid` / `active` / `expired`** (issue #253) — `ApiAppDeployment` (`GET /api/v1/app-deployments` and `/{id}`, and every endpoint returning a deployment) gains a nullable `billing_state` string. Additive: no existing field changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,6 +2975,7 @@ version = "0.4.7"
 dependencies = [
  "anyhow",
  "rand 0.9.4",
+ "regex",
  "serde",
  "serde_yaml",
 ]

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -275,6 +275,38 @@ This is not a substitute for a real reconcile — it does not exercise the
 ingress, the PVC provisioner or `depends_on` ordering — but it does exercise the
 exact check that refuses these pods.
 
+**`config[].pattern`** — a regex a submitted value must match, checked at
+order time (issue #271):
+
+```yaml
+services:
+  haven:
+    image: holgerhatgarkeinenode/haven-docker:v1.2.2
+    user: "1000"
+    ports:
+      - { name: ws, container: 3355, protocol: http, expose: ingress }
+    env:
+      OWNER_NPUB: "${owner_npub}"
+config:
+  - { name: owner_npub, label: "Owner npub", type: string, required: true,
+      pattern: "npub1[02-9ac-hj-np-z]{58}" }
+```
+
+`type:` only covers what a form input can check — a whole number, a boolean —
+and both are now enforced too: an order submitting `abc` for an `int` field is
+refused with the field's label. But most catalog fields are a `string` whose
+*shape* the app depends on, and an app that is strict about it is strict in the
+worst way: HAVEN panics on an `owner_npub` that is not an npub, so before this
+a mistyped character was accepted, charged for, and turned into a deployment
+that restarted forever with nothing on screen naming the field.
+
+The pattern is **anchored automatically** — it must match the whole value, so
+`npub1…` cannot admit a value with junk on the end. It is compiled when the app
+is created or updated, so a pattern that does not compile is the author's error
+rather than a customer's failed order, and a declared `default` is checked
+against its own field there too. Not applied to `type: file`, whose content is
+arbitrary. Keep it under 200 characters.
+
 **Variable references** — every `${NAME}` in `env`, `files[].content` or a
 `content_from` must be declared, either as a `config:` field, a `secrets:` entry,
 or the built-in `HOSTNAME`. This is enforced when an app is created or updated
@@ -658,7 +690,11 @@ services:
       - { name: db, path: /app/db, size: 10Gi, label: events }
       - { name: blossom, path: /app/blossom, size: 20Gi, label: media }
 config:
-  - { name: owner_npub, label: "Owner npub", type: string, required: true }
+  # HAVEN panics in nPubToPubkey on anything that is not an npub, so a mistyped
+  # character became a paid-for deployment that crashlooped (#271). The pattern
+  # is bech32: `npub1` + 58 characters from the bech32 alphabet (no 1/b/i/o).
+  - { name: owner_npub, label: "Owner npub", type: string, required: true,
+      pattern: "npub1[02-9ac-hj-np-z]{58}" }
   # The private relay's name and description are served as NIP-11 metadata, so
   # they are customer-visible. The chat/outbox/inbox sets are functional relays
   # rather than branding surfaces and stay fixed — eight more order-form fields
@@ -839,7 +875,8 @@ secrets:
   # is rejected at startup as an invalid secret key.
   - { name: BUZZ_RELAY_PRIVATE_KEY, generate: token, bytes: 32 }
 config:
-  - { name: owner_pubkey, label: "Owner pubkey (64-char hex)", type: string, required: true }
+  - { name: owner_pubkey, label: "Owner pubkey (64-char hex)", type: string, required: true,
+      pattern: "[0-9a-fA-F]{64}" }
 ```
 
 ### Before this one can be enabled

--- a/lnvps_compose/Cargo.toml
+++ b/lnvps_compose/Cargo.toml
@@ -7,4 +7,5 @@ edition.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_yaml = "0.9.34"
+regex = "1"
 rand = "0.9"

--- a/lnvps_compose/src/lib.rs
+++ b/lnvps_compose/src/lib.rs
@@ -513,6 +513,99 @@ pub struct ConfigField {
     /// Whether the field must be supplied.
     #[serde(default)]
     pub required: bool,
+    /// Regex the submitted value must match in full (issue #271).
+    ///
+    /// `type:` covers what a form input can check — an integer, a boolean — and
+    /// nothing else. Most catalog fields are a `string` whose shape the app
+    /// depends on: HAVEN takes an `owner_npub` and *panics* on anything that is
+    /// not one, so a mistyped character was accepted at order time and became a
+    /// crashlooping deployment the customer had already paid for. A pattern is
+    /// the smallest thing that closes that, and it generalises — the next app
+    /// wants a domain, a URL or a hex key, each of which would otherwise be
+    /// another `FieldType` variant.
+    ///
+    /// Anchored automatically: the value must match end to end, so a pattern
+    /// cannot accidentally admit a value with the right prefix. Compiled at
+    /// app-create time, so a pattern that does not compile is rejected there
+    /// rather than at a customer's order. Ignored for `type: file`, whose
+    /// content is arbitrary.
+    #[serde(default)]
+    pub pattern: Option<String>,
+}
+
+/// Longest accepted `pattern`. Long enough for the character-class patterns a
+/// catalog field needs (an npub, a domain, a hex key) and short enough that the
+/// admin API is not a place to paste a program.
+pub const MAX_PATTERN_LEN: usize = 200;
+
+impl ConfigField {
+    /// The label a customer sees, falling back to the field name.
+    ///
+    /// Error messages use this: the customer typed into a box labelled "Owner
+    /// npub", and telling them `owner_npub` is wrong makes them hunt for it.
+    pub fn display_label(&self) -> &str {
+        match self.label.as_deref() {
+            Some(l) if !l.trim().is_empty() => l,
+            _ => &self.name,
+        }
+    }
+
+    /// Check one submitted value against this field's declared type and
+    /// pattern. `Ok(())` when the value is usable.
+    ///
+    /// Called for a customer's submitted value *and* for a declared `default`
+    /// at app-create time — a default that its own field would reject is a
+    /// broken app definition, and it fails at order time for whoever leaves the
+    /// field blank rather than for the person who authored it.
+    pub fn check_value(&self, value: &str) -> Result<()> {
+        let label = self.display_label();
+        match self.r#type {
+            FieldType::Int => {
+                if value.trim().parse::<i64>().is_err() {
+                    bail!("config field '{label}' must be a whole number (got '{value}')");
+                }
+            }
+            FieldType::Bool => {
+                if !matches!(value.trim(), "true" | "false") {
+                    bail!("config field '{label}' must be true or false (got '{value}')");
+                }
+            }
+            // A string is unconstrained unless the app says otherwise, and a
+            // file is arbitrary content by definition.
+            FieldType::String | FieldType::File => {}
+        }
+        if let Some(pattern) = &self.pattern
+            && self.r#type != FieldType::File
+        {
+            let re =
+                compile_pattern(pattern).map_err(|e| anyhow!("config field '{label}': {e}"))?;
+            if !re.is_match(value) {
+                bail!("config field '{label}' has the wrong format (expected: {pattern})");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Compile a `pattern` into a fully-anchored regex.
+///
+/// Anchoring is not the author's job: `npub1…` without `^…$` silently accepts a
+/// value with junk on either end, and that is exactly the mistake that produces
+/// a crashlooping deployment. The pattern is wrapped rather than rewritten, so
+/// an author's own `^`/`$` stay valid and mean the same thing.
+///
+/// The `regex` crate has no backtracking, so a catalog pattern cannot be made
+/// to hang the API on a crafted input; the length bound keeps the declaration
+/// readable, it is not a safety measure.
+fn compile_pattern(pattern: &str) -> Result<regex::Regex> {
+    if pattern.trim().is_empty() {
+        bail!("pattern is empty — omit it instead");
+    }
+    if pattern.len() > MAX_PATTERN_LEN {
+        bail!("pattern must be at most {MAX_PATTERN_LEN} characters");
+    }
+    regex::Regex::new(&format!("^(?:{pattern})$"))
+        .map_err(|e| anyhow!("pattern '{pattern}' is not a valid regex: {e}"))
 }
 
 /// Config field input type.
@@ -576,6 +669,18 @@ impl Compose {
     /// `compose-validate` CLI) so a typo or a newly added reference is caught
     /// while a human can still fix it.
     pub fn validate_declarations(&self) -> Result<()> {
+        // A declared `default` must satisfy its own field (#271): an `int`
+        // defaulting to "abc" fails at order time for whoever leaves the box
+        // blank, which is a customer paying for the author's typo. Authoring-
+        // time only, like the rest of this function — a row stored before the
+        // rule existed keeps rendering, and is caught the next time an admin
+        // edits it.
+        for f in &self.config {
+            if let Some(default) = &f.default {
+                f.check_value(default)
+                    .map_err(|e| anyhow!("config field '{}': default is invalid: {e}", f.name))?;
+            }
+        }
         for name in self.referenced_vars() {
             let declared = self.config.iter().any(|c| c.name == name)
                 || self.secrets.iter().any(|s| s.name == name)
@@ -842,6 +947,15 @@ impl Compose {
                      (got {bytes})",
                     s.name
                 );
+            }
+        }
+
+        // A declared `pattern` must compile (#271). Safe to enforce here, where
+        // the operator also runs it, because the field is new: no stored row
+        // can carry one that predates the rule.
+        for f in &self.config {
+            if let Some(pattern) = &f.pattern {
+                compile_pattern(pattern).map_err(|e| anyhow!("config field '{}': {e}", f.name))?;
             }
         }
         Ok(())
@@ -1151,9 +1265,17 @@ pub fn validate_custom_domain(d: &str) -> Result<String> {
 }
 
 /// Resolve a submitted `config` map against the app's `config` schema: required
-/// fields must be present, unknown keys rejected; returns the resolved map
-/// (submitted values ∪ declared defaults). Shared by the customer and admin
-/// APIs. `submitted` keys/values are the customer-supplied field values.
+/// fields must be present, unknown keys rejected, and every submitted value
+/// must satisfy its field's declared `type` and `pattern` (#271). Returns the
+/// resolved map (submitted values ∪ declared defaults). Shared by the customer
+/// and admin APIs. `submitted` keys/values are the customer-supplied field
+/// values.
+///
+/// The type check happens here, at order time, because here is the last moment
+/// the customer can still fix it. A value that reaches the operator is a value
+/// the customer has already paid for: HAVEN panics on an `owner_npub` that is
+/// not an npub, so before this the order was accepted and the deployment
+/// crashlooped with nothing on screen saying which character was wrong.
 pub fn resolve_config(
     compose: &Compose,
     submitted: &std::collections::BTreeMap<String, String>,
@@ -1167,12 +1289,21 @@ pub fn resolve_config(
     }
     let mut out = std::collections::BTreeMap::new();
     for field in &compose.config {
-        match submitted.get(&field.name).or(field.default.as_ref()) {
+        // An empty `int`/`bool` is "the customer left the box alone", not a
+        // value: a form that posts every field sends "" for the ones nobody
+        // touched, and failing those would reject an order over a field the
+        // app has a default for. An empty *string* is left alone — blank is a
+        // legitimate value there, and always has been.
+        let submitted_value = submitted.get(&field.name).filter(|v| {
+            !(v.trim().is_empty() && matches!(field.r#type, FieldType::Int | FieldType::Bool))
+        });
+        match submitted_value.or(field.default.as_ref()) {
             Some(v) => {
+                field.check_value(v)?;
                 out.insert(field.name.clone(), v.clone());
             }
             None if field.required => {
-                bail!("config field '{}' is required", field.name);
+                bail!("config field '{}' is required", field.display_label());
             }
             None => {}
         }
@@ -1799,6 +1930,96 @@ config:
         ))
         .unwrap();
         assert_eq!(ok.services["db"].scratch.len(), 2);
+    }
+
+    /// A declared `type` is enforced against a submitted value (#271) — before
+    /// this, `resolve_config` read `required` and never `type`.
+    #[test]
+    fn resolve_config_enforces_declared_types() {
+        let c = Compose::parse(
+            "services:\n  a:\n    image: x\n    env:\n      N: ${n}\n      B: ${b}\n      S: ${s}\n\
+             config:\n  - { name: n, label: \"Count\", type: int }\n  \
+             - { name: b, label: \"Enabled\", type: bool }\n  \
+             - { name: s, label: \"Name\", type: string }\n",
+        )
+        .unwrap();
+        let sub =
+            |k: &str, v: &str| std::collections::BTreeMap::from([(k.to_string(), v.to_string())]);
+
+        assert!(resolve_config(&c, &sub("n", "42")).is_ok());
+        assert!(resolve_config(&c, &sub("n", "-1")).is_ok());
+        assert!(resolve_config(&c, &sub("n", " 7 ")).is_ok(), "trimmed");
+        let err = resolve_config(&c, &sub("n", "abc"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Count"),
+            "names the label the customer saw: {err}"
+        );
+        assert!(err.contains("whole number"), "{err}");
+        assert!(resolve_config(&c, &sub("n", "1.5")).is_err());
+        // An empty int is an untouched form box, not a value: it falls back to
+        // the field's default (here: absent) rather than failing the order.
+        assert!(resolve_config(&c, &sub("n", "")).is_ok());
+        assert!(!resolve_config(&c, &sub("n", "")).unwrap().contains_key("n"));
+        assert!(resolve_config(&c, &sub("b", "  ")).is_ok());
+        // ...but a blank string is a legitimate value and is still stored.
+        assert_eq!(resolve_config(&c, &sub("s", "")).unwrap()["s"], "");
+
+        assert!(resolve_config(&c, &sub("b", "true")).is_ok());
+        assert!(resolve_config(&c, &sub("b", "false")).is_ok());
+        assert!(resolve_config(&c, &sub("b", "maybe")).is_err());
+        assert!(resolve_config(&c, &sub("b", "1")).is_err());
+
+        // A string is unconstrained unless the app declares a pattern.
+        assert!(resolve_config(&c, &sub("s", "anything at all")).is_ok());
+    }
+
+    /// A `pattern` is anchored, enforced at order time, and compiled at
+    /// authoring time — the npub case that produced a crashlooping, paid-for
+    /// deployment (#271).
+    #[test]
+    fn resolve_config_enforces_patterns() {
+        let npub = "npub1v0lxxxxutpvrelsksy8cdhgfux9l6a42hsj2qzquu2zk7vc9qnkszrqj49";
+        let c = Compose::parse(
+            "services:\n  a:\n    image: x\n    env:\n      O: ${owner_npub}\n\
+             config:\n  - { name: owner_npub, label: \"Owner npub\", type: string, \
+             required: true, pattern: \"npub1[02-9ac-hj-np-z]{58}\" }\n",
+        )
+        .unwrap();
+        let sub =
+            |v: &str| std::collections::BTreeMap::from([("owner_npub".to_string(), v.to_string())]);
+
+        assert!(resolve_config(&c, &sub(npub)).is_ok());
+        // One character out of the bech32 alphabet.
+        assert!(resolve_config(&c, &sub(&npub.replace("v0l", "b0l"))).is_err());
+        // Right shape, wrong length.
+        assert!(resolve_config(&c, &sub("npub1abc")).is_err());
+        // Anchored at both ends: a value that merely *contains* an npub is not
+        // an npub, and an unanchored pattern would have accepted both.
+        assert!(resolve_config(&c, &sub(&format!("{npub}junk"))).is_err());
+        assert!(resolve_config(&c, &sub(&format!("junk{npub}"))).is_err());
+        let err = resolve_config(&c, &sub("nope")).unwrap_err().to_string();
+        assert!(err.contains("Owner npub"), "{err}");
+
+        // A pattern that does not compile is the author's error, refused when
+        // the app is created rather than at a customer's order.
+        assert!(
+            Compose::parse(
+                "services:\n  a:\n    image: x\n    env:\n      O: ${o}\n\
+                 config:\n  - { name: o, type: string, pattern: \"[unclosed\" }\n"
+            )
+            .is_err()
+        );
+        // As is a default its own field would reject — authoring-time only, so
+        // a row stored before the rule still renders.
+        let bad_default = Compose::parse(
+            "services:\n  a:\n    image: x\n    env:\n      N: ${n}\n\
+             config:\n  - { name: n, type: int, default: \"abc\" }\n",
+        )
+        .unwrap();
+        assert!(bad_default.validate_declarations().is_err());
+        assert!(resolve_config(&bad_default, &std::collections::BTreeMap::new()).is_err());
     }
 
     #[test]

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -958,6 +958,94 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    /// A config field's `pattern` is compiled — and its `default` checked
+    /// against its own field — when the app is created or updated (#271), so a
+    /// broken constraint is the author's error rather than a customer's failed
+    /// order.
+    #[tokio::test]
+    async fn test_admin_app_compose_config_constraints() {
+        let client = setup().await;
+        let suffix = nostr::Keys::generate().public_key().to_hex()[..8].to_string();
+        let slug = format!("e2e-cfg-{suffix}");
+
+        let compose = |config: &str| {
+            format!(
+                "services:\n  web:\n    image: example/web:latest\n    user: \"1000\"\n    \
+                 ports:\n      - {{ name: http, container: 80, protocol: http, expose: ingress }}\n    \
+                 env:\n      V: ${{v}}\n\
+                 config:\n  - {config}\n"
+            )
+        };
+        let body = |compose: String| {
+            serde_json::json!({
+                "name": slug,
+                "display_name": "Config Constraints",
+                "category": "Nostr relay",
+                "compose": compose,
+                "amount": 1000,
+                "currency": "usd",
+                "interval_amount": 1,
+                "interval_type": "month",
+                "setup_amount": 0
+            })
+        };
+
+        // A pattern that does not compile.
+        let resp = client
+            .post_auth(
+                "/api/admin/v1/apps",
+                &body(compose("{ name: v, type: string, pattern: \"[unclosed\" }")),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let err = resp.text().await.unwrap();
+        assert!(err.contains("not a valid regex"), "{err}");
+
+        // A default its own field would reject at order time.
+        let resp = client
+            .post_auth(
+                "/api/admin/v1/apps",
+                &body(compose("{ name: v, type: int, default: \"abc\" }")),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let err = resp.text().await.unwrap();
+        assert!(err.contains("default is invalid"), "{err}");
+
+        // Valid: stored, and the same rules apply on update.
+        let resp = client
+            .post_auth(
+                "/api/admin/v1/apps",
+                &body(compose(
+                    "{ name: v, type: string, pattern: \"npub1[02-9ac-hj-np-z]{58}\" }",
+                )),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let created: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        let app_id = created["data"]["id"].as_u64().expect("app id");
+
+        let resp = client
+            .patch_auth(
+                &format!("/api/admin/v1/apps/{app_id}"),
+                &serde_json::json!({
+                    "compose": compose("{ name: v, type: string, pattern: \"[unclosed\" }")
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
     /// A generated secret can declare its byte length (issue #243), and an
     /// unusable length is refused when the app is created or updated rather
     /// than becoming an app that deploys and crash-loops on its own key.

--- a/lnvps_e2e/src/db.rs
+++ b/lnvps_e2e/src/db.rs
@@ -658,6 +658,44 @@ pub async fn seed_app_and_cluster_with_capacity(
     Ok((app_id, cluster_id, region_id))
 }
 
+/// Seed an orderable app whose `config:` declares a typed field and a
+/// pattern-constrained one, for the order-time validation in issue #271.
+///
+/// Returns `(app_id, region_id)`.
+pub async fn seed_app_with_typed_config(pool: &MySqlPool) -> anyhow::Result<(u64, u64)> {
+    let suffix = hex::encode(&rand_bytes32()[..4]);
+    let region_id = seed_enabled_region(pool, &format!("e2e-typed-{suffix}")).await?;
+    let compose = "services:\n  web:\n    image: example/web:latest\n    ports:\n      \
+         - { name: http, container: 80, protocol: http, expose: ingress }\n    env:\n      \
+         COUNT: ${count}\n      OWNER: ${owner_npub}\n\
+         config:\n  - { name: count, label: \"Count\", type: int, default: \"1\" }\n  \
+         - { name: owner_npub, label: \"Owner npub\", type: string, required: true, \
+         pattern: \"npub1[02-9ac-hj-np-z]{58}\" }\n";
+    let (app_id,): (u64,) = sqlx::query_as(
+        "INSERT INTO app (name, display_name, description, icon, category, compose, amount, \
+             currency, interval_amount, interval_type, setup_amount, enabled, cpu_milli, \
+             memory_bytes, storage_bytes) \
+         VALUES (?, 'E2E Typed Config', NULL, NULL, 'Nostr relay', ?, \
+             1000, 'USD', 1, 1, 0, 1, 250, 268435456, 0) RETURNING id",
+    )
+    .bind(format!("typed-{suffix}"))
+    .bind(compose)
+    .fetch_one(pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO app_cluster (name, region_id, ingress_domain, enabled, capacity_cpu_milli, \
+             capacity_memory_bytes, capacity_storage_bytes) \
+         VALUES (?, ?, 'apps.e2e.example.com', 1, 100000, 100000000000, 100000000000)",
+    )
+    .bind(format!("typedcluster-{suffix}"))
+    .bind(region_id)
+    .execute(pool)
+    .await?;
+
+    Ok((app_id, region_id))
+}
+
 /// Seed an enabled app whose compose declares one labelled and one unlabelled
 /// volume, for the per-volume storage breakdown (issue #260). Returns its id.
 ///

--- a/lnvps_e2e/src/user_api.rs
+++ b/lnvps_e2e/src/user_api.rs
@@ -1239,6 +1239,85 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
+    /// Declared config types and patterns are enforced at order time (#271).
+    /// Before this, `resolve_config` read `required` and never `type`, so a
+    /// value the app cannot use was accepted, charged for, and turned into a
+    /// crashlooping deployment — HAVEN panics on an `owner_npub` that is not an
+    /// npub, and nothing on screen named the field.
+    #[tokio::test]
+    async fn test_app_order_validates_config_field_types() {
+        let client = user_client_with_keys(nostr::Keys::generate());
+        let pool = crate::db::connect().await.unwrap();
+        let (app_id, region_id) = crate::db::seed_app_with_typed_config(&pool).await.unwrap();
+        let npub = "npub1v0lxxxxutpvrelsksy8cdhgfux9l6a42hsj2qzquu2zk7vc9qnkszrqj49";
+
+        let order = |name: &str, config: Value| {
+            serde_json::json!({
+                "app_id": app_id,
+                "name": name,
+                "region_id": region_id,
+                "config": config
+            })
+        };
+        let post = async |body: Value| -> (StatusCode, String) {
+            let resp = client
+                .post_auth("/api/v1/app-deployments", &body)
+                .await
+                .unwrap();
+            let status = resp.status();
+            (status, resp.text().await.unwrap())
+        };
+
+        // A non-integer `int` is refused, naming the label the customer typed
+        // into rather than the internal field name.
+        let (status, body) = post(order(
+            "typed-bad-int",
+            serde_json::json!({ "count": "abc", "owner_npub": npub }),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("Count"), "{body}");
+
+        // A value that is not an npub is refused by the declared pattern.
+        let (status, body) = post(order(
+            "typed-bad-npub",
+            serde_json::json!({ "count": "2", "owner_npub": "not-an-npub" }),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("Owner npub"), "{body}");
+
+        // The pattern is anchored: an npub with junk appended is not an npub.
+        let (status, _) = post(order(
+            "typed-trailing",
+            serde_json::json!({ "count": "2", "owner_npub": format!("{npub}x") }),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // Valid values order normally.
+        let (status, body) = post(order(
+            "typed-ok",
+            serde_json::json!({ "count": "2", "owner_npub": npub }),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+
+        // ...and the same rules apply to a config PATCH on the deployment, not
+        // just to the order.
+        let created: Value = serde_json::from_str(&body).unwrap();
+        let dep_id = created["data"]["id"].as_u64().expect("deployment id");
+        let resp = client
+            .patch_auth(
+                &format!("/api/v1/app-deployments/{dep_id}"),
+                &serde_json::json!({ "config": { "count": "nope", "owner_npub": npub } }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(resp.text().await.unwrap().contains("Count"));
+    }
+
     /// An unpaid order must not consume cluster capacity (#252). Nostr keys are
     /// free, so anyone can create deployments without paying; before the fix
     /// each one was counted against the cluster and could make a paying


### PR DESCRIPTION
Closes #271.

`resolve_config` enforced `required` and rejected unknown keys, and never looked at `type`. `FieldType` was declared, carried through the admin API, rendered as a form input — and ignored at the one moment it mattered, so an `int` field accepted `abc` and a `string` field accepted anything at all.

That is a validation gap until an app is strict about the value. HAVEN panics in `nPubToPubkey` on an `owner_npub` that is not an npub, so one mistyped character was accepted at order time, charged for, and became a deployment that restarted forever with nothing on screen naming the field.

## What changes

- **`type` is enforced at order time.** `int` must parse as a whole number, `bool` must be `true`/`false`. Applies to `POST /api/v1/app-deployments`, the config `PATCH`, and the admin order path — they share `resolve_config`.
- **A field may declare `pattern`**, a regex the value must match:

  ```yaml
  config:
    - { name: owner_npub, label: "Owner npub", type: string, required: true,
        pattern: "npub1[02-9ac-hj-np-z]{58}" }
  ```

  HAVEN's `owner_npub` and Buzz's `owner_pubkey` now carry one in `docs/managed-app-examples.md`.
- **Errors name the field's label**, not its internal name — the customer typed into a box labelled "Owner npub".

## Three decisions worth reviewing

- **Patterns are anchored by the platform, not the author.** `npub1…` without `^…$` accepts a value with junk on either end — precisely the mistake that produces the crashloop this closes. The pattern is wrapped (`^(?:…)$`), not rewritten, so an author's own anchors still mean what they say.
- **Where each check runs.** A `pattern` must compile in `validate()`, which the operator runs on stored rows — safe only because the field is new, so no stored row can carry one predating the rule. A `default` is checked against its own field in `validate_declarations()`, the authoring-only gate, so an app stored before this keeps rendering and is caught the next time an admin edits it. That split follows the precedent set when `${…}` declaration-checking was added.
- **An empty `int`/`bool` is an untouched form box, not a value.** A form that posts every field sends `""` for the ones nobody filled in; those fall back to the field's default rather than failing the order. An empty **string** is unchanged — blank is a legitimate value there. @Marta, this is the one that could have bitten the deploy form.

## Breaking-ish

An order that previously succeeded with a garbage `int`/`bool` now returns `400`. That is the point of the issue, and it is recorded in `API_CHANGELOG.md`. No existing app definition is affected: no field declares a `pattern` yet.

**The live catalog rows for HAVEN and Buzz need the same `pattern` edit** — no migration performs it, same as the `scratch:` and `/media` backfills.

## Tests

- `resolve_config_enforces_declared_types`, `resolve_config_enforces_patterns` (`lnvps_compose`) — int/bool acceptance and rejection, the label in the message, anchoring at both ends (a value that merely *contains* an npub is refused), an uncompilable pattern refused at parse, a bad default refused by `validate_declarations`, and the empty-value rule.
- `test_app_order_validates_config_field_types` (e2e) — bad int, bad npub and an npub with a trailing character all `400` over HTTP with the label in the body; valid values order; the same rules on the config `PATCH`.
- `test_admin_app_compose_config_constraints` (e2e) — an uncompilable pattern and an invalid default are `400` at app create, and on update.

`cargo test --workspace` green and `lnvps_e2e` green via `scripts/run-e2e.sh` (155 passed) at `d544e4c`. `cargo clippy` produces the same 317 warnings as master (no new lints) and `cargo fmt` is clean on every file touched.

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
