### PR TITLE
feat(apps): reconcile a deployment when its payment settles, not at the next poll (#254)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,7 @@ dependencies = [
  "env_logger",
  "k8s-openapi",
  "kube",
+ "lnvps_api_common",
  "lnvps_compose",
  "lnvps_db",
  "log 0.4.32",
@@ -3082,6 +3083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/docs/config.md
+++ b/docs/config.md
@@ -311,9 +311,18 @@ service-name: "lnvps-nostr"
 port-name: "http"
 cluster-issuer: "letsencrypt-prod"
 ingress-class: "nginx"
+app-cluster-id: 1             # managed apps: the cluster this operator serves
+redis: "redis://localhost:6379"   # reconcile on payment instead of at the next poll
 annotations:
   nginx.ingress.kubernetes.io/ssl-redirect: "true"
 ```
+
+`redis` is optional and only meaningful alongside `app-cluster-id`: the operator
+consumes `app-cluster-{id}` and reconciles a deployment as soon as its payment
+settles, rather than up to `reconcile-interval` later. Point it at the same
+Redis the API publishes to. The periodic reconcile remains the backstop, so a
+lost trigger is a delay rather than a deployment that never happens; omit the
+key to poll only.
 
 ---
 

--- a/lnvps_api/src/subscription/app.rs
+++ b/lnvps_api/src/subscription/app.rs
@@ -14,21 +14,58 @@
 use crate::subscription::{AppUpgradeConfig, SubscriptionLineItemHandler};
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
+use lnvps_api_common::{WorkCommander, WorkJob, app_cluster_stream};
 use lnvps_db::{
     LNVpsDb, Subscription, SubscriptionLineItem, SubscriptionPayment, SubscriptionPaymentType,
 };
-use log::info;
+use log::{info, warn};
 use std::sync::Arc;
 
 pub struct AppLineItemHandler {
     db: Arc<dyn LNVpsDb>,
     /// The line item this handler fulfils.
     line_item_id: u64,
+    /// Publisher for the operator's per-cluster reconcile stream (#254).
+    tx: Arc<dyn WorkCommander>,
 }
 
 impl AppLineItemHandler {
-    pub fn new(db: Arc<dyn LNVpsDb>, line_item_id: u64) -> Self {
-        Self { db, line_item_id }
+    pub fn new(db: Arc<dyn LNVpsDb>, line_item_id: u64, tx: Arc<dyn WorkCommander>) -> Self {
+        Self {
+            db,
+            line_item_id,
+            tx,
+        }
+    }
+
+    /// Ask the operator serving this deployment's cluster to reconcile it now
+    /// (issue #254).
+    ///
+    /// Without this the customer waits for the next poll — up to a full
+    /// `reconcile_interval`, 60s by default — before anything moves, and after
+    /// #252 that wait is in front of the whole provisioning sequence
+    /// (namespace, secrets, PVCs, Ingress and a Let's Encrypt round-trip)
+    /// rather than in front of a replica scale.
+    ///
+    /// Failure is logged, not propagated: the payment has settled and the
+    /// periodic reconcile still picks the deployment up. Turning a Redis blip
+    /// into a failed payment callback would be strictly worse than being 60
+    /// seconds late.
+    async fn trigger_reconcile(&self, deployment_id: u64, cluster_id: u64) {
+        let stream = app_cluster_stream(cluster_id);
+        match self
+            .tx
+            .send_to_stream(&stream, WorkJob::ReconcileAppDeployment { deployment_id })
+            .await
+        {
+            Ok(_) => {
+                info!("Requested immediate reconcile of app deployment {deployment_id} on {stream}")
+            }
+            Err(e) => warn!(
+                "Could not request immediate reconcile of app deployment {deployment_id} on \
+                 {stream}: {e} — the operator's periodic reconcile will still pick it up"
+            ),
+        }
     }
 }
 
@@ -90,12 +127,30 @@ impl SubscriptionLineItemHandler for AppLineItemHandler {
                 li.amount = app.amount * cfg.new_multiplier as u64;
                 self.db.update_subscription_line_item(&li).await?;
             }
+            // The resize is only real once the operator applies it, so ask for
+            // that now rather than at the next poll (#254).
+            self.trigger_reconcile(dep.id, dep.cluster_id).await;
             return Ok(());
         }
 
-        // The subscription is marked set up by `subscription_payment_paid`; the
-        // operator provisions the deployment on its next reconcile. Nothing to
-        // do synchronously here.
+        // The subscription is marked set up by `subscription_payment_paid`, and
+        // the operator is what provisions the deployment — so the only thing to
+        // do here is tell it not to wait for its next poll (#254). Nothing is
+        // provisioned synchronously on this path.
+        match self
+            .db
+            .get_app_deployment_by_line_item(self.line_item_id)
+            .await
+        {
+            Ok(dep) => self.trigger_reconcile(dep.id, dep.cluster_id).await,
+            // No deployment for a paid app line item is a wiring fault, but the
+            // payment itself is settled and this is only a latency optimisation
+            // — log it rather than failing the callback.
+            Err(e) => warn!(
+                "App line item {} paid but no deployment found to reconcile: {e}",
+                self.line_item_id
+            ),
+        }
         Ok(())
     }
 
@@ -259,18 +314,104 @@ mod tests {
         .unwrap()
     }
 
-    /// Payment + expiry are no-ops (the operator handles provisioning/scaling);
-    /// they must not touch the deployment.
+    /// Records what was published, and to which stream — the stream name is
+    /// the routing (#254), so a test that ignored it would not be testing much.
+    #[derive(Default)]
+    struct RecordingCommander {
+        sent: std::sync::Mutex<Vec<(String, WorkJob)>>,
+    }
+
+    impl RecordingCommander {
+        fn sent(&self) -> Vec<(String, WorkJob)> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl WorkCommander for RecordingCommander {
+        async fn send(&self, job: WorkJob) -> Result<String> {
+            self.sent
+                .lock()
+                .unwrap()
+                .push((lnvps_api_common::DEFAULT_WORK_STREAM.to_string(), job));
+            Ok("1".to_string())
+        }
+        async fn send_to_stream(&self, stream: &str, job: WorkJob) -> Result<String> {
+            self.sent.lock().unwrap().push((stream.to_string(), job));
+            Ok("1".to_string())
+        }
+        async fn recv(&self) -> Result<Vec<lnvps_api_common::WorkJobMessage>> {
+            Ok(vec![])
+        }
+        async fn ack(&self, _id: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A commander whose sends always fail, standing in for a Redis outage.
+    struct FailingCommander;
+
+    #[async_trait]
+    impl WorkCommander for FailingCommander {
+        async fn send(&self, _job: WorkJob) -> Result<String> {
+            Err(anyhow!("redis is down"))
+        }
+        async fn recv(&self) -> Result<Vec<lnvps_api_common::WorkJobMessage>> {
+            Ok(vec![])
+        }
+        async fn ack(&self, _id: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Payment and expiry still leave the deployment row alone — the operator
+    /// provisions and scales it. Payment now also asks that operator to
+    /// reconcile immediately (#254) instead of waiting up to a full poll.
     #[tokio::test]
-    async fn payment_and_expiry_are_noops() {
+    async fn payment_triggers_reconcile_without_touching_the_deployment() {
         let db = std::sync::Arc::new(MockDb::default());
         let id = seed_deployment(&db, 5).await;
-        let h = AppLineItemHandler::new(db.clone(), 5);
+        let tx = std::sync::Arc::new(RecordingCommander::default());
+        let h = AppLineItemHandler::new(db.clone(), 5, tx.clone());
 
         h.on_payment(&payment()).await.unwrap();
         h.on_expired(&subscription(), &line_item(5)).await.unwrap();
 
         assert!(!db.get_app_deployment(id).await.unwrap().deleted);
+        // Addressed to the cluster the deployment runs on, naming the
+        // deployment — the operator serving another cluster never sees it.
+        let sent = tx.sent();
+        assert_eq!(sent.len(), 1, "one trigger, on payment only: {sent:?}");
+        assert_eq!(sent[0].0, "app-cluster-1");
+        assert!(
+            matches!(sent[0].1, WorkJob::ReconcileAppDeployment { deployment_id } if deployment_id == id)
+        );
+    }
+
+    /// A trigger that cannot be published must not fail the payment callback:
+    /// the money has settled, and the operator's periodic reconcile is the
+    /// backstop (#254).
+    #[tokio::test]
+    async fn payment_survives_a_dead_trigger_queue() {
+        let db = std::sync::Arc::new(MockDb::default());
+        let id = seed_deployment(&db, 21).await;
+        let h = AppLineItemHandler::new(db.clone(), 21, std::sync::Arc::new(FailingCommander));
+
+        h.on_payment(&payment()).await.unwrap();
+
+        assert!(!db.get_app_deployment(id).await.unwrap().deleted);
+    }
+
+    /// Nor may a paid line item with no deployment row: it is a wiring fault
+    /// worth logging, not a reason to fail a settled payment.
+    #[tokio::test]
+    async fn payment_survives_a_missing_deployment() {
+        let db = std::sync::Arc::new(MockDb::default());
+        let tx = std::sync::Arc::new(RecordingCommander::default());
+        let h = AppLineItemHandler::new(db.clone(), 404, tx.clone());
+
+        h.on_payment(&payment()).await.unwrap();
+        assert!(tx.sent().is_empty());
     }
 
     /// Grace period exceeded soft-deletes the deployment so the operator GCs it.
@@ -278,7 +419,11 @@ mod tests {
     async fn grace_period_soft_deletes_deployment() {
         let db = std::sync::Arc::new(MockDb::default());
         let id = seed_deployment(&db, 7).await;
-        let h = AppLineItemHandler::new(db.clone(), 7);
+        let h = AppLineItemHandler::new(
+            db.clone(),
+            7,
+            std::sync::Arc::new(RecordingCommander::default()),
+        );
 
         h.on_grace_period_exceeded(&subscription(), &line_item(7))
             .await
@@ -300,7 +445,8 @@ mod tests {
             let mut items = db.subscription_line_items.lock().await;
             items.insert(11, line_item(11));
         }
-        let h = AppLineItemHandler::new(db.clone(), 11);
+        let tx = std::sync::Arc::new(RecordingCommander::default());
+        let h = AppLineItemHandler::new(db.clone(), 11, tx.clone());
 
         let mut p = payment();
         p.payment_type = SubscriptionPaymentType::Upgrade;
@@ -316,6 +462,11 @@ mod tests {
             4000,
             "line item repriced to app.amount x multiplier"
         );
+        // A resize is only real once the operator applies it, so it asks for a
+        // reconcile too (#254).
+        let sent = tx.sent();
+        assert_eq!(sent.len(), 1, "{sent:?}");
+        assert_eq!(sent[0].0, "app-cluster-1");
     }
 
     /// An upgrade payment must never shrink a deployment: PVCs cannot shrink,
@@ -333,7 +484,11 @@ mod tests {
             let mut items = db.subscription_line_items.lock().await;
             items.insert(12, line_item(12));
         }
-        let h = AppLineItemHandler::new(db.clone(), 12);
+        let h = AppLineItemHandler::new(
+            db.clone(),
+            12,
+            std::sync::Arc::new(RecordingCommander::default()),
+        );
 
         let mut p = payment();
         p.payment_type = SubscriptionPaymentType::Upgrade;
@@ -360,7 +515,11 @@ mod tests {
     async fn upgrade_payment_with_unusable_metadata_errors() {
         let db = std::sync::Arc::new(MockDb::default());
         let id = seed_deployment(&db, 13).await;
-        let h = AppLineItemHandler::new(db.clone(), 13);
+        let h = AppLineItemHandler::new(
+            db.clone(),
+            13,
+            std::sync::Arc::new(RecordingCommander::default()),
+        );
 
         // No metadata at all.
         let mut p = payment();
@@ -391,7 +550,11 @@ mod tests {
     #[tokio::test]
     async fn grace_period_no_deployment_is_ok() {
         let db = std::sync::Arc::new(MockDb::default());
-        let h = AppLineItemHandler::new(db.clone(), 99);
+        let h = AppLineItemHandler::new(
+            db.clone(),
+            99,
+            std::sync::Arc::new(RecordingCommander::default()),
+        );
         h.on_grace_period_exceeded(&subscription(), &line_item(99))
             .await
             .unwrap();

--- a/lnvps_api/src/subscription/mod.rs
+++ b/lnvps_api/src/subscription/mod.rs
@@ -232,7 +232,11 @@ impl SubscriptionHandler {
                 self.ip_range_provisioner.clone(),
                 li.id,
             ))),
-            SubscriptionType::App => Ok(Box::new(AppLineItemHandler::new(self.db.clone(), li.id))),
+            SubscriptionType::App => Ok(Box::new(AppLineItemHandler::new(
+                self.db.clone(),
+                li.id,
+                self.tx.clone(),
+            ))),
             // Exhaustive on purpose (no catch-all): adding a new SubscriptionType
             // must fail to compile until a handler is wired here, rather than
             // silently falling through. These variants have no ordering flow yet,

--- a/lnvps_api/src/worker.rs
+++ b/lnvps_api/src/worker.rs
@@ -2051,6 +2051,16 @@ impl Worker {
                 let vm = self.db.get_vm(*vm_id).await?;
                 self.check_vm(&vm).await?;
             }
+            // Addressed to an operator, not to this worker: it is published to
+            // a per-cluster stream (#254) and only reaches here if someone
+            // sends it to the general queue by mistake. Nothing to do — the
+            // operator's own poll is the backstop either way.
+            WorkJob::ReconcileAppDeployment { deployment_id } => {
+                warn!(
+                    "Ignoring ReconcileAppDeployment({deployment_id}) on the worker queue: it \
+                     belongs on the deployment's app-cluster stream"
+                );
+            }
             WorkJob::SpawnVm { vm_id } => {
                 let vm = self.db.get_vm(*vm_id).await?;
                 if vm.mac_address == "ff:ff:ff:ff:ff:ff" {

--- a/lnvps_api_common/src/work/mod.rs
+++ b/lnvps_api_common/src/work/mod.rs
@@ -21,6 +21,14 @@ pub struct WorkJobMessage {
 #[async_trait]
 pub trait WorkCommander: Send + Sync {
     async fn send(&self, job: WorkJob) -> Result<String>;
+    /// Send to a named stream instead of the default one.
+    ///
+    /// Defaults to [`WorkCommander::send`], which is right for the in-process
+    /// implementations (one queue, one consumer) and is overridden by the Redis
+    /// one, where the stream name is what routes a job to the right consumer.
+    async fn send_to_stream(&self, _stream: &str, job: WorkJob) -> Result<String> {
+        self.send(job).await
+    }
     async fn recv(&self) -> Result<Vec<WorkJobMessage>>;
     async fn ack(&self, id: &str) -> Result<()>;
 }
@@ -200,6 +208,24 @@ pub enum WorkJob {
         ip_range_id: u64,
         admin_user_id: Option<u64>,
     },
+    /// Reconcile one managed-app deployment now, rather than at the operator's
+    /// next poll (issue #254).
+    ///
+    /// Published to the deployment's cluster stream ([`app_cluster_stream`]) by
+    /// the payment path, and consumed by the operator serving that cluster. The
+    /// periodic reconcile stays as the backstop: a dropped trigger must be a
+    /// delay, not a deployment that never happens.
+    ReconcileAppDeployment { deployment_id: u64 },
+}
+
+/// Redis stream carrying reconcile triggers for one app cluster (issue #254).
+///
+/// Per cluster, not global: an operator serves exactly one cluster
+/// (`Settings::app_cluster_id`), so keying the stream by cluster is what routes
+/// a trigger to the operator that can act on it — without the API needing to
+/// discover N operators.
+pub fn app_cluster_stream(cluster_id: u64) -> String {
+    format!("app-cluster-{cluster_id}")
 }
 
 impl WorkJob {
@@ -218,6 +244,9 @@ impl WorkJob {
             // A reinstall is a one-shot action tied to a waiting user request;
             // don't let the worker silently retry it later.
             Self::ReinstallVm { .. } => true,
+            // The periodic reconcile is the backstop, so a failed trigger costs
+            // at most one interval — not worth retrying and blocking the stream.
+            Self::ReconcileAppDeployment { .. } => true,
             _ => false,
         }
     }
@@ -226,6 +255,7 @@ impl WorkJob {
 impl fmt::Display for WorkJob {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            WorkJob::ReconcileAppDeployment { .. } => write!(f, "ReconcileAppDeployment"),
             WorkJob::PatchHosts => write!(f, "PatchHosts"),
             WorkJob::CheckVms => write!(f, "CheckVms"),
             WorkJob::CheckVm { .. } => write!(f, "CheckVm"),

--- a/lnvps_api_common/src/work/sender.rs
+++ b/lnvps_api_common/src/work/sender.rs
@@ -12,16 +12,33 @@ use redis::{AsyncCommands, FromRedisValue};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
+/// Default stream: the general worker queue the API's worker process consumes.
+pub const DEFAULT_WORK_STREAM: &str = "worker";
+
 #[derive(Clone)]
 pub struct RedisWorkCommander {
     redis: redis::Client,
     conn: MultiplexedConnection,
     group_name: String,
     consumer_name: String,
+    /// Stream this commander reads from, and writes to unless
+    /// [`WorkCommander::send_to_stream`] names another.
+    stream: String,
 }
 
 impl RedisWorkCommander {
     pub async fn new(redis_url: &str, group_name: &str, consumer_name: &str) -> Result<Self> {
+        Self::new_for_stream(redis_url, DEFAULT_WORK_STREAM, group_name, consumer_name).await
+    }
+
+    /// A commander bound to a named stream — the operator's per-cluster
+    /// reconcile queue (issue #254), where the stream name is the routing.
+    pub async fn new_for_stream(
+        redis_url: &str,
+        stream: &str,
+        group_name: &str,
+        consumer_name: &str,
+    ) -> Result<Self> {
         let redis = redis::Client::open(redis_url)?;
         let conn = redis.get_multiplexed_async_connection().await?;
         Ok(Self {
@@ -29,6 +46,7 @@ impl RedisWorkCommander {
             redis,
             group_name: group_name.to_string(),
             consumer_name: consumer_name.to_string(),
+            stream: stream.to_string(),
         })
     }
 
@@ -44,13 +62,14 @@ impl RedisWorkCommander {
             redis,
             group_name: String::new(),
             consumer_name: String::new(),
+            stream: DEFAULT_WORK_STREAM.to_string(),
         })
     }
 
     pub async fn ensure_group_exists(&self, conn: &mut MultiplexedConnection) -> Result<()> {
         // Try to create the group with MKSTREAM option, ignore error if it already exists
         let _: Result<String, _> = conn
-            .xgroup_create_mkstream("worker", &self.group_name, "$")
+            .xgroup_create_mkstream(&self.stream, &self.group_name, "$")
             .await;
         Ok(())
     }
@@ -72,7 +91,9 @@ impl RedisWorkCommander {
             .block(100)
             .group(&self.group_name, &self.consumer_name);
 
-        let results: StreamReadReply = conn.xread_options(&["worker"], &[">"], &opts).await?;
+        let results: StreamReadReply = conn
+            .xread_options(&[self.stream.as_str()], &[">"], &opts)
+            .await?;
         let mut jobs = Vec::new();
         for stream_key in results.keys {
             jobs.extend(stream_key.ids.iter().filter_map(Self::map_work_job));
@@ -89,7 +110,7 @@ impl RedisWorkCommander {
         // Parse pending messages and claim them
         let jobs: StreamAutoClaimReply = conn
             .xautoclaim_options(
-                "worker",
+                self.stream.as_str(),
                 &self.group_name,
                 &self.consumer_name,
                 10_000,
@@ -132,6 +153,16 @@ impl RedisWorkCommander {
 
 #[async_trait]
 impl WorkCommander for RedisWorkCommander {
+    async fn send_to_stream(&self, stream: &str, job: WorkJob) -> Result<String> {
+        let job_json = serde_json::to_string(&job)?;
+        let fields = &[("job", job_json.as_str())];
+        let mut conn = self.conn.clone();
+        let opts = StreamAddOptions::default()
+            .trim(StreamTrimStrategy::maxlen(StreamTrimmingMode::Approx, 1000));
+        let id: String = conn.xadd_options(stream, "*", fields, &opts).await?;
+        Ok(id)
+    }
+
     async fn send(&self, job: WorkJob) -> Result<String> {
         let job_json = serde_json::to_string(&job)?;
 
@@ -140,7 +171,9 @@ impl WorkCommander for RedisWorkCommander {
         let mut conn = self.conn.clone();
         let opts = StreamAddOptions::default()
             .trim(StreamTrimStrategy::maxlen(StreamTrimmingMode::Approx, 1000));
-        let id: String = conn.xadd_options("worker", "*", fields, &opts).await?;
+        let id: String = conn
+            .xadd_options(self.stream.as_str(), "*", fields, &opts)
+            .await?;
         Ok(id)
     }
 
@@ -150,7 +183,9 @@ impl WorkCommander for RedisWorkCommander {
 
     async fn ack(&self, id: &str) -> Result<()> {
         let mut conn = self.conn.clone();
-        let _: u64 = conn.xack("worker", &self.group_name, &[id]).await?;
+        let _: u64 = conn
+            .xack(self.stream.as_str(), &self.group_name, &[id])
+            .await?;
         Ok(())
     }
 }

--- a/lnvps_operator/Cargo.toml
+++ b/lnvps_operator/Cargo.toml
@@ -10,11 +10,13 @@ path = "src/main.rs"
 [dependencies]
 lnvps_db = { path = "../lnvps_db", features = ["nostr-domain"] }
 lnvps_compose = { path = "../lnvps_compose" }
+lnvps_api_common = { path = "../lnvps_api_common" }
 rand = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Workspace dependencies
 tokio = { workspace = true, features = ["time", "signal"] }
+uuid.workspace = true
 anyhow.workspace = true
 log.workspace = true
 env_logger.workspace = true

--- a/lnvps_operator/config.minimal.yaml
+++ b/lnvps_operator/config.minimal.yaml
@@ -22,6 +22,10 @@ cluster-issuer: "letsencrypt-prod"
 #   key-file: "/etc/lnvps/encryption.key"
 #   auto-generate: false
 
+# Reconcile immediately on payment instead of at the next poll (optional).
+# Same Redis the API publishes to; requires app-cluster-id.
+# redis: "redis://localhost:6379"
+
 # Ingress configuration (optional - defaults shown)
 # ingress-class: "nginx"
 # ingress-namespace: "ingress-nginx"

--- a/lnvps_operator/config.yaml
+++ b/lnvps_operator/config.yaml
@@ -37,6 +37,14 @@ encryption:
 # operator only manages nostr domains). Requires `encryption` (above).
 app-cluster-id: 1
 
+# Redis carrying reconcile triggers for this cluster (optional). Point it at
+# the same Redis the API uses. When set (with app-cluster-id), the operator
+# consumes `app-cluster-{id}` and reconciles a deployment as soon as its
+# payment settles, instead of waiting up to reconcile-interval. The periodic
+# reconcile stays as the backstop, so a lost trigger is a delay rather than a
+# deployment that never happens. Omit to poll only.
+redis: "redis://localhost:6379"
+
 # Namespace the ingress controller runs in (optional, defaults to
 # "ingress-nginx"). The per-deployment isolation NetworkPolicy allows inbound
 # traffic from this namespace; it must match that namespace's

--- a/lnvps_operator/src/main.rs
+++ b/lnvps_operator/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use config::{Config as ConfigBuilder, File};
 use kube::Client;
+use lnvps_api_common::{RedisWorkCommander, WorkCommander, WorkJob, app_cluster_stream};
 use lnvps_db::{LNVpsDb, LNVpsDbMysql};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -79,6 +80,16 @@ pub struct Settings {
     /// columns such as `app_deployment.config`; must match the API's key. The
     /// `LNVPS_ENCRYPTION_KEY` env var (hex) takes precedence over this file.
     pub encryption: Option<EncryptionConfig>,
+
+    /// Redis URL carrying reconcile triggers for this operator's app cluster
+    /// (optional; issue #254).
+    ///
+    /// When set — and `app_cluster_id` is set — the operator consumes
+    /// `app-cluster-{id}` and reconciles a deployment as soon as its payment
+    /// settles, instead of at the next poll. When unset the operator behaves
+    /// exactly as before: the periodic reconcile is the only trigger, and it
+    /// remains the backstop either way.
+    pub redis: Option<String>,
 }
 
 #[derive(Parser)]
@@ -169,11 +180,19 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Immediate reconcile on payment (#254). Optional: without a Redis URL the
+    // periodic loop above is the only trigger, which is the behaviour that
+    // shipped before this.
+    let trigger_task = trigger_listener(context.clone());
+
     // TODO: Add back the controller logic here
 
     tokio::select! {
         _ = reconciliation_task => {
             warn!("Reconciliation task stopped unexpectedly");
+        }
+        _ = trigger_task => {
+            warn!("Reconcile-trigger listener stopped unexpectedly");
         }
         _ = signal::ctrl_c() => {
             info!("Received shutdown signal");
@@ -182,6 +201,91 @@ async fn main() -> Result<()> {
 
     info!("LNVPS Operator shutting down");
     Ok(())
+}
+
+/// Consume this cluster's reconcile-trigger stream, reconciling on demand
+/// (issue #254).
+///
+/// Returns immediately (and so parks forever in the `select!`) when the
+/// operator has no Redis URL or serves no app cluster — an operator that only
+/// handles nostr domains has nothing to listen for.
+///
+/// A trigger names one deployment, but this runs the same full reconcile the
+/// timer does. That keeps one code path: the sweep is already idempotent, it
+/// re-reads the deployment's current row rather than trusting the message, and
+/// a stale or duplicated trigger therefore costs a sweep rather than producing
+/// a different outcome from the periodic one.
+async fn trigger_listener(ctx: Arc<Context>) {
+    let (Some(redis_url), Some(cluster_id)) =
+        (ctx.settings.redis.clone(), ctx.settings.app_cluster_id)
+    else {
+        info!("Reconcile triggers disabled (no redis url or app cluster); polling only");
+        std::future::pending::<()>().await;
+        return;
+    };
+    let stream = app_cluster_stream(cluster_id);
+    // One consumer group per cluster, and a consumer name that is unique per
+    // process: two operators serving the same cluster then share the work
+    // rather than each reconciling every trigger.
+    let consumer = format!("operator-{}", uuid::Uuid::new_v4());
+    let connected =
+        RedisWorkCommander::new_for_stream(&redis_url, &stream, "operator", &consumer).await;
+    let commander = match connected {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                "Could not connect to redis at {redis_url} for {stream}: {e} — falling back to \
+                 the periodic reconcile only"
+            );
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+    info!("Listening for reconcile triggers on {stream} as {consumer}");
+
+    loop {
+        let jobs = match commander.recv().await {
+            Ok(j) => j,
+            Err(e) => {
+                // A dropped connection must not kill the listener: the periodic
+                // reconcile keeps deployments correct meanwhile, and the next
+                // read re-establishes the connection.
+                warn!("Reconcile-trigger read failed on {stream}: {e}");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+        // One sweep per batch, not per message: the sweep already covers every
+        // deployment on this cluster, so five payments landing together are one
+        // reconcile rather than five identical ones.
+        let triggers: Vec<u64> = jobs
+            .iter()
+            .filter_map(|m| match m.job {
+                WorkJob::ReconcileAppDeployment { deployment_id } => Some(deployment_id),
+                _ => None,
+            })
+            .collect();
+        for m in jobs
+            .iter()
+            .filter(|m| !matches!(m.job, WorkJob::ReconcileAppDeployment { .. }))
+        {
+            warn!("Ignoring unexpected job on {stream}: {}", m.job);
+        }
+        if !triggers.is_empty() {
+            info!("Reconcile trigger for app deployment(s) {triggers:?}");
+            if let Err(e) = app_deployments::reconcile_app_deployments(&ctx).await {
+                error!("Triggered reconcile failed: {e}");
+            }
+        }
+        for msg in &jobs {
+            // Acked either way: a job this operator cannot act on must not be
+            // redelivered forever, and a failed reconcile is retried by the
+            // periodic loop rather than by the stream.
+            if let Err(e) = commander.ack(&msg.id).await {
+                warn!("Could not ack {} on {stream}: {e}", msg.id);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -208,6 +312,7 @@ mod tests {
         assert!(full.app_cluster_id.is_some());
         assert!(full.encryption.is_some());
         assert_eq!(full.ingress_namespace.as_deref(), Some("ingress-nginx"));
+        assert_eq!(full.redis.as_deref(), Some("redis://localhost:6379"));
         assert_eq!(
             full.encryption.unwrap().key_file,
             PathBuf::from("/etc/lnvps/encryption.key")
@@ -217,5 +322,8 @@ mod tests {
         let minimal = load("config.minimal.yaml");
         assert!(minimal.app_cluster_id.is_none());
         assert!(minimal.encryption.is_none());
+        // No redis: the periodic reconcile is the only trigger, which is what
+        // the operator did before #254.
+        assert!(minimal.redis.is_none());
     }
 }


### PR DESCRIPTION
Closes #254.

The operator was a pure polling loop — `interval.tick()` every `reconcile_interval` seconds (60 by default), nothing consuming a queue — and `AppLineItemHandler::on_payment` did nothing at all for a first payment. A customer paid and waited a median 30 seconds before anything moved.

That is small today only because everything is provisioned *before* payment, which is the bug #252 fixes. After it, payment is when provisioning starts: namespace, generated secrets, PVC binding, Service, Ingress and a Let's Encrypt issuance that is itself seconds to minutes. The pointless 60s sits at the front of all of it, on a screen the customer is watching.

## Mechanism

`AppLineItemHandler::on_payment` publishes `WorkJob::ReconcileAppDeployment { deployment_id }` to `app-cluster-{id}`; the operator serving that cluster consumes it and reconciles.

- **Per-cluster stream, not the shared `worker` queue.** An operator serves exactly one cluster (`Settings::app_cluster_id`), so the stream name *is* the routing — no service discovery from the API to N operators, and an operator never sees another cluster's triggers. `RedisWorkCommander` gains a stream name (defaulting to `worker`, so every existing user is unchanged) and the trait gains `send_to_stream`, defaulted to `send` so the in-process implementations need no changes.
- **The poll stays as the backstop.** An event-driven reconcile that drops a message is worse than a slow one. `redis:` is optional in the operator config — unset means exactly the previous behaviour — a failed publish is logged rather than failing a settled payment, and a lost message costs at most one interval.
- **A trigger names a deployment; the operator runs its normal sweep.** One code path, already idempotent, re-reading the current row rather than trusting the message, so a stale or duplicated trigger costs a sweep instead of producing a different outcome from the periodic one. Triggers arriving in one batch are coalesced into a single sweep.

Fired on **renewals** too, not just first payments — an expired deployment sits at 0 replicas and the renewal is exactly when it should come back — and on the **upgrade** branch, where the resize is only real once the operator applies it.

## Config

```yaml
# lnvps_operator config
app-cluster-id: 1
redis: "redis://localhost:6379"   # same Redis the API publishes to
```

Documented in `docs/config.md`, `lnvps_operator/config.yaml` and `config.minimal.yaml`; the example-config test asserts both the set and unset cases.

## What I did not do

- **No new deployment state.** Making the wait *legible* is #253/web#54, which is merged.
- **Did not shorten `reconcile_interval`.** It multiplies load across every deployment permanently to improve one rare moment; the issue rejects it and I agree.
- **Did not add a per-deployment reconcile path.** A second, narrower path would have to be kept in step with the sweep for no benefit I can measure — the sweep is already scoped to one cluster.

## Tests

- `payment_triggers_reconcile_without_touching_the_deployment` — one trigger, on the payment path only, addressed to `app-cluster-1` and naming the deployment; the row is still untouched (the operator provisions it).
- `payment_survives_a_dead_trigger_queue` — a commander whose sends always fail does not fail the payment callback.
- `payment_survives_a_missing_deployment` — a paid line item with no deployment row logs and publishes nothing.
- `upgrade_payment_applies_multiplier_and_reprices` — now also asserts the upgrade branch triggers.
- `example_configs_deserialize` — `redis:` present in the full config, absent in the minimal one.

`cargo test --workspace` green and `lnvps_e2e` green via `scripts/run-e2e.sh` (153 passed) at `a84beb5`. `cargo clippy` produces the same 317 warnings as master and `cargo fmt` is clean on every file touched.

One behaviour worth a reviewer's eye: `recv()` blocks 100ms and returns, so the listener wakes ~10×/second against Redis. That is the same shape as the API worker's existing loop; I kept parity rather than adding a sleep that would eat into the latency this exists to remove.

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
