### PR TITLE
feat(operator): grant secret access per deployment namespace (#299)

### DIFF
--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -137,14 +137,22 @@ creates the object on the first pass, and the operator holds no watches, so
 The operator holds no cluster-wide grant on Secrets. `lnvps-operator-appns` is a
 second ClusterRole carrying the secret verbs, and it is never bound
 cluster-wide: as the operator creates each `app-N` namespace it writes a
-RoleBinding to it in that namespace, so its token reads only namespaces it
-provisioned — not `kube-system`, not cert-manager's, not another deployment's
-TLS keys.
+RoleBinding to it in that namespace, and a RoleBinding grants only inside its
+own namespace.
 
 Writing that binding is allowed by two narrow rules rather than by holding the
 secret verbs: `rolebindings: create, patch`, and `bind` on
 `lnvps-operator-appns` by name. `bind` exists for exactly this — it permits a
 binding to a named role without holding that role's permissions.
+
+**What this does and does not buy.** Those two rules are themselves
+cluster-wide — a ClusterRole cannot scope `rolebindings` to namespaces that do
+not exist yet — so a stolen token can write the same binding into `kube-system`
+and read Secrets there. The reachable ceiling is unchanged. What changes is that
+reaching it now takes a deliberate second write that lands in the audit log,
+instead of a single `get` that looks exactly like normal operation. Narrowing
+further needs an admission policy on who may bind that role, or a controller
+that is not the thing creating namespaces.
 
 The subject comes from the downward API (`LNVPS_OPERATOR_NAMESPACE`,
 `LNVPS_OPERATOR_SERVICE_ACCOUNT`). With either missing the operator writes no

--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -132,20 +132,37 @@ reconcile loop issues: `create` accompanies `patch` because server-side apply
 creates the object on the first pass, and the operator holds no watches, so
 `watch` is granted nowhere.
 
-### Secret access is still cluster-wide
+### Secret access is scoped per namespace
 
-The only secret the operator reads is `generated` in each `app-N` namespace it
-created (`read_generated`), but the grant above is a ClusterRole, so a stolen
-token reads every Secret in the cluster — every tenant's generated passwords and
-every TLS private key.
+The operator holds no cluster-wide grant on Secrets. `lnvps-operator-appns` is a
+second ClusterRole carrying the secret verbs, and it is never bound
+cluster-wide: as the operator creates each `app-N` namespace it writes a
+RoleBinding to it in that namespace, so its token reads only namespaces it
+provisioned — not `kube-system`, not cert-manager's, not another deployment's
+TLS keys.
 
-Moving that to a Role in each `app-N` namespace does not work on its own:
-Kubernetes refuses to let a subject grant permissions it does not already hold,
-so the operator would need those same cluster-wide secret verbs (or `escalate`)
-to create the binding. The way out is a second, static ClusterRole holding the
-namespace-scoped verbs plus `bind` on it by name, with the operator creating a
-RoleBinding per namespace at reconcile time. That is a code change and a
-two-step rollout, tracked in issue #299.
+Writing that binding is allowed by two narrow rules rather than by holding the
+secret verbs: `rolebindings: create, patch`, and `bind` on
+`lnvps-operator-appns` by name. `bind` exists for exactly this — it permits a
+binding to a named role without holding that role's permissions.
+
+The subject comes from the downward API (`LNVPS_OPERATOR_NAMESPACE`,
+`LNVPS_OPERATOR_SERVICE_ACCOUNT`). With either missing the operator writes no
+binding at all and relies on whatever grant it already has, which is what makes
+the rollout survivable.
+
+**Rollout is three ordered steps, and the manifest is the end state:**
+
+1. Apply `lnvps-operator-appns` and add the `rolebindings` + `bind` rules to
+   `lnvps-operator`, *keeping* its existing `secrets` rule.
+2. Roll the new image with the two downward-API env vars. Each namespace gets
+   its binding on the next reconcile pass.
+3. Remove the `secrets` rule from `lnvps-operator`.
+
+Doing 3 before 2 leaves the operator unable to read `generated`, which now fails
+the reconcile loudly rather than regenerating every password. Namespaces created
+before step 2 are repaired by the pass that binds them; the binding is deleted
+with its namespace, so nothing outlives a deployment.
 
 ## Runtime hardening
 

--- a/lnvps_operator/k8s-minimal.yaml
+++ b/lnvps_operator/k8s-minimal.yaml
@@ -30,11 +30,17 @@ rules:
 - apiGroups: [""]
   resources: ["services", "configmaps", "persistentvolumeclaims"]
   verbs: ["create", "patch"]
-# Secrets are also read: generated values are read back so they stay stable
-# across reconciles. See the note on scope in README.md.
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "create", "patch"]
+# Secrets are NOT here: they are granted per deployment namespace by the
+# lnvps-operator-appns ClusterRole below, bound by the operator as it creates
+# each namespace. These two rules are what let it write that binding without
+# holding the secret verbs cluster-wide.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
+  verbs: ["create", "patch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  resourceNames: ["lnvps-operator-appns"]
+  verbs: ["bind"]
 # Namespaces are no longer quota'd; the rule exists to remove objects left by
 # deployments provisioned before that change.
 - apiGroups: [""]
@@ -56,6 +62,18 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
   verbs: ["create", "patch"]
+---
+# Namespace-scoped grant. Never bound cluster-wide: the operator creates a
+# RoleBinding to it inside each app-N namespace it provisions, so a stolen
+# token reads only the namespaces the operator itself created.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lnvps-operator-appns
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -126,6 +144,17 @@ spec:
         env:
         - name: RUST_LOG
           value: "info"
+        # Identity the operator names as the subject of the per-namespace
+        # RoleBinding it writes. Without both, it creates no binding and falls
+        # back to whatever grant it already holds.
+        - name: LNVPS_OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LNVPS_OPERATOR_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         # Database field-encryption key (hex). MUST match the API's key so the
         # operator can decrypt app_deployment.config. Required for app
         # deployments; omit if running nostr-domains only.

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -31,6 +31,7 @@ use k8s_openapi::api::core::v1::{
     ResourceRequirements, SeccompProfile, SecurityContext, Service, ServicePort, ServiceSpec,
     Volume as K8sVolume, VolumeMount, VolumeResourceRequirements,
 };
+use k8s_openapi::api::rbac::v1::{RoleBinding, RoleRef, Subject};
 use k8s_openapi::api::networking::v1::{
     HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
     IngressServiceBackend, IngressSpec, IngressTLS, NetworkPolicy, NetworkPolicySpec,
@@ -45,6 +46,10 @@ use lnvps_compose::{
 
 /// Label value marking objects this operator owns.
 pub const MANAGED_BY: &str = "lnvps-operator";
+
+/// ClusterRole carrying the namespace-scoped verbs the operator needs inside a
+/// deployment namespace. Bound per namespace, never cluster-wide.
+pub const APP_NAMESPACE_CLUSTER_ROLE: &str = "lnvps-operator-appns";
 
 /// The Kubernetes namespace for a deployment.
 pub fn namespace_name(deployment_id: u64) -> String {
@@ -110,6 +115,62 @@ pub fn build_namespace(deployment_id: u64) -> Namespace {
 /// [`ROOT_ENTRYPOINT_CAPABILITIES`]) still applies.
 pub fn build_namespace_baseline(deployment_id: u64) -> Namespace {
     build_namespace_with_level(deployment_id, "baseline")
+}
+
+/// The identity the operator runs as, when the cluster tells it.
+///
+/// Needed to bind itself permission inside each deployment namespace; without
+/// it the operator cannot write a RoleBinding naming a subject, and falls back
+/// to whatever cluster-wide grant it already has.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorIdentity {
+    pub service_account: String,
+    pub namespace: String,
+}
+
+impl OperatorIdentity {
+    /// Read from the downward API the Deployment injects. Absent in a local run
+    /// and in any install that predates it, which is why every caller treats
+    /// `None` as "leave the namespace unbound".
+    pub fn from_env() -> Option<Self> {
+        let service_account = std::env::var("LNVPS_OPERATOR_SERVICE_ACCOUNT").ok()?;
+        let namespace = std::env::var("LNVPS_OPERATOR_NAMESPACE").ok()?;
+        if service_account.trim().is_empty() || namespace.trim().is_empty() {
+            return None;
+        }
+        Some(Self {
+            service_account: service_account.trim().to_string(),
+            namespace: namespace.trim().to_string(),
+        })
+    }
+}
+
+/// Binds the operator to [`APP_NAMESPACE_CLUSTER_ROLE`] inside one deployment
+/// namespace, which is what lets its token read that namespace's secrets
+/// without holding a cluster-wide grant on every Secret in the cluster.
+///
+/// A RoleBinding to a ClusterRole grants only within the binding's namespace,
+/// so this is the whole isolation boundary: no binding, no access.
+pub fn build_role_binding(deployment_id: u64, operator: &OperatorIdentity) -> RoleBinding {
+    RoleBinding {
+        metadata: ObjectMeta {
+            name: Some(MANAGED_BY.to_string()),
+            namespace: Some(namespace_name(deployment_id)),
+            labels: Some(labels(deployment_id)),
+            ..Default::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "ClusterRole".to_string(),
+            name: APP_NAMESPACE_CLUSTER_ROLE.to_string(),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name: operator.service_account.clone(),
+            namespace: Some(operator.namespace.clone()),
+            ..Default::default()
+        }]),
+    }
 }
 
 /// The isolation NetworkPolicy for a deployment namespace.
@@ -1314,6 +1375,11 @@ async fn reconcile_one(
         .as_deref()
         .unwrap_or("ingress-nginx");
     apply(client, &build_network_policy(id, ingress_ns)).await?;
+    // The binding has to exist before anything reads or writes a Secret here:
+    // it is the only grant the operator has in this namespace.
+    if let Some(operator) = OperatorIdentity::from_env() {
+        apply(client, &build_role_binding(id, &operator)).await?;
+    }
 
     // 2. Generated secrets: preserve existing values, generate any new ones.
     let existing = read_generated(client, id).await?;
@@ -1651,6 +1717,68 @@ async fn gc_namespaces(client: &Client, active: &HashSet<u64>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The per-namespace binding is the only thing standing between the
+    /// operator's token and every Secret in the cluster, so its shape is
+    /// pinned: right namespace, right ClusterRole, right subject.
+    #[test]
+    fn role_binding_grants_the_operator_only_inside_the_deployment_namespace() {
+        let operator = OperatorIdentity {
+            service_account: "lnvps-operator".to_string(),
+            namespace: "lnvps".to_string(),
+        };
+        let rb = build_role_binding(7, &operator);
+
+        assert_eq!(rb.metadata.namespace.as_deref(), Some("app-7"));
+        assert_eq!(rb.role_ref.kind, "ClusterRole");
+        assert_eq!(rb.role_ref.name, APP_NAMESPACE_CLUSTER_ROLE);
+        let subjects = rb.subjects.expect("a subject");
+        assert_eq!(subjects.len(), 1);
+        assert_eq!(subjects[0].kind, "ServiceAccount");
+        assert_eq!(subjects[0].name, "lnvps-operator");
+        // The subject namespace is where the operator runs, not the namespace
+        // being granted: getting these two the wrong way round grants nothing
+        // and 403s every reconcile.
+        assert_eq!(subjects[0].namespace.as_deref(), Some("lnvps"));
+        assert_eq!(
+            rb.metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get("managed-by"))
+                .map(String::as_str),
+            Some(MANAGED_BY)
+        );
+    }
+
+    /// A partially configured environment must not produce a binding with a
+    /// half-empty subject, which the API server would reject on every pass.
+    #[test]
+    fn operator_identity_needs_both_halves() {
+        // Safety: single-threaded test, no other thread reads these vars.
+        unsafe {
+            std::env::remove_var("LNVPS_OPERATOR_SERVICE_ACCOUNT");
+            std::env::set_var("LNVPS_OPERATOR_NAMESPACE", "lnvps");
+        }
+        assert!(OperatorIdentity::from_env().is_none());
+        unsafe {
+            std::env::set_var("LNVPS_OPERATOR_SERVICE_ACCOUNT", "  ");
+        }
+        assert!(OperatorIdentity::from_env().is_none());
+        unsafe {
+            std::env::set_var("LNVPS_OPERATOR_SERVICE_ACCOUNT", "lnvps-operator");
+        }
+        assert_eq!(
+            OperatorIdentity::from_env(),
+            Some(OperatorIdentity {
+                service_account: "lnvps-operator".to_string(),
+                namespace: "lnvps".to_string(),
+            })
+        );
+        unsafe {
+            std::env::remove_var("LNVPS_OPERATOR_SERVICE_ACCOUNT");
+            std::env::remove_var("LNVPS_OPERATOR_NAMESPACE");
+        }
+    }
 
     /// A missing Secret is a first run; anything else — a 403 from a grant this
     /// deployment's namespace does not carry — has to stop the reconcile rather

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -31,12 +31,12 @@ use k8s_openapi::api::core::v1::{
     ResourceRequirements, SeccompProfile, SecurityContext, Service, ServicePort, ServiceSpec,
     Volume as K8sVolume, VolumeMount, VolumeResourceRequirements,
 };
-use k8s_openapi::api::rbac::v1::{RoleBinding, RoleRef, Subject};
 use k8s_openapi::api::networking::v1::{
     HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
     IngressServiceBackend, IngressSpec, IngressTLS, NetworkPolicy, NetworkPolicySpec,
     ServiceBackendPort,
 };
+use k8s_openapi::api::rbac::v1::{RoleBinding, RoleRef, Subject};
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use lnvps_compose::{
@@ -1369,17 +1369,18 @@ async fn reconcile_one(
         build_namespace(id)
     };
     apply_namespace(client, &namespace).await?;
+    // The binding is the operator's only grant inside this namespace, and the
+    // authorizer reads it from a cache that lags the write. Applying it first
+    // buys the rest of this pass as propagation time before a Secret is read.
+    if let Some(operator) = OperatorIdentity::from_env() {
+        apply(client, &build_role_binding(id, &operator)).await?;
+    }
     let ingress_ns = ctx
         .settings
         .ingress_namespace
         .as_deref()
         .unwrap_or("ingress-nginx");
     apply(client, &build_network_policy(id, ingress_ns)).await?;
-    // The binding has to exist before anything reads or writes a Secret here:
-    // it is the only grant the operator has in this namespace.
-    if let Some(operator) = OperatorIdentity::from_env() {
-        apply(client, &build_role_binding(id, &operator)).await?;
-    }
 
     // 2. Generated secrets: preserve existing values, generate any new ones.
     let existing = read_generated(client, id).await?;


### PR DESCRIPTION
Closes #299. Separate from #297, which is merged and closed — that hardened the pod (non-root, trimmed verbs, DSN in a Secret) but deliberately left secret access cluster-wide, and this is the piece it deferred.

The operator no longer holds any cluster-wide grant on Secrets. Instead:

- `lnvps-operator-appns` (new ClusterRole) carries `secrets: get, create, patch` and is **never bound cluster-wide** — a RoleBinding grants only inside its own namespace.
- As the operator creates each `app-N` namespace it applies a RoleBinding to that ClusterRole in that namespace (`build_role_binding`, `lnvps_operator/src/app_deployments.rs:148`, applied at `:1382` right after the NetworkPolicy and before anything touches a Secret). A RoleBinding to a ClusterRole grants only inside its own namespace, so the binding is the whole boundary.
- Writing that binding costs two narrow rules instead of the secret verbs: `rolebindings: create, patch`, and `bind` on `lnvps-operator-appns` by `resourceNames`. `bind` is the RBAC escape hatch for exactly this — a binding to a named role without holding its permissions, so no `escalate` and no cluster-wide secret read.
- The subject comes from the downward API (`metadata.namespace`, `spec.serviceAccountName`). With either missing, `OperatorIdentity::from_env` returns `None`, no binding is written, and the operator relies on whatever grant it already has. That is what makes the rollout survivable rather than a flag day.

Tests (`cargo test -p lnvps_operator` 52 pass): the binding's namespace, `roleRef` and subject are pinned — including that the subject namespace is where the operator runs, not the namespace being granted, which is the mistake that grants nothing and 403s forever — and a half-configured environment produces no binding rather than a subject with an empty half.

**Rollout is three ordered steps and the manifest is the end state.** This is the ask, not something merging does:

1. Apply `lnvps-operator-appns`, and add the `rolebindings` + `bind` rules to `lnvps-operator` while **keeping** its current `secrets` rule.
2. Roll the new image (with the two env vars). Every namespace picks up its binding on the next reconcile pass.
3. Remove the `secrets` rule from `lnvps-operator`.

Step 3 before step 2 leaves the operator unable to read `generated`; since #300 that fails the reconcile loudly instead of regenerating every password, but it is still an outage for app reconcile. The binding lives in the namespace, so it is deleted with it.

**What the ceiling actually is.** `rolebindings: create, patch` and `bind` are themselves cluster-wide — a ClusterRole cannot scope rolebindings to namespaces that do not exist yet — so a stolen token can write the same binding into `kube-system` and read Secrets there. What changes is that reaching it takes a deliberate second write that lands in the audit log rather than a single `get` indistinguishable from normal operation. Narrowing further needs an admission policy on who may bind that role.

Two things this does not do: the operator still holds the field-encryption key and the database DSN, so a compromised pod still reads tenant config from the database; and the other namespaced verbs (configmaps, services, PVCs, deployments, networkpolicies) are still cluster-wide. Both are separable from the secret boundary and neither is in scope here.

Channel: lnvps (f5894ea9-44c7-56fb-bd9b-6e3e671e4bc1)
