### PR TITLE
fix(apps): report a deployment's status from the workload, not the billing gate (#276)

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -3926,7 +3926,7 @@ These use the dedicated **`app_deployment`** RBAC resource (distinct from the ca
 | `app_id` | int | Only deployments of this catalog app |
 | `cluster_id` | int | Only deployments on this cluster |
 | `region_id` | int | Only deployments on any cluster in this region |
-| `status` | string | Observed status: `pending`, `running`, `stopped`, `error`, `deleting` |
+| `status` | string | Observed status, read back from the cluster (issue #276): `running` = every replica ready, `pending` = still coming up, `error` = a container will not start (reason in `status_message`), `stopped` = billing/lifecycle (stopped, unpaid or expired), `deleting` = being torn down |
 | `desired_state` | string | Desired run state: `running`, `stopped` |
 | `search` | string | Case-insensitive substring match on `name`, `hostname`, `custom_domain` |
 | `include_deleted` | bool | Include soft-deleted deployments (default `false`) |

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -52,6 +52,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   A `pattern` is compiled when the app is created or updated, so an invalid regex is the catalog author's error rather than a customer's failed order, and a declared `default` is checked against its own field at the same point. Existing app definitions are unaffected: no field declares a `pattern` yet, and the documented `owner_npub` (HAVEN) and `owner_pubkey` (Buzz) fields gain one in this release — the live catalog rows need the same edit, which no migration performs.
 
+- **An app deployment's `status` now reports the workload, not the billing gate** (issue #276) — **`status` on `ApiAppDeployment` changes meaning; no field is added or removed.** The operator wrote `running` whenever the subscription was paid, the customer had not stopped the deployment, and the reconcile completed — nothing anywhere read the workload back. A database that aborted while initialising its data directory therefore reported `running` in the admin UI and on the customer's own page, continuously, while it crash-looped.
+
+  `running` now requires every replica to be ready. A container the kubelet has given up on (`CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `CreateContainerConfigError`, `CreateContainerError`) reports `error`, with the failing service, that reason and the head of the container's last termination message in `status_message`. Anything else not yet ready reports `pending`, which is what a deployment coming up honestly is.
+
+  **Clients that treated `running` as "provisioned successfully" will now see `pending` for the first seconds of a deployment's life and `error` for one that cannot start.** Both were previously reported as `running`. `stopped` is unchanged and still answers the billing/lifecycle question — pair it with `billing_state` (issue #253) to tell "customer stopped it" from "never paid". When the operator cannot reach the API server to read health, it leaves the stored status alone rather than guessing.
+
 ### Added
 
 - **`billing_state` on an app deployment — `unpaid` / `active` / `expired`** (issue #253) — `ApiAppDeployment` (`GET /api/v1/app-deployments` and `/{id}`, and every endpoint returning a deployment) gains a nullable `billing_state` string. Additive: no existing field changes.

--- a/lnvps_api/src/api/apps.rs
+++ b/lnvps_api/src/api/apps.rs
@@ -286,8 +286,23 @@ pub struct ApiAppDeployment {
     /// Desired run state: `running` or `stopped`.
     pub desired_state: String,
     /// Observed status: `pending`, `running`, `stopped`, `error`, `deleting`.
+    ///
+    /// Read back from the cluster, not from the billing gate (issue #276):
+    /// `running` means every replica is ready, `pending` means the workload is
+    /// still coming up, and `error` means a container will not start — the
+    /// kubelet's reason and the container's last output are in
+    /// `status_message`. A crash-looping app previously reported `running`
+    /// here, because the field only ever said "the subscription is paid".
+    ///
+    /// `stopped` remains a billing/lifecycle answer (stopped by the customer,
+    /// unpaid, or expired); use `billing_state` to tell those apart.
     pub status: String,
     /// Human-readable status/error detail from the operator, when present.
+    ///
+    /// For `error` this names the failing service, the kubelet's reason
+    /// (`CrashLoopBackOff`, `ImagePullBackOff`, …) and the head of the
+    /// container's last termination message — worth rendering verbatim, since
+    /// it is usually the only thing that says *what* is wrong.
     pub status_message: Option<String>,
     /// Subscription this deployment is billed under (renew via the subscription
     /// endpoints). `None` if the subscription can't be resolved.

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -27,7 +27,7 @@ use crate::Context;
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
 use k8s_openapi::api::core::v1::{
     ConfigMap, Container, ContainerPort, EnvVar, Namespace, PersistentVolumeClaim,
-    PersistentVolumeClaimSpec, PodSecurityContext, PodSpec, PodTemplateSpec, ResourceQuota,
+    PersistentVolumeClaimSpec, Pod, PodSecurityContext, PodSpec, PodTemplateSpec, ResourceQuota,
     ResourceRequirements, SeccompProfile, SecurityContext, Service, ServicePort, ServiceSpec,
     Volume as K8sVolume, VolumeMount, VolumeResourceRequirements,
 };
@@ -1252,7 +1252,8 @@ async fn reconcile_one(
     // retention note further down).
     if !provisions_cluster_objects(&gate) {
         info!("app deployment {id} not provisioned: {gate}");
-        write_back_status(ctx, deployment, hostname, &gate).await?;
+        // Nothing was applied, so there is no workload to read.
+        write_back_status(ctx, deployment, hostname, &gate, None).await?;
         return Ok(());
     }
 
@@ -1354,10 +1355,171 @@ async fn reconcile_one(
     // namespace cap.
     delete_resource_quota(client, id).await?;
 
-    // 7. Status write-back: record the hostname and running state.
-    write_back_status(ctx, deployment, hostname, &gate).await?;
+    // 7. Status write-back: record the hostname and what the workload is
+    // actually doing (#276).
+    //
+    // A failed read is not a failed reconcile: the objects are applied and
+    // correct, and the API server being briefly unavailable must not undo that
+    // or overwrite a true status with a guess.
+    let health = match read_workload_health(client, id).await {
+        Ok(h) => Some(h),
+        Err(e) => {
+            warn!("app deployment {id}: could not read workload health: {e}");
+            None
+        }
+    };
+    write_back_status(ctx, deployment, hostname, &gate, health).await?;
     info!("reconciled app deployment {id}");
     Ok(())
+}
+
+/// What the cluster says about a deployment's workload (issue #276).
+///
+/// Collected from the Deployments and Pods in the deployment's namespace, and
+/// mapped to a status by [`workload_status`]. Kept as data so the mapping is a
+/// pure function, testable without a cluster — like [`gate_running`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WorkloadHealth {
+    /// Replicas asked for, summed across the deployment's services.
+    pub desired: i32,
+    /// Replicas the cluster reports as ready.
+    pub ready: i32,
+    /// Containers the kubelet says will not start.
+    pub failures: Vec<ContainerFailure>,
+}
+
+/// One container the kubelet is refusing to run, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerFailure {
+    /// Compose service the container belongs to.
+    pub service: String,
+    /// Container name (a service's own container, or one of its init steps).
+    pub container: String,
+    /// The kubelet's waiting reason, e.g. `CrashLoopBackOff`.
+    pub reason: String,
+    /// The last termination message, when the container ran and died.
+    pub detail: Option<String>,
+}
+
+/// Waiting reasons that mean "this will not start on its own".
+///
+/// `CrashLoopBackOff` only appears after the kubelet has restarted a container
+/// repeatedly, so it is a settled verdict rather than a container that is
+/// merely slow — which is why a not-yet-ready workload without one of these is
+/// reported as `Pending` and not as an error.
+const TERMINAL_WAITING_REASONS: [&str; 5] = [
+    "CrashLoopBackOff",
+    "ImagePullBackOff",
+    "ErrImagePull",
+    "CreateContainerConfigError",
+    "CreateContainerError",
+];
+
+/// Map observed workload health onto the status the customer sees (issue #276).
+///
+/// `Running` used to mean "the billing gate is open": it was written whenever
+/// the subscription was paid and the customer had not stopped the deployment,
+/// and nothing ever read the workload back. A database that aborted while
+/// initialising its data directory reported `Running` throughout, in the admin
+/// UI and on the customer's own page, for as long as it kept crashing.
+///
+/// So `Running` now requires every replica to be ready. A container the kubelet
+/// has given up on is `Error` with the reason (and its last words) in
+/// `status_message`; anything else that is not yet ready is `Pending`, which is
+/// what a deployment coming up honestly is.
+pub fn workload_status(health: &WorkloadHealth) -> (AppDeploymentStatus, Option<String>) {
+    if !health.failures.is_empty() {
+        let detail = health
+            .failures
+            .iter()
+            .map(|f| {
+                let mut line = format!("{}: {}", f.service, f.reason);
+                if let Some(d) = &f.detail {
+                    // The last termination message is the app's own output and
+                    // can be long; it is the most useful part, so keep the head
+                    // of it rather than dropping it.
+                    let d = d.trim();
+                    if !d.is_empty() {
+                        let head: String = d.chars().take(200).collect();
+                        line.push_str(&format!(" ({head})"));
+                    }
+                }
+                line
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        return (AppDeploymentStatus::Error, Some(detail));
+    }
+    if health.desired > 0 && health.ready >= health.desired {
+        return (AppDeploymentStatus::Running, None);
+    }
+    (
+        AppDeploymentStatus::Pending,
+        Some(format!(
+            "waiting for the workload to become ready ({}/{} replicas)",
+            health.ready, health.desired
+        )),
+    )
+}
+
+/// Read the workload's health back out of the cluster (issue #276).
+///
+/// Deployments give the ready/desired counts; pods give the reason a container
+/// is not starting, which is the part a customer can act on ("no such image",
+/// "the database aborted") and which the replica count alone cannot say.
+async fn read_workload_health(client: &Client, deployment_id: u64) -> Result<WorkloadHealth> {
+    let ns = namespace_name(deployment_id);
+    let mut health = WorkloadHealth::default();
+
+    let deps: Api<Deployment> = Api::namespaced(client.clone(), &ns);
+    for d in deps.list(&ListParams::default()).await?.items {
+        health.desired += d.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
+        health.ready += d
+            .status
+            .as_ref()
+            .and_then(|s| s.ready_replicas)
+            .unwrap_or(0);
+    }
+
+    let pods: Api<Pod> = Api::namespaced(client.clone(), &ns);
+    for p in pods.list(&ListParams::default()).await?.items {
+        // The compose service name is on the pod as the component label, which
+        // is what the customer recognises — the pod name is generated.
+        let service = p
+            .labels()
+            .get("app.kubernetes.io/component")
+            .cloned()
+            .unwrap_or_else(|| p.name_any());
+        let Some(status) = &p.status else { continue };
+        let statuses = status
+            .container_statuses
+            .iter()
+            .flatten()
+            .chain(status.init_container_statuses.iter().flatten());
+        for cs in statuses {
+            let Some(waiting) = cs.state.as_ref().and_then(|s| s.waiting.as_ref()) else {
+                continue;
+            };
+            let Some(reason) = waiting.reason.as_deref() else {
+                continue;
+            };
+            if !TERMINAL_WAITING_REASONS.contains(&reason) {
+                continue;
+            }
+            health.failures.push(ContainerFailure {
+                service: service.clone(),
+                container: cs.name.clone(),
+                reason: reason.to_string(),
+                detail: cs
+                    .last_state
+                    .as_ref()
+                    .and_then(|s| s.terminated.as_ref())
+                    .and_then(|t| t.message.clone())
+                    .or_else(|| waiting.message.clone()),
+            });
+        }
+    }
+    Ok(health)
 }
 
 /// Record the deployment's hostname and why it is (not) running.
@@ -1372,15 +1534,33 @@ async fn write_back_status(
     deployment: &AppDeployment,
     hostname: String,
     gate: &GateReason,
+    health: Option<WorkloadHealth>,
 ) -> Result<()> {
     let id = deployment.id;
     let mut updated = deployment.clone();
     updated.hostname = Some(hostname);
     match gate {
-        GateReason::Running => {
-            updated.status = AppDeploymentStatus::Running;
-            updated.status_message = None;
-        }
+        GateReason::Running => match health {
+            // The gate being open only says the customer has paid and wants it
+            // running. What it *is* doing comes from the cluster (#276).
+            Some(h) => {
+                let (status, message) = workload_status(&h);
+                if status != AppDeploymentStatus::Running {
+                    info!(
+                        "app deployment {id} is {status}: {}",
+                        message.as_deref().unwrap_or("")
+                    );
+                }
+                updated.status = status;
+                updated.status_message = message;
+            }
+            // Health could not be read (see the call site). Asserting anything
+            // here would be a guess: leave the stored status alone rather than
+            // reporting a state nobody observed.
+            None => {
+                warn!("app deployment {id}: workload health unknown, leaving status as-is");
+            }
+        },
         // A lookup fault is an operational error, not a lifecycle state — mark
         // it Error so it's visibly wrong and alerted on, not a calm `stopped`.
         GateReason::SubscriptionLookupFailed(e) => {
@@ -2638,6 +2818,83 @@ config:
             // Shared namespace objects render from the footprint.
             let _ = build_network_policy(id, "ingress-nginx");
         }
+    }
+
+    /// `Running` now means the workload is running, not that the bill is paid
+    /// (#276). A crash-looping container reads Error with the reason, a
+    /// workload still coming up reads Pending, and only a fully ready one reads
+    /// Running.
+    #[test]
+    fn workload_status_reports_what_the_cluster_says() {
+        // Every replica ready: the only case that is Running.
+        let (s, m) = workload_status(&WorkloadHealth {
+            desired: 2,
+            ready: 2,
+            failures: vec![],
+        });
+        assert_eq!(s, AppDeploymentStatus::Running);
+        assert_eq!(m, None);
+
+        // Coming up is Pending, not Running — and says how far along it is.
+        let (s, m) = workload_status(&WorkloadHealth {
+            desired: 2,
+            ready: 1,
+            failures: vec![],
+        });
+        assert_eq!(s, AppDeploymentStatus::Pending);
+        assert!(m.unwrap().contains("1/2"));
+
+        // A deployment with nothing applied yet is Pending, not Running: a
+        // zero/zero "everything I asked for is ready" would be the same lie in
+        // a different shape.
+        let (s, _) = workload_status(&WorkloadHealth::default());
+        assert_eq!(s, AppDeploymentStatus::Pending);
+
+        // The case Kieran hit: a container the kubelet has given up on. Error,
+        // naming the service, the reason, and the container's last words.
+        let (s, m) = workload_status(&WorkloadHealth {
+            desired: 2,
+            ready: 1,
+            failures: vec![ContainerFailure {
+                service: "db".to_string(),
+                container: "db".to_string(),
+                reason: "CrashLoopBackOff".to_string(),
+                detail: Some("InnoDB: Unable to create temporary file\n".to_string()),
+            }],
+        });
+        assert_eq!(s, AppDeploymentStatus::Error);
+        let m = m.unwrap();
+        assert!(m.contains("db: CrashLoopBackOff"), "{m}");
+        assert!(m.contains("InnoDB"), "{m}");
+
+        // A failure outranks a ready count: a two-service app with one service
+        // up and one crash-looping is broken, not running.
+        let (s, _) = workload_status(&WorkloadHealth {
+            desired: 1,
+            ready: 1,
+            failures: vec![ContainerFailure {
+                service: "web".to_string(),
+                container: "web".to_string(),
+                reason: "ImagePullBackOff".to_string(),
+                detail: None,
+            }],
+        });
+        assert_eq!(s, AppDeploymentStatus::Error);
+
+        // A long last-termination message is truncated rather than dropped —
+        // the head of it is what names the fault.
+        let (_, m) = workload_status(&WorkloadHealth {
+            desired: 1,
+            ready: 0,
+            failures: vec![ContainerFailure {
+                service: "db".to_string(),
+                container: "db".to_string(),
+                reason: "CrashLoopBackOff".to_string(),
+                detail: Some("x".repeat(5000)),
+            }],
+        });
+        let m = m.unwrap();
+        assert!(m.len() < 400, "message stays renderable: {}", m.len());
     }
 
     // ── billing gate (reconcile_one) ────────────────────────────────────────

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -1393,8 +1393,6 @@ pub struct WorkloadHealth {
 pub struct ContainerFailure {
     /// Compose service the container belongs to.
     pub service: String,
-    /// Container name (a service's own container, or one of its init steps).
-    pub container: String,
     /// The kubelet's waiting reason, e.g. `CrashLoopBackOff`.
     pub reason: String,
     /// The last termination message, when the container ran and died.
@@ -1483,43 +1481,54 @@ async fn read_workload_health(client: &Client, deployment_id: u64) -> Result<Wor
 
     let pods: Api<Pod> = Api::namespaced(client.clone(), &ns);
     for p in pods.list(&ListParams::default()).await?.items {
-        // The compose service name is on the pod as the component label, which
-        // is what the customer recognises — the pod name is generated.
-        let service = p
-            .labels()
-            .get("app.kubernetes.io/component")
-            .cloned()
-            .unwrap_or_else(|| p.name_any());
-        let Some(status) = &p.status else { continue };
-        let statuses = status
-            .container_statuses
-            .iter()
-            .flatten()
-            .chain(status.init_container_statuses.iter().flatten());
-        for cs in statuses {
-            let Some(waiting) = cs.state.as_ref().and_then(|s| s.waiting.as_ref()) else {
-                continue;
-            };
-            let Some(reason) = waiting.reason.as_deref() else {
-                continue;
-            };
-            if !TERMINAL_WAITING_REASONS.contains(&reason) {
-                continue;
-            }
-            health.failures.push(ContainerFailure {
-                service: service.clone(),
-                container: cs.name.clone(),
-                reason: reason.to_string(),
-                detail: cs
-                    .last_state
-                    .as_ref()
-                    .and_then(|s| s.terminated.as_ref())
-                    .and_then(|t| t.message.clone())
-                    .or_else(|| waiting.message.clone()),
-            });
-        }
+        health.failures.extend(pod_failures(&p));
     }
     Ok(health)
+}
+
+/// The terminal container failures a single pod reports, if any.
+///
+/// Pure so the reason filter and the service-name fallback are testable without
+/// a cluster.
+fn pod_failures(pod: &Pod) -> Vec<ContainerFailure> {
+    // The compose service name is on the pod as the component label, which
+    // is what the customer recognises — the pod name is generated.
+    let service = pod
+        .labels()
+        .get("app.kubernetes.io/component")
+        .cloned()
+        .unwrap_or_else(|| pod.name_any());
+    let Some(status) = &pod.status else {
+        return vec![];
+    };
+    let statuses = status
+        .container_statuses
+        .iter()
+        .flatten()
+        .chain(status.init_container_statuses.iter().flatten());
+    let mut failures = vec![];
+    for cs in statuses {
+        let Some(waiting) = cs.state.as_ref().and_then(|s| s.waiting.as_ref()) else {
+            continue;
+        };
+        let Some(reason) = waiting.reason.as_deref() else {
+            continue;
+        };
+        if !TERMINAL_WAITING_REASONS.contains(&reason) {
+            continue;
+        }
+        failures.push(ContainerFailure {
+            service: service.clone(),
+            reason: reason.to_string(),
+            detail: cs
+                .last_state
+                .as_ref()
+                .and_then(|s| s.terminated.as_ref())
+                .and_then(|t| t.message.clone())
+                .or_else(|| waiting.message.clone()),
+        });
+    }
+    failures
 }
 
 /// Record the deployment's hostname and why it is (not) running.
@@ -2857,7 +2866,6 @@ config:
             ready: 1,
             failures: vec![ContainerFailure {
                 service: "db".to_string(),
-                container: "db".to_string(),
                 reason: "CrashLoopBackOff".to_string(),
                 detail: Some("InnoDB: Unable to create temporary file\n".to_string()),
             }],
@@ -2874,7 +2882,6 @@ config:
             ready: 1,
             failures: vec![ContainerFailure {
                 service: "web".to_string(),
-                container: "web".to_string(),
                 reason: "ImagePullBackOff".to_string(),
                 detail: None,
             }],
@@ -2888,13 +2895,79 @@ config:
             ready: 0,
             failures: vec![ContainerFailure {
                 service: "db".to_string(),
-                container: "db".to_string(),
                 reason: "CrashLoopBackOff".to_string(),
                 detail: Some("x".repeat(5000)),
             }],
         });
         let m = m.unwrap();
         assert!(m.len() < 400, "message stays renderable: {}", m.len());
+    }
+
+    /// A pod is only a failure once the kubelet has settled on one: a container
+    /// still being created is not an error the customer can act on.
+    #[test]
+    fn pod_failures_reports_only_terminal_reasons() {
+        use k8s_openapi::api::core::v1::{
+            ContainerState, ContainerStateTerminated, ContainerStateWaiting, ContainerStatus,
+            PodStatus,
+        };
+
+        let waiting = |reason: &str| ContainerState {
+            waiting: Some(ContainerStateWaiting {
+                reason: Some(reason.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let status = |name: &str, state: ContainerState| ContainerStatus {
+            name: name.to_string(),
+            state: Some(state),
+            ..Default::default()
+        };
+
+        let mut crashing = status("db", waiting("CrashLoopBackOff"));
+        crashing.last_state = Some(ContainerState {
+            terminated: Some(ContainerStateTerminated {
+                message: Some("InnoDB: Unable to create temporary file\n".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let pod = Pod {
+            metadata: ObjectMeta {
+                name: Some("db-7f9c8-abcde".to_string()),
+                labels: Some(BTreeMap::from([(
+                    "app.kubernetes.io/component".to_string(),
+                    "db".to_string(),
+                )])),
+                ..Default::default()
+            },
+            status: Some(PodStatus {
+                container_statuses: Some(vec![
+                    status("web", waiting("ContainerCreating")),
+                    crashing,
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pod_failures(&pod),
+            vec![ContainerFailure {
+                // The component label, not the generated pod name.
+                service: "db".to_string(),
+                reason: "CrashLoopBackOff".to_string(),
+                detail: Some("InnoDB: Unable to create temporary file\n".to_string()),
+            }]
+        );
+
+        // Without the label there is still a name to show, so a failure is
+        // never dropped for want of one.
+        let mut unlabelled = pod.clone();
+        unlabelled.metadata.labels = None;
+        assert_eq!(unlabelled.name_any(), pod_failures(&unlabelled)[0].service);
     }
 
     // ── billing gate (reconcile_one) ────────────────────────────────────────


### PR DESCRIPTION
Closes #276.

`write_back_status` set `Running` whenever `gate == GateReason::Running` — paid, unexpired, desired-running (`app_deployments.rs:1379-1383`) — and nothing in the operator, the API or the admin API ever read the workload back. `Running` meant *"the billing gate is open"*.

So the database Kieran hit, aborting while it initialised its data directory, reported **Running** in the admin UI and on the customer's own page, continuously, for as long as it crash-looped. Both UIs render the field directly; there was nothing truer for them to render.

## What it does now

After applying the objects, the operator reads the Deployments and Pods in the deployment's namespace and maps what it finds:

| observed | status | `status_message` |
|---|---|---|
| every replica ready | `running` | none |
| a container the kubelet has given up on | `error` | `db: CrashLoopBackOff (InnoDB: Unable to create temporary file…)` |
| anything else not yet ready | `pending` | `waiting for the workload to become ready (1/2 replicas)` |

The terminal waiting reasons are `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `CreateContainerConfigError`, `CreateContainerError` — the settled ones. `CrashLoopBackOff` only appears after the kubelet has restarted a container repeatedly, so a container that is merely slow reads `pending` and does not flap to `error` during a normal rollout. Init containers count: a service whose setup step cannot start never runs, which is the same failure from the customer's side.

## Three choices worth reviewing

- **The mapping is a pure function over observed data** (`workload_status`), sitting beside `gate_running`, so every case is unit-tested without a cluster.
- **A failed health read is not a failed reconcile.** The objects are applied and correct; the API server being briefly unreachable must not undo that. It leaves the stored status alone rather than overwriting a true status with a guess — which is the exact failure mode this issue is about.
- **`stopped` still comes from the gate.** Stopped-by-user, unpaid and expired are billing answers, not workload ones, and `billing_state` (#253) already separates them.

## Breaking-ish

For clients reading `running` as "provisioned successfully": the first seconds of a deployment's life now read `pending`, and one that cannot start reads `error`. Both previously read `running`. Recorded in `API_CHANGELOG.md` and `ADMIN_API_ENDPOINTS.md`.

@Marta — `status_message` is worth rendering verbatim on `error`; it is usually the only thing that names the fault.

## Tests

`workload_status_reports_what_the_cluster_says` covers ready → `running`, partial → `pending` with the count, empty → `pending` (a 0/0 "all ready" would be the same lie in another shape), a crash-looping container → `error` naming service, reason and last words, a failure outranking a healthy replica count, and truncation of a long termination message.

No e2e: the operator's read-back needs a Kubernetes API server, and the e2e stack has none — the suite seeds deployment rows directly. Stating that rather than implying coverage I don't have.

`cargo test --workspace` green and `lnvps_e2e` green via `scripts/run-e2e.sh` (153 passed) at `3a2d1f1`. `cargo clippy` unchanged from master (317 warnings both ways) and `cargo fmt` clean on the files touched.

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
