### PR TITLE
fix(e2e): wait for the expiry history entry, not the is_active flip (#261)

### DIFF
--- a/lnvps_e2e/src/db.rs
+++ b/lnvps_e2e/src/db.rs
@@ -174,13 +174,9 @@ const HARD_DELETE_RETRIES: u32 = 20;
 
 /// MySQL error 1451: cannot delete a parent row, a child row still references it.
 fn is_fk_violation(e: &sqlx::Error) -> bool {
-    match e {
-        sqlx::Error::Database(db) => db
-            .try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>()
-            .map(|e| e.number() == 1451)
-            .unwrap_or(false),
-        _ => false,
-    }
+    e.as_database_error()
+        .and_then(|d| d.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>())
+        .is_some_and(|e| e.number() == 1451)
 }
 
 /// Hard-delete a VM and all its dependent rows from the database.

--- a/lnvps_e2e/src/db.rs
+++ b/lnvps_e2e/src/db.rs
@@ -169,6 +169,20 @@ pub async fn remove_all_roles(pool: &MySqlPool, user_id: u64) -> anyhow::Result<
     Ok(())
 }
 
+/// How many times `hard_delete_vm` retries a foreign-key failure before giving up.
+const HARD_DELETE_RETRIES: u32 = 20;
+
+/// MySQL error 1451: cannot delete a parent row, a child row still references it.
+fn is_fk_violation(e: &sqlx::Error) -> bool {
+    match e {
+        sqlx::Error::Database(db) => db
+            .try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>()
+            .map(|e| e.number() == 1451)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
 /// Hard-delete a VM and all its dependent rows from the database.
 /// Used by E2E cleanup when the worker cannot reach a fake host.
 ///
@@ -191,14 +205,30 @@ pub async fn hard_delete_vm(pool: &MySqlPool, vm_id: u64) -> anyhow::Result<()> 
         .bind(vm_id)
         .execute(pool)
         .await?;
-    sqlx::query("DELETE FROM vm_history WHERE vm_id = ?")
-        .bind(vm_id)
-        .execute(pool)
-        .await?;
-    sqlx::query("DELETE FROM vm WHERE id = ?")
-        .bind(vm_id)
-        .execute(pool)
-        .await?;
+
+    // The worker may still be writing history for this VM while teardown runs,
+    // which re-parents a `vm_history` row between the child delete and the
+    // parent delete and fails the FK. Retry the pair; a handler that is mid
+    // flight finishes well inside this window.
+    let mut attempt = 0;
+    loop {
+        sqlx::query("DELETE FROM vm_history WHERE vm_id = ?")
+            .bind(vm_id)
+            .execute(pool)
+            .await?;
+        match sqlx::query("DELETE FROM vm WHERE id = ?")
+            .bind(vm_id)
+            .execute(pool)
+            .await
+        {
+            Ok(_) => break,
+            Err(e) if is_fk_violation(&e) && attempt < HARD_DELETE_RETRIES => {
+                attempt += 1;
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
 
     // Delete subscription rows that were linked to this VM (if any).
     if let Some(sid) = sub_id {

--- a/lnvps_e2e/src/lifecycle.rs
+++ b/lnvps_e2e/src/lifecycle.rs
@@ -1644,12 +1644,11 @@ mod tests {
     //   CheckVms → worker deletes the VM → vm.deleted = true.
     //
     // Path B — check_subscriptions (expiry + stop):
-    //   Order a VM, pay for it, manually expire the subscription via DB,
-    //   publish CheckSubscriptions → worker stops the VM → a "Expired"
-    //   entry appears in vm_history (the stop call will fail on a fake
-    //   host but the history log is written first via the best-effort
-    //   stop path; if the host call happens to fail before the log we
-    //   simply verify the subscription state is consistent).
+    //   Order a VM, pay for it, expire the subscription via DB *inside* the
+    //   grace window, publish CheckSubscriptions → worker stops the VM → an
+    //   "Expired" entry appears in vm_history. Expiring past the grace window
+    //   would instead take the cancellation path, which deletes the VM and is
+    //   not what this half of the test is for.
     // ====================================================================
 
     #[tokio::test]
@@ -2036,25 +2035,27 @@ mod tests {
                 );
                 eprintln!("[cleanup] Subscription {sub2_id} active and has expiry ✓");
 
-                // Manually expire the subscription (set expires 2 days in the past).
+                // Expire the subscription one hour ago: past `expires`, well
+                // inside the grace period a day-old subscription gets, so the
+                // worker takes the expiry path and not the cancellation path.
                 {
                     let pool = crate::db::connect().await.unwrap();
-                    crate::db::expire_subscription(&pool, sub2_id, 2 * 86_400)
+                    crate::db::expire_subscription(&pool, sub2_id, 3_600)
                         .await
                         .unwrap();
                     pool.close().await;
                 }
-                eprintln!("[cleanup] Expired subscription {sub2_id} by 2 days ✓");
+                eprintln!("[cleanup] Expired subscription {sub2_id} by 1 hour ✓");
 
                 // Trigger check_subscriptions.
                 crate::worker::trigger_check_subscriptions().await.unwrap();
                 eprintln!("[cleanup] Published CheckSubscriptions job");
 
                 // Poll VM history for an "Expired" entry (up to 30 s).
-                // The worker calls on_expired → stop_vm (fails on fake host
-                // but the history entry is written best-effort).  We also
-                // accept the subscription becoming inactive as a valid signal
-                // that the grace-period path fired instead.
+                // The worker calls on_expired → stop_vm (best-effort on a fake
+                // host) → log_vm_expired. The history entry is the last thing
+                // the handler writes for this VM, so it is also the signal that
+                // teardown below may delete the VM without racing the worker.
                 let expired_signal = poll_until(30, 500, || {
                     let admin = admin.clone();
                     async move {
@@ -2063,38 +2064,26 @@ mod tests {
                             .get_auth(&format!("/api/admin/v1/vms/{paid_vm_id}/history"))
                             .await
                             .unwrap();
-                        if let Ok(h) =
+                        let Ok(h) =
                             serde_json::from_str::<serde_json::Value>(&hr.text().await.unwrap())
-                        {
-                            if h["data"].as_array().map_or(false, |arr| {
-                                arr.iter().any(|e| {
-                                    e["action_type"]
-                                        .as_str()
-                                        .map_or(false, |t| t.eq_ignore_ascii_case("expired"))
-                                })
-                            }) {
-                                return true;
-                            }
-                        }
-                        // Also accept subscription becoming inactive
-                        let sr = admin
-                            .get_auth(&format!("/api/admin/v1/subscriptions/{sub2_id}"))
-                            .await
-                            .unwrap();
-                        if let Ok(s) =
-                            serde_json::from_str::<serde_json::Value>(&sr.text().await.unwrap())
-                        {
-                            return !s["data"]["is_active"].as_bool().unwrap_or(true);
-                        }
-                        false
+                        else {
+                            return false;
+                        };
+                        h["data"].as_array().is_some_and(|arr| {
+                            arr.iter().any(|e| {
+                                e["action_type"]
+                                    .as_str()
+                                    .is_some_and(|t| t.eq_ignore_ascii_case("expired"))
+                            })
+                        })
                     }
                 })
                 .await;
 
                 assert!(
                     expired_signal,
-                    "Expired subscription {sub2_id} should have triggered stop/deactivation \
-                     within 30 s (check vm history for Expired entry or subscription is_active=false)"
+                    "Expired subscription {sub2_id} should have produced an Expired \
+                     vm_history entry for VM {paid_vm_id} within 30 s"
                 );
                 eprintln!("[cleanup] Subscription expiry handled by worker for VM {paid_vm_id} ✓");
 


### PR DESCRIPTION
Closes #261.

`test_unpaid_vm_cleanup` expired its subscription by 2 days, but a subscription created seconds earlier gets a **1 day** grace window (`lnvps_api_common/src/model.rs:276-288`). So the worker took the cancellation branch, not the expiry branch: `is_active = false` is committed *first*, then `on_grace_period_exceeded` deletes the VM and writes `vm_history` (`lnvps_api/src/worker.rs:368-395`, `lnvps_api/src/subscription/vm.rs:237-266`).

The test accepted `is_active == false` as a success signal, so it began teardown at the one moment guaranteed to have a `vm_history` write in flight, and `hard_delete_vm` hit FK 1451 on the `vm` delete.

- `lnvps_e2e/src/lifecycle.rs:2035-2088` — expire by 1 hour, inside the grace window, so the path under test is the one the comment describes (`on_expired` → `log_vm_expired`); poll only for the `Expired` history entry, which is that path's last `vm_history` write.
- `lnvps_e2e/src/db.rs:172-232` — `hard_delete_vm` retries the `vm_history`/`vm` delete pair on 1451, so no future teardown can lose this race.

Test-only; no product code touched, no contract change.

Verified: 5 consecutive full-suite runs at `83c3390`, 156 passed / 0 failed each. `cargo clippy -p lnvps_e2e --all-targets` clean over both files.
