### PR TITLE
fix(apps): a service with volumes must declare a user (#277)

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -60,6 +60,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   **Clients that treated `running` as "provisioned successfully" will now see `pending` for the first seconds of a deployment's life and `error` for one that cannot start.** Both were previously reported as `running`. `stopped` is unchanged and still answers the billing/lifecycle question — pair it with `billing_state` (issue #253) to tell "customer stopped it" from "never paid". When the operator cannot reach the API server to read health, it leaves the stored status alone rather than guessing.
 
+- **A managed-app service that declares `volumes:` must now declare `user:`** (issue #277) — enforced when an app is created or updated through the admin API; `POST`/`PATCH /api/admin/v1/apps` returns `400` for a compose that declares a data volume on a service with no user. Kubernetes chowns a freshly provisioned PVC to the pod's `fsGroup`, which the operator takes from the numeric compose `user:`; without one the volume mounts root-owned `0755` while the kubelet starts the container as whatever non-root UID the image names, so the app deploys, starts, and fails on its first write — on a fresh volume, every time, with nothing in the deployment's status saying so. `user: root` satisfies the rule: a root process can write to a root-owned volume.
+
+  Authoring-time only. An app definition stored before this rule keeps reconciling exactly as it did (the rendered pod is unchanged); it is caught the next time an admin edits it. No documented catalog app is affected — all thirteen services with volumes already declare a user.
+
 ### Added
 
 - **`billing_state` on an app deployment — `unpaid` / `active` / `expired`** (issue #253) — `ApiAppDeployment` (`GET /api/v1/app-deployments` and `/{id}`, and every endpoint returning a deployment) gains a nullable `billing_state` string. Additive: no existing field changes.

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -209,6 +209,14 @@ past its limit. Something that needs more than that is storage — declare a
 An `init:` step already gets a writable `/tmp`. If the service declares
 `scratch:` at `/tmp` the step shares that one instead.
 
+**A service with `volumes:` must declare `user:`** (issue #277), and app
+create/update refuses one that does not. Kubernetes chowns a freshly
+provisioned PVC to the pod's `fsGroup`, the operator takes that from the numeric
+`user:`, and without one the volume mounts root-owned `0755` while the kubelet
+starts the container as whatever non-root UID the image names — so the app comes
+up and fails on its first write, on a fresh volume, every time. `user: root` is
+a valid answer: a root process can write to a root-owned volume.
+
 `user` also accepts a **numeric UID** (e.g. `user: "1000"`), which is required
 when the image's Dockerfile sets `USER` to a *name* rather than a number (e.g.
 `USER nonroot`). The kubelet enforces `runAsNonRoot` by reading the image

--- a/lnvps_compose/src/lib.rs
+++ b/lnvps_compose/src/lib.rs
@@ -723,6 +723,34 @@ impl Compose {
                     .map_err(|e| anyhow!("config field '{}': default is invalid: {e}", f.name))?;
             }
         }
+        // A service with a data volume must say who writes to it (issue #277).
+        //
+        // Kubernetes chowns a freshly provisioned PVC to the pod's `fsGroup`,
+        // and the operator takes that from the numeric compose `user:`. Declare
+        // volumes without one and there is no fsGroup, so the volume mounts
+        // root-owned `0755` while the kubelet — under `runAsNonRoot` with no
+        // `runAsUser` — starts the container as whatever non-root UID the image
+        // names. The app then comes up and fails on its first write, on a fresh
+        // volume, every time.
+        //
+        // `user: root` is a valid answer here: a root process can write to a
+        // root-owned volume. The unusable combination is specifically volumes
+        // plus silence.
+        //
+        // Authoring-time only, like the rest of this function: a row stored
+        // before the rule keeps reconciling (its pod is unchanged by this), and
+        // it is caught the next time an admin edits it.
+        for (sname, svc) in &self.services {
+            if !svc.volumes.is_empty() && svc.user.is_none() {
+                bail!(
+                    "service '{sname}': declares volumes but no `user:` — a fresh PVC is chowned \
+                     to the pod's fsGroup, which comes from a numeric `user:`, so without one the \
+                     volume mounts root-owned 0755 and a non-root image cannot write to it. Set \
+                     the image's numeric UID (`docker inspect -f '{{{{.Config.User}}}}' <image>`), \
+                     or `user: root` if its entrypoint starts as root."
+                );
+            }
+        }
         for name in self.referenced_vars() {
             let declared = self.config.iter().any(|c| c.name == name)
                 || self.secrets.iter().any(|s| s.name == name)
@@ -2175,6 +2203,55 @@ config:
         assert!(!addresses_host("redis://redis", "redis"));
         // The scheme alone must not match its own service name.
         assert!(!addresses_host("redis://other:6379", "redis"));
+    }
+
+    /// A service with a data volume must declare who writes to it (#277).
+    /// Without a numeric `user:` there is no fsGroup, so the PVC mounts
+    /// root-owned and the non-root container the kubelet starts cannot write.
+    #[test]
+    fn volumes_require_a_declared_user() {
+        let svc = |user: &str| {
+            format!(
+                "services:\n  a:\n    image: x\n{user}    \
+                 volumes:\n      - {{ name: data, path: /data, size: 1Gi }}\n"
+            )
+        };
+
+        // Volumes + silence: refused, with the fix in the message.
+        let c = Compose::parse(&svc("")).unwrap();
+        let err = c.validate_declarations().unwrap_err().to_string();
+        assert!(err.contains("declares volumes but no `user:`"), "{err}");
+        assert!(err.contains("fsGroup"), "{err}");
+
+        // A numeric UID becomes the fsGroup...
+        assert!(
+            Compose::parse(&svc("    user: \"1000\"\n"))
+                .unwrap()
+                .validate_declarations()
+                .is_ok()
+        );
+        // ...and root is a valid answer too: a root process can write to a
+        // root-owned volume, so there is nothing to chown.
+        assert!(
+            Compose::parse(&svc("    user: root\n"))
+                .unwrap()
+                .validate_declarations()
+                .is_ok()
+        );
+
+        // No volumes, no requirement — the rule is about who writes to a PVC,
+        // not about declaring a user for its own sake.
+        assert!(
+            Compose::parse("services:\n  a:\n    image: x\n")
+                .unwrap()
+                .validate_declarations()
+                .is_ok()
+        );
+
+        // Authoring-time only: `validate()` (which the operator runs on stored
+        // rows) still accepts it, so an app stored before this rule keeps
+        // reconciling rather than vanishing from the cluster.
+        assert!(Compose::parse(&svc("")).is_ok());
     }
 
     #[test]

--- a/lnvps_compose/src/lib.rs
+++ b/lnvps_compose/src/lib.rs
@@ -723,23 +723,8 @@ impl Compose {
                     .map_err(|e| anyhow!("config field '{}': default is invalid: {e}", f.name))?;
             }
         }
-        // A service with a data volume must say who writes to it (issue #277).
-        //
-        // Kubernetes chowns a freshly provisioned PVC to the pod's `fsGroup`,
-        // and the operator takes that from the numeric compose `user:`. Declare
-        // volumes without one and there is no fsGroup, so the volume mounts
-        // root-owned `0755` while the kubelet — under `runAsNonRoot` with no
-        // `runAsUser` — starts the container as whatever non-root UID the image
-        // names. The app then comes up and fails on its first write, on a fresh
-        // volume, every time.
-        //
-        // `user: root` is a valid answer here: a root process can write to a
-        // root-owned volume. The unusable combination is specifically volumes
-        // plus silence.
-        //
-        // Authoring-time only, like the rest of this function: a row stored
-        // before the rule keeps reconciling (its pod is unchanged by this), and
-        // it is caught the next time an admin edits it.
+        // A fresh PVC is chowned to the pod's fsGroup, which comes from a
+        // numeric `user:`; volumes plus silence is the unwritable combination.
         for (sname, svc) in &self.services {
             if !svc.volumes.is_empty() && svc.user.is_none() {
                 bail!(

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -1115,6 +1115,70 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    /// A service with volumes and no `user:` is refused at app create/update
+    /// (#277): a fresh PVC is chowned to the pod's fsGroup, which comes from a
+    /// numeric `user:`, so without one the app deploys and fails on its first
+    /// write — every time, on a fresh volume.
+    #[tokio::test]
+    async fn test_admin_app_compose_volumes_require_user() {
+        let client = setup().await;
+        let suffix = nostr::Keys::generate().public_key().to_hex()[..8].to_string();
+        let slug = format!("e2e-vol-user-{suffix}");
+
+        let compose = |user: &str| {
+            format!(
+                "services:\n  web:\n    image: example/web:latest\n{user}    \
+                 ports:\n      - {{ name: http, container: 80, protocol: http, expose: ingress }}\n    \
+                 volumes:\n      - {{ name: data, path: /data, size: 1Gi }}\n"
+            )
+        };
+        let body = |compose: String| {
+            serde_json::json!({
+                "name": slug,
+                "display_name": "Volumes Need A User",
+                "category": "Nostr relay",
+                "compose": compose,
+                "amount": 1000,
+                "currency": "usd",
+                "interval_amount": 1,
+                "interval_type": "month",
+                "setup_amount": 0
+            })
+        };
+
+        let resp = client
+            .post_auth("/api/admin/v1/apps", &body(compose("")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let err = resp.text().await.unwrap();
+        assert!(err.contains("declares volumes but no `user:`"), "{err}");
+
+        // With a UID it is accepted, and the rule applies on update too.
+        let resp = client
+            .post_auth("/api/admin/v1/apps", &body(compose("    user: \"1000\"\n")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let created: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        let app_id = created["data"]["id"].as_u64().expect("app id");
+
+        let resp = client
+            .patch_auth(
+                &format!("/api/admin/v1/apps/{app_id}"),
+                &serde_json::json!({ "compose": compose("") }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
     /// A generated secret can declare its byte length (issue #243), and an
     /// unusable length is refused when the app is created or updated rather
     /// than becoming an app that deploys and crash-loops on its own key.


### PR DESCRIPTION
Closes #277.

Kubernetes chowns a freshly provisioned PVC to the pod's `fsGroup`, and `pod_security_context_for` takes that from the numeric compose `user:` (`lnvps_operator/src/app_deployments.rs:305-313`). A service that declares `volumes:` and no `user:` therefore gets no fsGroup at all, so the volume mounts root-owned `0755` — while the kubelet, under `runAsNonRoot` with no `runAsUser`, starts the container as whatever non-root UID the image names.

The result is an app that deploys, starts, and fails on its first write, on a fresh volume, every time. The consequence was already written down at `lnvps_compose/src/lib.rs:201-203`; nothing enforced it.

App create/update now refuses that combination:

```
service 'web': declares volumes but no `user:` — a fresh PVC is chowned to the pod's fsGroup,
which comes from a numeric `user:`, so without one the volume mounts root-owned 0755 and a
non-root image cannot write to it. Set the image's numeric UID (`docker inspect -f
'{{.Config.User}}' <image>`), or `user: root` if its entrypoint starts as root.
```

`user: root` satisfies the rule — a root process can write to a root-owned volume. The unusable combination is specifically volumes plus silence.

## Where the check lives

`validate_declarations` (authoring-time), not `validate()`, following the precedent set for `${…}` declarations and config defaults: the operator runs `validate()` on stored rows, so putting the rule there would stop reconciling an already-deployed app instead of fixing it. A row stored before this keeps rendering exactly as it did, and is caught the next time an admin edits it.

## On the ordering

**This does not explain the outage Kieran reported**, and I'd flag that before it gets treated as fixed. All thirteen documented services with volumes already declare a user, and the failure described is a database aborting during data-dir creation — the two catalog databases (route96's `mariadb`, Buzz's `postgres`) both declare `user: root`, which gets no fsGroup *and does not need one*. So #277 is a real latent gap, not the live cause, unless the deployed row differs from the documented compose.

I cannot read the live row (no DB or admin credentials). @Kieran — the failing deployment's `compose` and `kubectl describe pod` output would settle it in one step. #276 is the change that makes the reported symptom (*Running* while crashed) visible at all.

## Tests

- `volumes_require_a_declared_user` — refused with the fix in the message; a numeric UID and `user: root` both accepted; no volumes means no requirement; and `validate()` still accepts it, so stored rows keep reconciling.
- `test_admin_app_compose_volumes_require_user` (e2e) — `400` at app create with the message, accepted with a UID, and refused again on update.

`cargo test --workspace` green at `67e6827`. `cargo clippy` unchanged from master and `cargo fmt` clean on the files touched.

**e2e is red for a reason that is not this change**: `test_unpaid_vm_cleanup` fails with #261's exact signature on this branch *and* on unmodified `origin/master` (`a8c64bb`) — 153 passed / 1 failed here, 152 passed / 1 failed on master. Evidence posted on #261; rerunning does not clear it, so no branch can currently produce a green local e2e.

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
