### PR TITLE
fix(catalog): tag buzz-relay nostr + relay (#258)

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`buzz-relay` now carries the `nostr` and `relay` tags** (issue #258) — the catalog row was added after the tag backfill, so it held no tags at all and was missing from every tag filter, `?tag=nostr` as much as `?tag=relay`. A migration assigns both, matching `pyramid-relay`, which shares its category. No schema or response-shape change, but the numbers move: `?tag=relay` returns 5 apps rather than 4, `?tag=nostr` 6 rather than 5, and the `app_count` on those two tags in `GET /api/v1/app-tags` rises to match. A client that assumes a uniform price across a tag's results should note that the new relay row is €8.50/month.
+
 - **`GET /api/v1/payment/{id}` now works for every subscription type** — it previously resolved the payer through the VM back-reference, so a payment for a managed app, IP range or other non-VPS subscription errored instead of returning. Ownership is now asserted on the subscription and the embedded `vm_id` is `0` for non-VPS payments (the endpoint remains deprecated in favour of `GET /api/v1/subscriptions/{id}/payments/{payment_id}`).
 
 ### Deprecated

--- a/lnvps_db/migrations/20260728103000_app_tag_buzz_relay.sql
+++ b/lnvps_db/migrations/20260728103000_app_tag_buzz_relay.sql
@@ -1,0 +1,19 @@
+-- buzz-relay was added to the catalog after 20260727090000_app_tags.sql, whose
+-- backfill named the five apps that existed when it was written, so the row
+-- carries no tags at all and is invisible to every tag filter -- including
+-- ?tag=nostr, not only ?tag=relay.
+--
+-- `nostr` + `relay` matches pyramid-relay, which shares its category
+-- ("Community Nostr relay"). Being a workspace as well as a relay is not a
+-- reason to withhold `relay`: the tag axis is many-to-many precisely so an app
+-- that is two things is filed under both.
+--
+-- Matched by name and inert against a database that does not hold the row,
+-- following the backfill in 20260727090000_app_tags.sql. IGNORE so a catalog
+-- that was already corrected by hand is not a failed migration.
+INSERT IGNORE INTO app_tag_assignment (app_id, tag_id)
+SELECT a.id, t.id
+FROM app a
+         JOIN app_tag t
+WHERE a.name = 'buzz-relay'
+  AND t.slug IN ('nostr', 'relay');

--- a/lnvps_db/migrations/20260728103000_app_tag_buzz_relay.sql
+++ b/lnvps_db/migrations/20260728103000_app_tag_buzz_relay.sql
@@ -4,9 +4,7 @@
 -- ?tag=nostr, not only ?tag=relay.
 --
 -- `nostr` + `relay` matches pyramid-relay, which shares its category
--- ("Community Nostr relay"). Being a workspace as well as a relay is not a
--- reason to withhold `relay`: the tag axis is many-to-many precisely so an app
--- that is two things is filed under both.
+-- ("Community Nostr relay").
 --
 -- Matched by name and inert against a database that does not hold the row,
 -- following the backfill in 20260727090000_app_tags.sql. IGNORE so a catalog


### PR DESCRIPTION
Closes #258.

`buzz-relay` was added to the catalog after `20260727090000_app_tags.sql`, whose backfill named the five apps that existed when it was written, so the row carries no tags at all — invisible to `?tag=nostr` as much as to `?tag=relay`.

`lnvps_db/migrations/20260728103000_app_tag_buzz_relay.sql` assigns `nostr` + `relay`, matching `pyramid-relay`, which shares its category ("Community Nostr relay"). Matched by name and inert against a database without the row, following the backfill it extends; `INSERT IGNORE` so a catalog already corrected by hand is not a failed migration.

Verified against MariaDB 11: the full migration chain applies clean on an empty database (no rows, no error), and on a database seeded with `buzz-relay` + `pyramid-relay` it produces exactly the two assignments for `buzz-relay` and nothing for `pyramid-relay`; re-running leaves the count at 2.

Effect on clients, no schema or shape change: `?tag=relay` returns 5 apps rather than 4, `?tag=nostr` 6 rather than 5, and `app_count` on both tags rises to match. The new relay row is €8.50/month, so a caller assuming a uniform price across a tag's results needs to look again — noted in `API_CHANGELOG.md` and raised with Marta for `/nostr-relay-hosting`.

Not fixed here, filed separately: `tags` is optional on `POST /api/admin/v1/apps` (`lnvps_api_admin/src/admin/apps.rs:286`), which is how this row was created untagged, and how the next one will be.

Full e2e suite green at `674185c` (156/156); `cargo test --workspace` green apart from `lnvps_e2e`, which needs the docker harness.
