### PR TITLE
feat(operator): read the database DSN from a Secret, not the ConfigMap (#297 part 3)

### DIFF
--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -144,13 +144,15 @@ the `LNVPS_DATABASE_URL` environment variable (a Secret in the manifest). The
 config file's `db` key is still honoured as a fallback for local runs; the
 environment wins when both are set.
 
-It touches four things in the schema: it reads domains, apps and app clusters,
-and updates `app_deployment` rows. That is `SELECT` and `UPDATE` — no inserts,
-no deletes, and it never runs migrations, so it needs no DDL:
+It reads nostr domains, apps, app clusters, app deployments and the
+subscription rows that decide whether a deployment is paid for, and it writes
+to exactly one table: `app_deployment`. No inserts, no deletes, and it never
+runs migrations, so it needs no DDL:
 
 ```sql
 CREATE USER 'lnvps_operator'@'%' IDENTIFIED BY '<password>';
-GRANT SELECT, UPDATE ON lnvps.* TO 'lnvps_operator'@'%';
+GRANT SELECT ON lnvps.* TO 'lnvps_operator'@'%';
+GRANT UPDATE ON lnvps.app_deployment TO 'lnvps_operator'@'%';
 ```
 
 ```bash
@@ -158,8 +160,12 @@ kubectl -n lnvps-system create secret generic lnvps-operator-db \
   --from-literal=url='mysql://lnvps_operator:<password>@mysql-service:3306/lnvps'
 ```
 
-A schema change that makes the operator insert or delete needs the grant
-widened first, or the reconcile fails at that statement.
+Create the Secret before applying the Deployment. The `secretKeyRef` is
+required, so a container scheduled without it sits in
+`CreateContainerConfigError` and never starts.
+
+A schema change that makes the operator write another table, insert or delete
+needs the grant widened first, or the reconcile fails at that statement.
 
 ## Monitoring
 

--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -28,14 +28,11 @@ docker buildx bake lnvps-operator   # shared root Dockerfile, target lnvps-opera
 
 ### 2. Update Configuration
 
-Edit the ConfigMap in `k8s-deployment.yaml`:
+Edit the ConfigMap in `k8s-minimal.yaml`:
 
 ```yaml
 data:
   config.yaml: |
-    # Update the database connection string
-    db: "mysql://username:password@your-mysql-host:3306/lnvps"
-    
     # Set the namespace where your nostr service runs
     namespace: "your-namespace"
     
@@ -46,6 +43,9 @@ data:
     # Set your cert-manager cluster issuer
     cluster-issuer: "your-cluster-issuer"
 ```
+
+The database connection string does not go in the ConfigMap. See
+[Database user](#database-user).
 
 ### 3. Deploy the Operator
 
@@ -137,6 +137,30 @@ The operator requires these Kubernetes permissions:
 
 These are automatically created by the deployment manifest.
 
+## Database user
+
+The operator connects with its own MySQL user, not root, and reads the DSN from
+the `LNVPS_DATABASE_URL` environment variable (a Secret in the manifest). The
+config file's `db` key is still honoured as a fallback for local runs; the
+environment wins when both are set.
+
+It touches four things in the schema: it reads domains, apps and app clusters,
+and updates `app_deployment` rows. That is `SELECT` and `UPDATE` — no inserts,
+no deletes, and it never runs migrations, so it needs no DDL:
+
+```sql
+CREATE USER 'lnvps_operator'@'%' IDENTIFIED BY '<password>';
+GRANT SELECT, UPDATE ON lnvps.* TO 'lnvps_operator'@'%';
+```
+
+```bash
+kubectl -n lnvps-system create secret generic lnvps-operator-db \
+  --from-literal=url='mysql://lnvps_operator:<password>@mysql-service:3306/lnvps'
+```
+
+A schema change that makes the operator insert or delete needs the grant
+widened first, or the reconcile fails at that statement.
+
 ## Monitoring
 
 The deployment includes:
@@ -214,6 +238,6 @@ annotations:
 
 - The operator runs as non-root user (UID 65534)
 - Uses read-only root filesystem
-- Database credentials should be stored in Secrets
+- The database DSN is read from a Secret, never the ConfigMap
 - Network policies can restrict operator traffic
 - Consider using Pod Security Standards/Admission Controllers

--- a/lnvps_operator/k8s-minimal.yaml
+++ b/lnvps_operator/k8s-minimal.yaml
@@ -111,8 +111,10 @@ spec:
             secretKeyRef:
               name: lnvps-operator-encryption
               key: key
-        # Connection string for the operator's own MySQL user, which needs
-        # SELECT and UPDATE on the lnvps schema and nothing else. See README.md.
+        # Connection string for the operator's own MySQL user: SELECT on the
+        # schema, UPDATE on app_deployment, nothing else. See README.md.
+        # Create this Secret before applying the Deployment — the reference is
+        # required, so without it the container never starts.
         - name: LNVPS_DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/lnvps_operator/k8s-minimal.yaml
+++ b/lnvps_operator/k8s-minimal.yaml
@@ -65,7 +65,8 @@ metadata:
 data:
   config.yaml: |
     # CHANGE THESE VALUES FOR YOUR SETUP
-    db: "mysql://root:password@mysql-service:3306/lnvps"
+    # The database DSN is a credential and is NOT here: it comes from the
+    # lnvps-operator-db Secret through LNVPS_DATABASE_URL below.
     namespace: "default"
     service-name: "lnvps-nostr"
     port-name: "http"
@@ -110,6 +111,13 @@ spec:
             secretKeyRef:
               name: lnvps-operator-encryption
               key: key
+        # Connection string for the operator's own MySQL user, which needs
+        # SELECT and UPDATE on the lnvps schema and nothing else. See README.md.
+        - name: LNVPS_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: lnvps-operator-db
+              key: url
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/lnvps_operator/src/main.rs
+++ b/lnvps_operator/src/main.rs
@@ -23,6 +23,10 @@ use crate::metrics::PrometheusClient;
 /// operator can decrypt columns the API encrypted (e.g. `app_deployment.config`).
 const ENCRYPTION_KEY_ENV: &str = "LNVPS_ENCRYPTION_KEY";
 
+/// Overrides `db` from the config file, so a deployment can keep its
+/// non-sensitive settings in a ConfigMap and read the DSN from a Secret.
+const DATABASE_URL_ENV: &str = "LNVPS_DATABASE_URL";
+
 /// Database field-encryption configuration (mirrors the API's `EncryptionConfig`
 /// so both sides use the same key).
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -38,7 +42,10 @@ pub struct EncryptionConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Settings {
-    /// MYSQL connection string
+    /// MYSQL connection string. Optional here because the DSN carries a
+    /// password and belongs in a Secret rather than the config file; see
+    /// [`DATABASE_URL_ENV`].
+    #[serde(default)]
     pub db: String,
 
     /// Kubernetes namespace to watch (defaults to "default" if not specified)
@@ -129,6 +136,22 @@ pub struct Context {
     pub metrics: Option<PrometheusClient>,
 }
 
+/// The DSN to connect with: the environment wins over the config file, so the
+/// credential can live in a Secret while the rest of the config stays in a
+/// ConfigMap.
+fn database_url(configured: &str, from_env: Option<String>) -> Result<String> {
+    let env = from_env.unwrap_or_default();
+    let url = if env.trim().is_empty() {
+        configured.trim()
+    } else {
+        env.trim()
+    };
+    if url.is_empty() {
+        anyhow::bail!("no database connection string: set {DATABASE_URL_ENV} or `db` in the config");
+    }
+    Ok(url.to_string())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // kube (via hyper-rustls) and sqlx's TLS both use rustls, but the dependency
@@ -165,7 +188,8 @@ async fn main() -> Result<()> {
         );
     }
 
-    let db = LNVpsDbMysql::new(&settings.db).await?;
+    let db_url = database_url(&settings.db, std::env::var(DATABASE_URL_ENV).ok())?;
+    let db = LNVpsDbMysql::new(&db_url).await?;
     let client = Client::try_default().await?;
 
     let metrics = match &settings.prometheus {
@@ -323,6 +347,27 @@ async fn trigger_listener(ctx: Arc<Context>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The DSN is a credential, so a deployment can supply it from a Secret
+    /// through the environment; the config file stays the fallback.
+    #[test]
+    fn database_url_prefers_the_environment() {
+        assert_eq!(
+            database_url("mysql://from-config", Some("mysql://from-env".into())).unwrap(),
+            "mysql://from-env"
+        );
+        assert_eq!(
+            database_url("mysql://from-config", None).unwrap(),
+            "mysql://from-config"
+        );
+        // An env var set to nothing is not a connection string.
+        assert_eq!(
+            database_url("mysql://from-config", Some("  ".into())).unwrap(),
+            "mysql://from-config"
+        );
+        assert!(database_url("", None).is_err());
+        assert!(database_url("", Some(String::new())).is_err());
+    }
 
     fn load(name: &str) -> Settings {
         let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), name);


### PR DESCRIPTION
Part 3 of #297 (dedicated DB credentials), and the last part. Parts 1 and 2 are #298 and #300; this branch is off master, so it is independent of both.

- `LNVPS_DATABASE_URL` overrides `db` from the config file (`lnvps_operator/src/main.rs:141-155`), matching how `LNVPS_ENCRYPTION_KEY` already works in the same binary. `Settings.db` becomes `#[serde(default)]`; with neither set the operator refuses to start rather than connecting to nothing.
- `k8s-minimal.yaml` — the DSN is out of the ConfigMap and comes from a `lnvps-operator-db` Secret.
- `README.md` — a "Database user" section with the exact grant.

**The grant is narrower than the issue proposed.** The issue asked for `SELECT/INSERT/UPDATE/DELETE`; the operator issues four database calls in total —`list_all_domains`, `get_app`, `get_app_cluster`, `get_subscription_by_line_item_id`, `list_all_app_deployments` are reads, and `update_app_deployment` / `update_app_deployment_usage` are `UPDATE` statements (`lnvps_db/src/mysql.rs:4240`, `:4267`). It never inserts, never deletes and never migrates (`.migrate()` has no call site in `lnvps_operator/src`), so:

```sql
GRANT SELECT ON lnvps.* TO 'lnvps_operator'@'%';
GRANT UPDATE ON lnvps.app_deployment TO 'lnvps_operator'@'%';
```

If a later change makes the operator insert or delete, the grant has to widen first or the reconcile fails at that statement. That is a deliberate trade: least privilege now, one more ask later.

Test: `database_url_prefers_the_environment` (`lnvps_operator/src/main.rs`) pins env-over-config, config fallback, whitespace-only env ignored, and the both-empty error. `cargo test --workspace` green (`lnvps_e2e` aside, which needs live services); clippy clean on the crate.

**Two asks, both Kieran's — merging this does neither:**

1. Create the MySQL user and grant above.
2. Create the `lnvps-operator-db` Secret with its DSN **before** applying the Deployment — the reference is required, so a container scheduled without it sits in CreateContainerConfigError.

Until both exist, the running operator keeps using whatever DSN its current config carries — the env var is absent, so the config value still wins. Nothing breaks on merge.

Channel: lnvps (f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1)