### PR TITLE
fix(operator): cut the ClusterRole to the verbs the loop issues (#297 part 2)

### DIFF
--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -126,16 +126,37 @@ spec:
 
 ## RBAC Permissions
 
-The operator requires these Kubernetes permissions:
+The operator requires these Kubernetes permissions, each one a verb the
+reconcile loop actually issues:
 
-- **core/namespaces**: `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-- **core/services, secrets, configmaps, persistentvolumeclaims, resourcequotas**: `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-- **core/pods**: `get`, `list`, `watch` (read-only; container statuses are the reason a deployment is not ready)
-- **apps/deployments**: `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-- **networking.k8s.io/ingresses, networkpolicies**: `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-- **core/events**: `create`, `patch` (for event logging)
+- **core/namespaces**: `list`, `create`, `patch`, `delete`
+- **core/services, configmaps, persistentvolumeclaims**: `create`, `patch`
+- **core/secrets**: `get`, `create`, `patch`
+- **core/resourcequotas**: `delete`
+- **core/pods**: `list` (container statuses are the reason a deployment is not ready)
+- **apps/deployments**: `list`, `create`, `patch`
+- **networking.k8s.io/ingresses**: `get`, `create`, `update`, `patch`, `delete`
+- **networking.k8s.io/networkpolicies**: `create`, `patch`
+
+`create` accompanies `patch` because server-side apply creates the object on
+the first pass. The operator holds no watches, so `watch` is granted nowhere.
 
 These are automatically created by the deployment manifest.
+
+### Secret access is still cluster-wide
+
+The only secret the operator reads is `generated` in each `app-N` namespace it
+created (`read_generated`), but the grant above is a ClusterRole, so a stolen
+token reads every Secret in the cluster — every tenant's generated passwords and
+every TLS private key.
+
+Moving that to a Role in each `app-N` namespace does not work on its own:
+Kubernetes refuses to let a subject grant permissions it does not already hold,
+so the operator would need those same cluster-wide secret verbs (or `escalate`)
+to create the binding. The way out is a second, static ClusterRole holding the
+namespace-scoped verbs plus `bind` on it by name, with the operator creating a
+RoleBinding per namespace at reconcile time. That is a code change and a
+two-step rollout, tracked in issue #299.
 
 ## Monitoring
 

--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -126,22 +126,11 @@ spec:
 
 ## RBAC Permissions
 
-The operator requires these Kubernetes permissions, each one a verb the
-reconcile loop actually issues:
-
-- **core/namespaces**: `list`, `create`, `patch`, `delete`
-- **core/services, configmaps, persistentvolumeclaims**: `create`, `patch`
-- **core/secrets**: `get`, `create`, `patch`
-- **core/resourcequotas**: `delete`
-- **core/pods**: `list` (container statuses are the reason a deployment is not ready)
-- **apps/deployments**: `list`, `create`, `patch`
-- **networking.k8s.io/ingresses**: `get`, `create`, `update`, `patch`, `delete`
-- **networking.k8s.io/networkpolicies**: `create`, `patch`
-
-`create` accompanies `patch` because server-side apply creates the object on
-the first pass. The operator holds no watches, so `watch` is granted nowhere.
-
-These are automatically created by the deployment manifest.
+The ClusterRole in [`k8s-minimal.yaml`](k8s-minimal.yaml) is the list, and each
+rule there is annotated with the call that needs it. Every verb is one the
+reconcile loop issues: `create` accompanies `patch` because server-side apply
+creates the object on the first pass, and the operator holds no watches, so
+`watch` is granted nowhere.
 
 ### Secret access is still cluster-wide
 

--- a/lnvps_operator/k8s-minimal.yaml
+++ b/lnvps_operator/k8s-minimal.yaml
@@ -17,31 +17,44 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: lnvps-operator
+# Every rule below is a verb the reconcile loop issues. The operator holds no
+# watches, so `watch` is granted nowhere; server-side apply needs `create` as
+# well as `patch`, because the first pass creates the object.
 rules:
-# Namespaces: one dedicated namespace per app deployment (isolation boundary),
-# plus cluster-scoped listing for namespace garbage collection.
+# One namespace per deployment, listed cluster-wide for garbage collection and
+# deleted when its deployment is gone.
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-# Core resources created inside each deployment namespace.
+  verbs: ["list", "create", "patch", "delete"]
+# Applied into each deployment namespace, never read back.
 - apiGroups: [""]
-  resources: ["services", "secrets", "configmaps", "persistentvolumeclaims", "resourcequotas"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-# Pods are read-only: the replica counts say a workload is not ready, only the
-# container statuses say why, and that reason is what the customer sees.
+  resources: ["services", "configmaps", "persistentvolumeclaims"]
+  verbs: ["create", "patch"]
+# Secrets are also read: generated values are read back so they stay stable
+# across reconciles. See the note on scope in README.md.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "patch"]
+# Namespaces are no longer quota'd; the rule exists to remove objects left by
+# deployments provisioned before that change.
+- apiGroups: [""]
+  resources: ["resourcequotas"]
+  verbs: ["delete"]
+# Read-only: the replica counts say a workload is not ready, only the container
+# statuses say why, and that reason is what the customer sees.
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "watch"]
-# Workloads.
+  verbs: ["list"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-# Ingress (nostr domains + app deployments) and per-deployment isolation policy.
+  verbs: ["list", "create", "patch"]
+# Nostr domain ingresses are read, replaced and deleted by name; app ingresses
+# are server-side applied.
 - apiGroups: ["networking.k8s.io"]
-  resources: ["ingresses", "networkpolicies"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["events"]
+  resources: ["ingresses"]
+  verbs: ["get", "create", "update", "patch", "delete"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
   verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -1029,18 +1029,24 @@ fn build_generated_secret(
     }
 }
 
-/// Read a deployment's existing generated secret values (empty on first run).
-async fn read_generated(client: &Client, deployment_id: u64) -> BTreeMap<String, String> {
+/// Read a deployment's existing generated secret values.
+///
+/// Only a missing Secret means "first run". Any other failure has to stop the
+/// reconcile: read as empty, it regenerates every value and the apply that
+/// follows overwrites the stored ones, while the volumes still hold data
+/// written under the old passwords.
+async fn read_generated(client: &Client, deployment_id: u64) -> Result<BTreeMap<String, String>> {
     let api: Api<k8s_openapi::api::core::v1::Secret> =
         Api::namespaced(client.clone(), &namespace_name(deployment_id));
     match api.get("generated").await {
-        Ok(s) => s
+        Ok(s) => Ok(s
             .data
             .unwrap_or_default()
             .into_iter()
             .map(|(k, v)| (k, String::from_utf8_lossy(&v.0).to_string()))
-            .collect(),
-        Err(_) => BTreeMap::new(),
+            .collect()),
+        Err(kube::Error::Api(e)) if e.code == 404 => Ok(BTreeMap::new()),
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -1310,7 +1316,7 @@ async fn reconcile_one(
     apply(client, &build_network_policy(id, ingress_ns)).await?;
 
     // 2. Generated secrets: preserve existing values, generate any new ones.
-    let existing = read_generated(client, id).await;
+    let existing = read_generated(client, id).await?;
     let generated = ensure_secrets(&compose, &existing)?;
     apply(client, &build_generated_secret(id, &generated)).await?;
 
@@ -1645,6 +1651,47 @@ async fn gc_namespaces(client: &Client, active: &HashSet<u64>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A missing Secret is a first run; anything else — a 403 from a grant this
+    /// deployment's namespace does not carry — has to stop the reconcile rather
+    /// than look like "no secrets yet" and regenerate them all.
+    #[tokio::test]
+    async fn read_generated_separates_a_missing_secret_from_a_denied_one() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        async fn client_for(server: &MockServer) -> Client {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+            let mut config = kube::Config::new(server.uri().parse().unwrap());
+            config.default_namespace = "default".to_string();
+            Client::try_from(config).unwrap()
+        }
+
+        let missing = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/namespaces/app-7/secrets/generated"))
+            .respond_with(ResponseTemplate::new(404).set_body_string(
+                r#"{"kind":"Status","status":"Failure","code":404,"reason":"NotFound"}"#,
+            ))
+            .mount(&missing)
+            .await;
+        assert!(
+            read_generated(&client_for(&missing).await, 7)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let denied = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/namespaces/app-7/secrets/generated"))
+            .respond_with(ResponseTemplate::new(403).set_body_string(
+                r#"{"kind":"Status","status":"Failure","code":403,"reason":"Forbidden"}"#,
+            ))
+            .mount(&denied)
+            .await;
+        assert!(read_generated(&client_for(&denied).await, 7).await.is_err());
+    }
 
     const APP: &str = r#"
 services:


### PR DESCRIPTION
Part 2 of #297 (scoped RBAC). Part 1 is #298; part 3 (dedicated DB credentials) follows.

Every rule in the ClusterRole is now a verb the reconcile loop actually issues. Full inventory of Kubernetes calls in `lnvps_operator/src` (there are 16, all listed):

| resource | calls | verbs |
|---|---|---|
| namespaces | `list` `:1629`, `delete` `:1637`, apply `:1000` | list, create, patch, delete |
| secrets | `get("generated")` `:1036`, apply `:1315`, `:1341` | get, create, patch |
| services, configmaps, persistentvolumeclaims | apply `:1344`, `:1338`, `:1334` | create, patch |
| resourcequotas | `delete("quota")` `:296` | delete |
| pods | `list` `:1517` | list |
| apps/deployments | `list` `:1507`, apply `:1345` | list, create, patch |
| ingresses | `get`/`create`/`replace`/`delete` `nostr_domains.rs:262-448`, apply `:1381` | get, create, update, patch, delete |
| networkpolicies | apply `:1310` | create, patch |

Line numbers are `lnvps_operator/src/app_deployments.rs` unless noted.

What comes out:

- **`events`** — dead. Nothing in `lnvps_operator/src` constructs an `Event` or a recorder.
- **`watch` everywhere** — the loop is a polling reconcile; there is no `watcher()` and no `Controller` in the tree.
- **`update` except on ingresses** — everything else is server-side apply, which is `patch`. `create` stays beside `patch` because the first pass creates the object.
- **`get`/`list` where nothing reads back** — services, configmaps, PVCs, networkpolicies are written and never read.
- **`delete` on the per-namespace objects** — teardown deletes the namespace, and Kubernetes garbage-collects what is inside it.

Secret access stays cluster-wide, and the README now says so plainly rather than leaving it implied. Scoping it to `app-N` cannot be done by moving the rule to a Role: RBAC refuses to let a subject grant permissions it does not hold, so the operator would still need the cluster-wide verbs in order to create the binding. The route that works — a second ClusterRole plus `bind` by `resourceNames`, and a RoleBinding written per namespace at reconcile time — is code and a two-step rollout, filed as #299.

No test: this is the example manifest. `cargo test --workspace` unchanged and green (`lnvps_e2e` aside, which needs live services).

**This one has a live failure mode #298 does not.** Applying it takes permissions *away*. If the running operator is doing something this inventory missed, it starts 403-ing on the next pass. It also must not be applied as a whole file while #295 is open — the ClusterRoleBinding subject in this manifest names a namespace the operator may not run in. Applying the ClusterRole alone is the safe half, and that is Kieran's call.

Channel: lnvps (f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1)
