### PR TITLE
fix(apps): a service addressed by name must declare ports (#281)

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -36,6 +36,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **A managed-app service addressed as `name:port` by another service must declare `ports:`** (issue #281) — enforced when an app is created or updated through the admin API; `POST`/`PATCH /api/admin/v1/apps` returns `400` for a compose that points at a peer with no ports. The operator creates a Kubernetes Service — the only source of an in-namespace DNS name — only for a service with declared ports, so `postgres://buzz:…@db:5432/buzz` against a `db` that declares none is a hostname that does not resolve. The Buzz catalog app reached production this way and failed on its first connection with `Name or service not known`; the same defect was latent in `route96`, whose `db` is addressed at `db:3306` and declared no ports. Both documented composes now carry internal port blocks (`expose: none`, so nothing becomes publicly reachable).
+
+  Authoring-time only, like the `${…}` rule beside it: an app definition stored before this keeps reconciling unchanged and is caught the next time an admin edits it. The live catalog rows need the same edit, which no migration performs — and because the operator re-reads the app's compose on every pass, updating the row repairs an already-deployed instance without re-ordering it.
+
+- **Managed app config fields are validated against their declared `type`### Changed
+
 - **Managed app config fields are validated against their declared `type`, and may declare a `pattern`** (issue #271) — **stricter validation on `POST /api/v1/app-deployments`, `PATCH /api/v1/app-deployments/{id}` and the admin app create/update endpoints.** An order that previously succeeded with a garbage value now returns `400`.
 
   `resolve_config` enforced `required` and unknown keys and never looked at `type`, so an `int` field accepted `abc`, a `bool` field accepted `maybe`, and a `string` field accepted anything at all. That is only a validation gap until an app is strict about the value: HAVEN panics on an `owner_npub` that is not an npub, so a single mistyped character was accepted at order time, charged for, and became a deployment that restarted forever with nothing on screen naming the field.

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -275,6 +275,37 @@ This is not a substitute for a real reconcile — it does not exercise the
 ingress, the PVC provisioner or `depends_on` ordering — but it does exercise the
 exact check that refuses these pods.
 
+**A service another service talks to must declare `ports:`** (issue #281). The
+operator creates a Kubernetes Service — the only thing that gives a compose
+service a DNS name inside the namespace — only for a service with declared
+ports. So this does not resolve, and the app fails at its first connection with
+`Name or service not known`:
+
+```yaml
+services:
+  db:
+    image: postgres:17-alpine
+    user: root
+    # Drop this block and `db:5432` below stops resolving: no ports, no
+    # Service, no DNS name. `expose: none` keeps it in-namespace — only
+    # `expose: ingress` ports reach the Ingress.
+    ports:
+      - { name: postgres, container: 5432, protocol: tcp, expose: none }
+  relay:
+    image: example/relay:latest
+    user: "1000"
+    ports:
+      - { name: http, container: 3000, protocol: http, expose: ingress }
+    env:
+      DATABASE_URL: "postgres://buzz:pw@db:5432/buzz"
+```
+
+App create/update refuses a compose that addresses a portless peer as
+`name:port`, and so do `compose-validate` and `compose-to-docker`. **A local
+`docker compose up` will not catch this on its own** — docker gives every
+service a DNS alias whether or not it declares ports, which is exactly why the
+rule is enforced at authoring time.
+
 **`config[].pattern`** — a regex a submitted value must match, checked at
 order time (issue #271):
 
@@ -458,6 +489,10 @@ services:
     image: mariadb:11
     user: root    # mariadb's entrypoint starts as root, then drops to `mysql`
     resources: { cpu: 500m, memory: 512Mi }
+    # No ports, no Service, no DNS name — `db:3306` in route96's config would
+    # not resolve (#281). `expose: none` keeps it in-namespace.
+    ports:
+      - { name: mysql, container: 3306, protocol: tcp, expose: none }
     env:
       MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MARIADB_DATABASE: route96
@@ -753,6 +788,11 @@ services:
     image: postgres:17-alpine
     user: root    # postgres' entrypoint starts as root, then drops to `postgres`
     resources: { cpu: 500m, memory: 1Gi }
+    # A port block is what gives the service a DNS name inside the namespace:
+    # no ports, no Service, and `db` in the relay's DATABASE_URL does not
+    # resolve (#281). `expose: none` keeps it internal.
+    ports:
+      - { name: postgres, container: 5432, protocol: tcp, expose: none }
     env:
       POSTGRES_DB: buzz
       POSTGRES_USER: buzz
@@ -772,6 +812,8 @@ services:
     image: redis:7-alpine
     user: root    # redis' entrypoint starts as root, then drops to `redis`
     resources: { cpu: 250m, memory: 512Mi }
+    ports:
+      - { name: redis, container: 6379, protocol: tcp, expose: none }
     volumes:
       # RDB snapshots; without a writable /data redis fails its bgsave and then
       # refuses writes with MISCONF

--- a/lnvps_compose/src/bin/compose-to-docker.rs
+++ b/lnvps_compose/src/bin/compose-to-docker.rs
@@ -620,6 +620,16 @@ fn run(args: Args) -> Result<()> {
         read_source(&args.source).with_context(|| format!("cannot read {}", args.source))?;
     let compose = Compose::parse(&source).context("parse error")?;
     compose.validate().context("validation error")?;
+    // This is an authoring tool, so it applies the admission-only rules too —
+    // as `compose-validate` does. One of them matters especially here: docker
+    // gives every service a DNS alias whether or not it declares ports, and
+    // Kubernetes only gives one to a service that renders a Service. So a
+    // compose that addresses a portless peer runs *fine locally* and fails in
+    // the cluster with "Name or service not known" (#281). Refusing it here is
+    // what keeps a green local run meaningful.
+    compose
+        .validate_declarations()
+        .context("validation error")?;
 
     std::fs::create_dir_all(&args.out_dir)
         .with_context(|| format!("creating {}", args.out_dir.display()))?;

--- a/lnvps_compose/src/lib.rs
+++ b/lnvps_compose/src/lib.rs
@@ -669,6 +669,48 @@ impl Compose {
     /// `compose-validate` CLI) so a typo or a newly added reference is caught
     /// while a human can still fix it.
     pub fn validate_declarations(&self) -> Result<()> {
+        // A service addressed as `name:port` by another service must declare a
+        // port (issue #281).
+        //
+        // `build_service` is the only thing that gives a compose service a DNS
+        // name inside the namespace, and it renders nothing for a service with
+        // no `ports:`. So `postgres://buzz:pw@db:5432/buzz` in the relay's env,
+        // with a `db` service that declares no ports, is a name that does not
+        // resolve — which is how the Buzz app reached production and failed
+        // with "Name or service not known" on its first connection.
+        //
+        // Only in-document names are checked: an external `redis.example.com`
+        // is not a compose service and is nothing to do with us.
+        for (sname, svc) in &self.services {
+            // Everywhere a service can name a peer: its own env, its inline
+            // file contents, and its init steps' env (the setup step that waits
+            // for a peer is exactly this pattern).
+            let mut texts: Vec<&str> = svc.env.values().map(String::as_str).collect();
+            for f in &svc.files {
+                if let Some(c) = &f.content {
+                    texts.push(c.as_str());
+                }
+            }
+            for init in &svc.init {
+                texts.extend(init.env.values().map(String::as_str));
+            }
+            for (target, tsvc) in &self.services {
+                if target == sname || !tsvc.ports.is_empty() {
+                    continue;
+                }
+                if !texts.iter().any(|t| addresses_host(t, target)) {
+                    continue;
+                }
+                bail!(
+                    "service '{sname}' addresses '{target}:<port>', but service '{target}' \
+                     declares no `ports:` — the operator only creates a Service (and therefore a \
+                     DNS name) for a service with declared ports, so that hostname will not \
+                     resolve. Add an internal port block to '{target}', e.g. \
+                     `ports: [{{ name: {target}, container: <port>, protocol: tcp, expose: none }}]`"
+                );
+            }
+        }
+
         // A declared `default` must satisfy its own field (#271): an `int`
         // defaulting to "abc" fails at order time for whoever leaves the box
         // blank, which is a customer paying for the author's typo. Authoring-
@@ -1328,6 +1370,38 @@ const MAX_FILE_BYTES: usize = 256 * 1024;
 fn path_is_within(path: &str, dir: &str) -> bool {
     let dir = dir.trim_end_matches('/');
     path.starts_with(&format!("{dir}/"))
+}
+
+/// Whether `text` addresses `host` as a hostname followed by a port, the way a
+/// connection string does: `postgres://u:p@db:5432/x`, `redis://redis:6379`,
+/// `http://s3:9000`, `db:3306`.
+///
+/// Deliberately narrow — the name must be preceded by a URL/host boundary and
+/// followed by `:` and a digit. `redis://redis:6379` matches once (the second
+/// `redis`), and a mention of the word in prose or in a longer token
+/// (`mydb:5432`, `db.example.com:5432`) does not match at all.
+fn addresses_host(text: &str, host: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = text[from..].find(host) {
+        let start = from + rel;
+        let end = start + host.len();
+        let before_ok = start == 0
+            || matches!(
+                bytes[start - 1],
+                b'/' | b'@' | b' ' | b'\t' | b'"' | b'\'' | b'=' | b',' | b'(' | b'[' | b'\n'
+            );
+        let after_ok = bytes.get(end) == Some(&b':')
+            && bytes
+                .get(end + 1)
+                .map(|c| c.is_ascii_digit())
+                .unwrap_or(false);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = end.max(start + 1);
+    }
+    false
 }
 
 /// Validate an init step's name as a DNS label: it becomes a container name,
@@ -2020,6 +2094,87 @@ config:
         .unwrap();
         assert!(bad_default.validate_declarations().is_err());
         assert!(resolve_config(&bad_default, &std::collections::BTreeMap::new()).is_err());
+    }
+
+    /// A service addressed as `name:port` must declare a port, because that is
+    /// what makes the operator render a Service — and a Service is the only
+    /// thing that gives the name a DNS record (#281).
+    #[test]
+    fn addressed_services_must_declare_a_port() {
+        // The shape that reached production: the relay points at `db:5432`,
+        // and `db` declares no ports.
+        let broken = "services:\n  db:\n    image: postgres:17\n    user: root\n  \
+             relay:\n    image: example/relay\n    user: \"1000\"\n    \
+             ports:\n      - { name: http, container: 3000, protocol: http, expose: ingress }\n    \
+             env:\n      DATABASE_URL: \"postgres://buzz:pw@db:5432/buzz\"\n";
+        let c = Compose::parse(broken).unwrap();
+        let err = c.validate_declarations().unwrap_err().to_string();
+        assert!(err.contains("addresses 'db:<port>'"), "{err}");
+        assert!(err.contains("declares no `ports:`"), "{err}");
+        // Rendering is unchanged: `validate()` (which the operator runs on
+        // stored rows) still accepts it, so an app already deployed keeps
+        // reconciling rather than disappearing.
+        assert!(Compose::parse(broken).is_ok());
+
+        // With an internal port block it passes — `expose: none` is enough,
+        // since the Service is what DNS needs, not the ingress.
+        let fixed = broken.replace(
+            "  db:\n    image: postgres:17\n    user: root\n",
+            "  db:\n    image: postgres:17\n    user: root\n    ports:\n      \
+             - { name: postgres, container: 5432, protocol: tcp, expose: none }\n",
+        );
+        Compose::parse(&fixed)
+            .unwrap()
+            .validate_declarations()
+            .unwrap();
+
+        // An init step naming a portless peer counts: the step that waits for
+        // a backing service is exactly where this bites first.
+        let init_case = "services:\n  cache:\n    image: redis:7\n    user: root\n  \
+             app:\n    image: example/app\n    user: \"1000\"\n    \
+             ports:\n      - { name: http, container: 80, protocol: http, expose: ingress }\n    \
+             init:\n      - name: wait\n        image: busybox\n        \
+             env:\n          TARGET: \"redis://cache:6379\"\n";
+        assert!(
+            Compose::parse(init_case)
+                .unwrap()
+                .validate_declarations()
+                .is_err()
+        );
+
+        // A file's content counts too — a config file is where a hostname
+        // usually lives for apps that do not read env.
+        let file_case = "services:\n  cache:\n    image: redis:7\n    user: root\n  \
+             app:\n    image: example/app\n    user: \"1000\"\n    \
+             ports:\n      - { name: http, container: 80, protocol: http, expose: ingress }\n    \
+             files:\n      - { path: /app/c.yaml, content: \"redis: cache:6379\\n\" }\n";
+        assert!(
+            Compose::parse(file_case)
+                .unwrap()
+                .validate_declarations()
+                .is_err()
+        );
+    }
+
+    /// The host match is deliberately narrow: a hostname position followed by a
+    /// port, not any mention of the name (#281).
+    #[test]
+    fn addresses_host_matches_only_host_positions() {
+        assert!(addresses_host("postgres://buzz:pw@db:5432/buzz", "db"));
+        assert!(addresses_host("redis://redis:6379", "redis"));
+        assert!(addresses_host("http://s3:9000", "s3"));
+        assert!(addresses_host("db:3306", "db"));
+        assert!(addresses_host("host = \"cache:6379\"", "cache"));
+
+        // Not a host position: part of a longer name, or a different host that
+        // merely ends with ours.
+        assert!(!addresses_host("mydb:5432", "db"));
+        assert!(!addresses_host("db.example.com:5432", "db"));
+        // Named without a port — nothing here needs a Service.
+        assert!(!addresses_host("the db is postgres", "db"));
+        assert!(!addresses_host("redis://redis", "redis"));
+        // The scheme alone must not match its own service name.
+        assert!(!addresses_host("redis://other:6379", "redis"));
     }
 
     #[test]

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -1046,6 +1046,75 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    /// A compose that points one service at another by `name:port` is refused
+    /// at app create/update unless that peer declares ports (#281) — no ports
+    /// means no Service, which means no DNS name, which is how the Buzz app
+    /// reached production and died on "Name or service not known".
+    #[tokio::test]
+    async fn test_admin_app_compose_addressed_peer_needs_ports() {
+        let client = setup().await;
+        let suffix = nostr::Keys::generate().public_key().to_hex()[..8].to_string();
+        let slug = format!("e2e-peer-ports-{suffix}");
+
+        let compose = |db_ports: &str| {
+            format!(
+                "services:\n  db:\n    image: postgres:17-alpine\n    user: root\n{db_ports}  \
+                 relay:\n    image: example/relay:latest\n    user: \"1000\"\n    \
+                 ports:\n      - {{ name: http, container: 3000, protocol: http, expose: ingress }}\n    \
+                 env:\n      DATABASE_URL: \"postgres://buzz:pw@db:5432/buzz\"\n"
+            )
+        };
+        let body = |compose: String| {
+            serde_json::json!({
+                "name": slug,
+                "display_name": "Addressed Peer",
+                "category": "Nostr relay",
+                "compose": compose,
+                "amount": 1000,
+                "currency": "usd",
+                "interval_amount": 1,
+                "interval_type": "month",
+                "setup_amount": 0
+            })
+        };
+
+        let resp = client
+            .post_auth("/api/admin/v1/apps", &body(compose("")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let err = resp.text().await.unwrap();
+        assert!(err.contains("addresses 'db:<port>'"), "{err}");
+
+        // An internal port block satisfies it; `expose: none` is enough,
+        // because the Service is what DNS needs, not the Ingress.
+        let ok_ports = "    ports:\n      \
+             - { name: postgres, container: 5432, protocol: tcp, expose: none }\n";
+        let resp = client
+            .post_auth("/api/admin/v1/apps", &body(compose(ok_ports)))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let created: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        let app_id = created["data"]["id"].as_u64().expect("app id");
+
+        // Same rule on update, so an edit cannot reintroduce it.
+        let resp = client
+            .patch_auth(
+                &format!("/api/admin/v1/apps/{app_id}"),
+                &serde_json::json!({ "compose": compose("") }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = client
+            .delete_auth(&format!("/api/admin/v1/apps/{app_id}"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
     /// A generated secret can declare its byte length (issue #243), and an
     /// unusable length is refused when the app is created or updated rather
     /// than becoming an app that deploys and crash-loops on its own key.

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -2605,6 +2605,24 @@ config:
                     !svc.ports.is_empty(),
                     "{name}/{sname}: service presence tracks declared ports"
                 );
+                // ...and every peer this service addresses by name must be one
+                // of the services that gets one (#281). The assertion above
+                // says the rendering is self-consistent; this one asks whether
+                // it is *sufficient*, which is the question the Buzz entry
+                // failed in production: `db:5432` in the relay's env, with a
+                // `db` that declared no ports and so had no DNS name.
+                for (peer, psvc) in &c.services {
+                    if peer == sname || !psvc.ports.is_empty() {
+                        continue;
+                    }
+                    for value in senv.values() {
+                        assert!(
+                            !value.contains(&format!("{peer}:")),
+                            "{name}/{sname}: addresses '{peer}:…' but '{peer}' declares no \
+                             ports, so no Service and no DNS name is created for it"
+                        );
+                    }
+                }
                 for v in &svc.volumes {
                     assert!(build_pvc(id, sname, &v.name, &v.size, 1).spec.is_some());
                 }


### PR DESCRIPTION
Closes #281.

`build_service` is the only thing that gives a compose service a DNS name inside its namespace, and it renders nothing for a service with no `ports:` (`app_deployments.rs:562-569`). So Buzz's relay pointing at `postgres://buzz:…@db:5432/buzz`, with a `db` that declares no ports, is a hostname that does not exist — which is what Kieran's production deployment hit:

```
Failed to connect to Postgres: failed to lookup address information: Name or service not known
```

Nothing caught it: `validate()` only constrains `expose: ingress` to `protocol: http`, `validate_declarations()` only checked `${…}`, and a bare hostname in an env value is neither.

## The rule

App create/update now refuses a compose where one service addresses another as `name:port` when that peer declares no ports:

```
service 'relay' addresses 'db:<port>', but service 'db' declares no `ports:` — the operator only
creates a Service (and therefore a DNS name) for a service with declared ports, so that hostname
will not resolve. Add an internal port block to 'db', e.g. `ports: [{ name: db, container: <port>,
protocol: tcp, expose: none }]`
```

The match is deliberately narrow — a hostname position followed by `:` and a digit — so `redis://redis:6379` matches once (the host, not the scheme), while `mydb:5432`, `db.example.com:5432` and the word "db" in prose do not match at all. Only in-document service names count; an external host is nothing to do with us. Env, inline file contents and `init:` step env are all scanned, since a peer's name appears in all three.

Authoring-time (`validate_declarations`), not `validate()`, on the same precedent as the `${…}` and config-default rules: the operator runs `validate()` on stored rows, so putting it there would stop reconciling a deployed app rather than fix it.

## It immediately found a second one

**`route96`'s `db` has the identical defect** — addressed at `db:3306` from the app's config file, no ports declared. The new rule fails on the *current* documented compose, which is how I found it.

It escaped my #268 verification for a specific reason worth recording: **`docker compose up` cannot reproduce this.** Docker gives every service a DNS alias whether or not it declares ports, so `db` resolved locally for a reason Kubernetes does not share. `compose-to-docker` now applies the admission-only rules too, so a green local run means something again.

## For the catalog rows (@Kieran)

Three port blocks, not two — all three are in `docs/managed-app-examples.md` in this PR, so the row edit is a copy-paste:

| app | service | port block |
|---|---|---|
| Buzz | `db` | `{ name: postgres, container: 5432, protocol: tcp, expose: none }` |
| Buzz | `redis` | `{ name: redis, container: 6379, protocol: tcp, expose: none }` |
| route96 | `db` | `{ name: mysql, container: 3306, protocol: tcp, expose: none }` |

`expose: none` keeps them internal — `build_ingress` selects only `expose: ingress` ports. Reconcile re-reads the compose every pass, so updating the row repairs the running deployment without re-ordering it.

## Tests

- `addressed_services_must_declare_a_port` — the production shape refused with both service names; accepted once an internal port block exists; init-step env and file content both count; `validate()` still accepts it so stored rows keep reconciling.
- `addresses_host_matches_only_host_positions` — host-position matching, including the `redis://redis:6379` and `mydb:5432` cases.
- `documented_examples_map_to_k8s` — gained the render-level assertion: a peer a service addresses must be one that renders a Service.
- `test_admin_app_compose_addressed_peer_needs_ports` (e2e) — `400` at create with the message, accepted with the port block, refused again on update.

`cargo test --workspace` green apart from the two live-mirror `shasum` tests (#267). e2e: my new test passes; the suite's only failure is `test_unpaid_vm_cleanup` with #261's exact signature, which I showed earlier today reproduces on unmodified `origin/master` — evidence on that issue. Both at `d4222de`. `cargo clippy` unchanged from master (317) and `cargo fmt` clean on the files touched.

Originating channel: `lnvps` (`f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1`).
