### PR TITLE
Record both sides of a converted referral payout

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -3395,7 +3395,7 @@ Returns the referral plus per-currency earned commission, payout history and cou
     "created": "2026-07-18T10:00:00Z",
     "earned": [ { "currency": "BTC", "amount": 5000 } ],
     "payouts": [
-      { "id": 1, "amount": 5000, "fee": 0, "currency": "BTC", "created": "2026-07-18T11:00:00Z", "is_paid": true, "mode": "lightning_address", "output": "lnbc...", "pre_image": "<hex>" }
+      { "id": 1, "amount": 5000, "fee": 0, "currency": "BTC", "sent_amount": 5000, "sent_fee": 0, "sent_currency": "BTC", "rate": 1.0, "rate_collected": null, "created": "2026-07-18T11:00:00Z", "is_paid": true, "mode": "lightning_address", "output": "lnbc...", "pre_image": "<hex>" }
     ],
     "referrals_success": 3,
     "referrals_failed": 1
@@ -3439,6 +3439,8 @@ Required Permission: `referral::view`
 
 Returns an array of payout records (`AdminReferralPayoutInfo`), most recent first. Each record carries `fee` (the network/routing fee charged to the referrer, debited from their balance), `mode` (`lightning_address`/`nwc`/`on_chain`), and `output` (a BOLT11 invoice for Lightning payouts, or the on-chain outpoint `"{txid}:{vout}"` for on-chain payouts; batched rows share the txid but carry distinct vouts).
 
+A payout has two sides. The **settled** side (`amount`, `fee`, `currency`) is what it discharges against the earned balance; commission nets in the currency it was earned in. The **sent** side (`sent_amount`, `sent_fee`, `sent_currency`) is what actually left the wallet. `rate` is settled-currency standard units per one sent-currency standard unit, and `rate_collected` is when that rate was quoted. When no conversion happened the two sides are equal, `rate` is `1` and `rate_collected` is `null`.
+
 #### Create Referral Payout
 
 ```
@@ -3452,9 +3454,21 @@ Creates a manual payout record (e.g. reconciling an out-of-band payment).
 ```json
 {
   "amount": 5000,
-  // Required - smallest currency unit, > 0
+  // Required - settled amount, smallest unit of `currency`, > 0
   "currency": "BTC",
-  // Required
+  // Required - the currency the commission was earned in; this is what the payout nets against
+  "fee": 0,
+  // Optional - fee charged to the referrer, smallest unit of `currency` (default 0)
+  "sent_currency": "BTC",
+  // Optional - currency actually transferred; omit (or repeat `currency`) when nothing was converted
+  "sent_amount": 5000,
+  // Required when `sent_currency` differs from `currency` - smallest unit of `sent_currency`, > 0
+  "sent_fee": 0,
+  // Optional - fee as the network charged it, smallest unit of `sent_currency` (default 0)
+  "rate": 90000.0,
+  // Required when `sent_currency` differs from `currency` - settled-currency standard units per one sent-currency standard unit, > 0. Rejected when the currencies are the same.
+  "rate_collected": "2026-07-28T17:00:00Z",
+  // Optional - when the rate was quoted (defaults to now for a converted payout). Rejected when the currencies are the same.
   "output": "lnbc...",
   // Optional - payout output reference (BOLT11 invoice or on-chain outpoint)
   "mode": "lightning_address",

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -66,6 +66,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Referral payouts record both sides of a currency conversion** (issue #308) — a payout row now carries a **settled** side and a **sent** side. The settled side (`amount`, `fee`, `currency`) is what the payout discharges against the earned balance; commission is earned per currency and nets in the currency it was earned in. The sent side (`sent_amount`, `sent_fee`, `sent_currency`) is what actually left the wallet. `rate` is settled-currency standard units per one sent-currency standard unit, and `rate_collected` is when that rate was quoted.
+
+  Additive on `ApiReferralPayout` (`GET /api/v1/referral`) and `AdminReferralPayoutInfo` (`GET /api/admin/v1/referrals/{id}` and `/payouts`): no existing field changes meaning. A payout that sent what it settles — every payout the automated engine makes today, and every row that existed before this change — has the two sides equal, `rate` `1` and `rate_collected` `null`. Treat a `null` `rate_collected` as "no conversion happened" rather than "rate 1 was quoted".
+
+  `POST /api/admin/v1/referrals/{id}/payouts` accepts the sent side for reconciling an out-of-band payment: `sent_currency`, `sent_amount`, `sent_fee`, `rate`, `rate_collected`, plus `fee` on the settled side. When `sent_currency` differs from `currency`, `sent_amount` and a positive `rate` are required; when they are the same, a `rate` or a diverging `sent_amount`/`sent_fee` is rejected. Automatic conversion at send time is not implemented — a cross-currency payout is recorded by an admin today.
+
 - **`usage` on an app deployment — what it is actually consuming** (issue #278) — `ApiAppDeployment` (`GET /api/v1/app-deployments` and `/{id}`, and every endpoint returning a deployment) gains a nullable `usage` object. Additive: no existing field changes.
 
   ```json

--- a/lnvps_api/src/api/referral.rs
+++ b/lnvps_api/src/api/referral.rs
@@ -103,15 +103,32 @@ pub struct ApiReferralEarning {
     pub amount: u64,
 }
 
-/// A single payout record
+/// A single payout record.
+///
+/// A payout has a settled side (`amount`, `fee`, `currency`) — what it takes
+/// off your earned balance — and a sent side (`sent_amount`, `sent_fee`,
+/// `sent_currency`) — what was actually transferred. They are equal, with
+/// `rate` 1 and `rate_collected` null, when no conversion happened.
 #[derive(Serialize)]
 pub struct ApiReferralPayout {
     pub id: u64,
     pub amount: u64,
-    /// Network/routing fee charged to you for this payout (smallest currency
-    /// unit), debited from your balance alongside `amount`.
+    /// Network/routing fee charged to you for this payout (smallest unit of
+    /// `currency`), debited from your balance alongside `amount`.
     pub fee: u64,
     pub currency: String,
+    /// Amount actually transferred, in the smallest unit of `sent_currency`.
+    pub sent_amount: u64,
+    /// Network/routing fee as the network charged it, in the smallest unit of
+    /// `sent_currency`.
+    pub sent_fee: u64,
+    /// Currency actually transferred.
+    pub sent_currency: String,
+    /// Settled-currency standard units per one sent-currency standard unit; 1
+    /// when the two currencies are the same.
+    pub rate: f32,
+    /// When `rate` was quoted; null when no conversion happened.
+    pub rate_collected: Option<chrono::DateTime<Utc>>,
     pub created: chrono::DateTime<Utc>,
     pub is_paid: bool,
     /// How this payout was made: `lightning_address`, `nwc`, or `on_chain`.
@@ -133,6 +150,11 @@ impl From<ReferralPayout> for ApiReferralPayout {
             amount: p.amount,
             fee: p.fee,
             currency: p.currency,
+            sent_amount: p.sent_amount,
+            sent_fee: p.sent_fee,
+            sent_currency: p.sent_currency,
+            rate: p.rate,
+            rate_collected: p.rate_collected,
             created: p.created,
             is_paid: p.is_paid,
             mode: p.mode.to_string(),

--- a/lnvps_api/src/referral/mod.rs
+++ b/lnvps_api/src/referral/mod.rs
@@ -46,6 +46,20 @@ fn payable_referral_msat(earned_msat: u64, existing_msat: u64, min_msat: u64) ->
     if pay_msat == 0 { None } else { Some(pay_msat) }
 }
 
+/// Millisats already reserved or paid against a referrer's BTC balance.
+///
+/// A payout nets in the currency it settles, not the currency it sent: a EUR
+/// commission sent as BTC discharges EUR and must leave the BTC balance alone,
+/// or the referrer is charged twice for one transfer. The referrer bears the
+/// fee, so it is debited alongside the amount.
+fn settled_btc_msat(payouts: &[ReferralPayout]) -> u64 {
+    payouts
+        .iter()
+        .filter(|p| p.currency.eq_ignore_ascii_case("BTC"))
+        .map(|p| p.amount.saturating_add(p.fee))
+        .sum()
+}
+
 /// Split `total_fee` across payouts in proportion to their `amounts`, returning
 /// one fee per entry (in order). Any rounding remainder is added to the largest
 /// payout so the shares sum to exactly `total_fee`.
@@ -287,7 +301,9 @@ impl ReferralPayoutHandler {
                 mode: ReferralPayoutMode::OnChain,
                 output: None,
                 pre_image: None,
-            };
+                ..Default::default()
+            }
+            .unconverted();
             let payout_id = self.db.insert_referral_payout(&payout).await?;
             reserved.push((payout_id, referral.clone(), addr.clone(), *pay_msat));
         }
@@ -348,7 +364,9 @@ impl ReferralPayoutHandler {
                         mode: ReferralPayoutMode::OnChain,
                         output: Some(outpoint.clone()),
                         pre_image: None,
-                    };
+                        ..Default::default()
+                    }
+                    .unconverted();
                     if let Err(e) = self.db.update_referral_payout(&payout).await {
                         warn!(
                             "Broadcast payout {} but failed to mark it paid: {}",
@@ -421,15 +439,7 @@ impl ReferralPayoutHandler {
             .filter(|u| u.currency.eq_ignore_ascii_case("BTC"))
             .map(|u| u.commission())
             .sum();
-        // The referrer bears fees, so debit amount + fee from their balance.
-        let existing: u64 = self
-            .db
-            .list_referral_payouts(referral.id)
-            .await?
-            .iter()
-            .filter(|p| p.currency.eq_ignore_ascii_case("BTC"))
-            .map(|p| p.amount.saturating_add(p.fee))
-            .sum();
+        let existing = settled_btc_msat(&self.db.list_referral_payouts(referral.id).await?);
         Ok(payable_referral_msat(
             earned_msat,
             existing,
@@ -449,17 +459,8 @@ impl ReferralPayoutHandler {
             .map(|u| u.commission())
             .sum();
 
-        // Subtract every existing BTC payout record (paid AND reserved) so an
-        // in-flight reservation is never paid twice. The referrer bears fees, so
-        // debit amount + fee.
-        let existing: u64 = self
-            .db
-            .list_referral_payouts(referral.id)
-            .await?
-            .iter()
-            .filter(|p| p.currency.eq_ignore_ascii_case("BTC"))
-            .map(|p| p.amount.saturating_add(p.fee))
-            .sum();
+        // Paid AND reserved, so an in-flight reservation is never paid twice.
+        let existing = settled_btc_msat(&self.db.list_referral_payouts(referral.id).await?);
 
         let Some(pay_msat) = payable_referral_msat(
             earned_msat,
@@ -481,7 +482,9 @@ impl ReferralPayoutHandler {
             mode: referral.mode,
             output: None,
             pre_image: None,
-        };
+            ..Default::default()
+        }
+        .unconverted();
         let payout_id = self.db.insert_referral_payout(&payout).await?;
         payout.id = payout_id;
 
@@ -491,8 +494,10 @@ impl ReferralPayoutHandler {
                 // `output` is the paid BOLT11 invoice for Lightning payouts.
                 payout.output = Some(bolt11);
                 payout.pre_image = pre_image;
-                // Charge the referrer the routing fee we paid.
+                // Charge the referrer the routing fee we paid. Settled and sent
+                // are both BTC here, so the fee is the same figure on each side.
                 payout.fee = fee_msat;
+                payout.sent_fee = fee_msat;
                 self.db.update_referral_payout(&payout).await?;
                 info!(
                     "Paid referral commission {} msat (fee {} msat) to code {} (payout {})",
@@ -695,6 +700,50 @@ mod tests {
         // Zero fee / zero amounts.
         assert_eq!(split_fee_proportional(&[1, 2], 0), vec![0, 0]);
         assert_eq!(split_fee_proportional(&[0, 0], 100), vec![0, 0]);
+    }
+
+    /// Netting is by the currency a payout settles, not the one it sent. A EUR
+    /// commission settled in EUR but transferred as BTC must not also reduce the
+    /// BTC balance, and a BTC commission stays debited whatever left the wallet.
+    #[test]
+    fn test_settled_btc_msat_nets_by_the_settled_currency() {
+        let btc = ReferralPayout {
+            amount: 2_000_000,
+            fee: 1_000,
+            currency: "BTC".to_string(),
+            ..Default::default()
+        };
+        // Same commission, sent as EUR out of band: still discharges BTC.
+        let btc_sent_as_eur = ReferralPayout {
+            amount: 500_000,
+            fee: 0,
+            currency: "btc".to_string(),
+            sent_amount: 430,
+            sent_currency: "EUR".to_string(),
+            rate: 0.000_001,
+            rate_collected: Some(Utc::now()),
+            ..Default::default()
+        };
+        // EUR commission sent as BTC: discharges EUR, invisible to BTC netting.
+        let eur_sent_as_btc = ReferralPayout {
+            amount: 5_000,
+            fee: 3,
+            currency: "EUR".to_string(),
+            sent_amount: 55_000_000,
+            sent_fee: 1_200,
+            sent_currency: "BTC".to_string(),
+            rate: 90_000.0,
+            rate_collected: Some(Utc::now()),
+            ..Default::default()
+        };
+
+        assert_eq!(settled_btc_msat(&[]), 0);
+        assert_eq!(settled_btc_msat(&[eur_sent_as_btc.clone()]), 0);
+        assert_eq!(
+            settled_btc_msat(&[btc.clone(), btc_sent_as_eur.clone(), eur_sent_as_btc]),
+            2_501_000,
+            "amount + fee of the BTC-settled rows only"
+        );
     }
 
     #[test]

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -1993,14 +1993,31 @@ pub struct AdminReferralEarning {
 }
 
 /// A payout record for a referral (admin view; includes preimage for audit).
+///
+/// A payout has a settled side (`amount`, `fee`, `currency`) — what it
+/// discharges against the earned balance — and a sent side (`sent_amount`,
+/// `sent_fee`, `sent_currency`) — what left the wallet. They are equal, with
+/// `rate` 1 and `rate_collected` null, when no conversion happened.
 #[derive(Serialize)]
 pub struct AdminReferralPayoutInfo {
     pub id: u64,
     pub amount: u64,
-    /// Network/routing fee charged to the referrer (smallest currency unit),
-    /// debited from their balance alongside `amount`.
+    /// Network/routing fee charged to the referrer (smallest unit of
+    /// `currency`), debited from their balance alongside `amount`.
     pub fee: u64,
     pub currency: String,
+    /// Amount actually transferred, in the smallest unit of `sent_currency`.
+    pub sent_amount: u64,
+    /// Network/routing fee as the network charged it, in the smallest unit of
+    /// `sent_currency`.
+    pub sent_fee: u64,
+    /// Currency actually transferred.
+    pub sent_currency: String,
+    /// Settled-currency standard units per one sent-currency standard unit; 1
+    /// when the two currencies are the same.
+    pub rate: f32,
+    /// When `rate` was quoted; null when no conversion happened.
+    pub rate_collected: Option<DateTime<Utc>>,
     pub created: DateTime<Utc>,
     pub is_paid: bool,
     /// How this payout was made: `lightning_address`, `nwc`, or `on_chain`.
@@ -2020,6 +2037,11 @@ impl From<lnvps_db::ReferralPayout> for AdminReferralPayoutInfo {
             amount: p.amount,
             fee: p.fee,
             currency: p.currency,
+            sent_amount: p.sent_amount,
+            sent_fee: p.sent_fee,
+            sent_currency: p.sent_currency,
+            rate: p.rate,
+            rate_collected: p.rate_collected,
             created: p.created,
             is_paid: p.is_paid,
             mode: p.mode.to_string(),
@@ -2070,10 +2092,31 @@ pub struct AdminUpdateReferralRequest {
 /// Create a manual payout record for a referral.
 #[derive(Deserialize)]
 pub struct AdminCreateReferralPayoutRequest {
-    /// Amount in the smallest currency unit.
+    /// Settled amount in the smallest unit of `currency`: what this payout takes
+    /// off the earned balance.
     pub amount: u64,
-    /// Currency code (e.g. `BTC`, `EUR`).
+    /// Currency this payout settles against (e.g. `BTC`, `EUR`) — the currency
+    /// the commission was earned in.
     pub currency: String,
+    /// Currency actually transferred, when it differs from `currency`. Omit (or
+    /// repeat `currency`) for a payout that sent what it settles.
+    pub sent_currency: Option<String>,
+    /// Amount actually transferred, in the smallest unit of `sent_currency`.
+    /// Required when `sent_currency` differs from `currency`.
+    pub sent_amount: Option<u64>,
+    /// Network/routing fee as the network charged it, in the smallest unit of
+    /// `sent_currency`. Defaults to 0.
+    pub sent_fee: Option<u64>,
+    /// Network/routing fee charged to the referrer, in the smallest unit of
+    /// `currency`. Defaults to 0.
+    pub fee: Option<u64>,
+    /// Settled-currency standard units per one sent-currency standard unit.
+    /// Required, and must be greater than 0, when the currencies differ;
+    /// rejected when they are the same.
+    pub rate: Option<f32>,
+    /// When the rate was quoted. Defaults to now for a converted payout;
+    /// rejected when no conversion happened.
+    pub rate_collected: Option<DateTime<Utc>>,
     /// Optional payout output reference (BOLT11 invoice or on-chain outpoint).
     pub output: Option<String>,
     /// Optional payout mode (`lightning_address`, `nwc`, `on_chain`); defaults

--- a/lnvps_api_admin/src/admin/referrals.rs
+++ b/lnvps_api_admin/src/admin/referrals.rs
@@ -291,7 +291,13 @@ fn apply_sent_side(
                 .to_string(),
         );
     };
-    check_rate_against_amounts(payout.amount, &payout.currency, sent_amount, &sent_currency, rate)?;
+    check_rate_against_amounts(
+        payout.amount,
+        &payout.currency,
+        sent_amount,
+        &sent_currency,
+        rate,
+    )?;
 
     payout.sent_amount = sent_amount;
     payout.sent_fee = req.sent_fee.unwrap_or(0);

--- a/lnvps_api_admin/src/admin/referrals.rs
+++ b/lnvps_api_admin/src/admin/referrals.rs
@@ -198,22 +198,33 @@ async fn admin_create_referral_payout(
         return ApiData::err("currency is required");
     }
 
-    let payout = ReferralPayout {
+    let mut payout = ReferralPayout {
         id: 0,
         referral_id: id,
         amount: req.amount,
-        currency,
+        currency: currency.clone(),
         created: chrono::Utc::now(),
-        fee: 0,
+        fee: req.fee.unwrap_or(0),
         is_paid: false,
         mode: match req.mode.as_deref() {
             Some(m) => lnvps_db::ReferralPayoutMode::from_str(m)
                 .map_err(|_| ApiError::new("Invalid payout mode"))?,
             None => lnvps_db::ReferralPayoutMode::default(),
         },
-        output: req.output.filter(|s| !s.trim().is_empty()),
+        output: req
+            .output
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
         pre_image: None,
+        ..Default::default()
     };
+
+    match apply_sent_side(&mut payout, &req) {
+        Ok(()) => {}
+        Err(e) => return ApiData::err(&e),
+    }
     let payout_id = this.db.insert_referral_payout(&payout).await?;
 
     // Apply the initial paid flag if requested (insert defaults to unpaid).
@@ -234,6 +245,58 @@ async fn admin_create_referral_payout(
         .find(|p| p.id == payout_id)
         .ok_or_else(|| ApiError::new("Failed to load created payout"))?;
     ApiData::ok(created.into())
+}
+
+/// Fill a new payout's sent side from the request, validating the two sides
+/// against each other.
+///
+/// A payout that sent what it settles carries the settled figures verbatim and
+/// no rate: a quote that never happened must not be recorded as one. A payout
+/// that converted has to say what left the wallet and at what rate, otherwise
+/// the record cannot be reconciled against the transfer afterwards.
+fn apply_sent_side(
+    payout: &mut ReferralPayout,
+    req: &AdminCreateReferralPayoutRequest,
+) -> Result<(), String> {
+    let sent_currency = req
+        .sent_currency
+        .as_deref()
+        .map(|c| c.trim().to_uppercase())
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| payout.currency.clone());
+
+    if sent_currency == payout.currency {
+        if req.rate.is_some() || req.rate_collected.is_some() {
+            return Err("rate is only valid when sent_currency differs from currency".to_string());
+        }
+        if req.sent_amount.is_some_and(|a| a != payout.amount)
+            || req.sent_fee.is_some_and(|f| f != payout.fee)
+        {
+            return Err(
+                "sent_amount and sent_fee must match amount and fee when the currency is the same"
+                    .to_string(),
+            );
+        }
+        let settled = payout.clone().unconverted();
+        *payout = settled;
+        return Ok(());
+    }
+
+    let Some(sent_amount) = req.sent_amount.filter(|a| *a > 0) else {
+        return Err("sent_amount is required when sent_currency differs from currency".to_string());
+    };
+    let Some(rate) = req.rate.filter(|r| *r > 0.0 && r.is_finite()) else {
+        return Err(
+            "rate is required and must be greater than 0 when sent_currency differs from currency"
+                .to_string(),
+        );
+    };
+    payout.sent_amount = sent_amount;
+    payout.sent_fee = req.sent_fee.unwrap_or(0);
+    payout.sent_currency = sent_currency;
+    payout.rate = rate;
+    payout.rate_collected = Some(req.rate_collected.unwrap_or_else(chrono::Utc::now));
+    Ok(())
 }
 
 /// Update / reconcile a payout record (mark paid, set invoice / preimage).
@@ -283,4 +346,123 @@ async fn admin_update_referral_payout(
         .find(|p| p.id == payout_id)
         .ok_or_else(|| ApiError::new("Failed to load updated payout"))?;
     ApiData::ok(updated.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(currency: &str, amount: u64) -> AdminCreateReferralPayoutRequest {
+        AdminCreateReferralPayoutRequest {
+            amount,
+            currency: currency.to_string(),
+            sent_currency: None,
+            sent_amount: None,
+            sent_fee: None,
+            fee: None,
+            rate: None,
+            rate_collected: None,
+            output: None,
+            mode: None,
+            is_paid: false,
+        }
+    }
+
+    fn payout(currency: &str, amount: u64, fee: u64) -> ReferralPayout {
+        ReferralPayout {
+            referral_id: 1,
+            amount,
+            fee,
+            currency: currency.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// A payout that sent what it settles mirrors the settled side and records
+    /// no rate — a rate of 1 with a timestamp would claim a quote happened.
+    #[test]
+    fn same_currency_mirrors_the_settled_side() {
+        let mut p = payout("BTC", 21_000, 7);
+        apply_sent_side(&mut p, &req("BTC", 21_000)).unwrap();
+        assert_eq!(p.sent_amount, 21_000);
+        assert_eq!(p.sent_fee, 7);
+        assert_eq!(p.sent_currency, "BTC");
+        assert_eq!(p.rate, 1.0);
+        assert!(p.rate_collected.is_none());
+    }
+
+    /// The sent side is what makes a cross-currency payout reconcilable against
+    /// the transfer, so it cannot be left to a default.
+    #[test]
+    fn cross_currency_requires_the_sent_amount_and_a_usable_rate() {
+        let mut r = req("EUR", 5_000);
+        r.sent_currency = Some("BTC".to_string());
+        r.rate = Some(90_000.0);
+        let err = apply_sent_side(&mut payout("EUR", 5_000, 0), &r).unwrap_err();
+        assert!(err.contains("sent_amount is required"), "{err}");
+
+        r.sent_amount = Some(55_000_000);
+        for bad in [None, Some(0.0), Some(-1.0), Some(f32::NAN)] {
+            r.rate = bad;
+            let err = apply_sent_side(&mut payout("EUR", 5_000, 0), &r).unwrap_err();
+            assert!(err.contains("rate is required"), "{bad:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn cross_currency_records_both_sides_and_the_quote_time() {
+        let mut r = req("EUR", 5_000);
+        r.sent_currency = Some("btc".to_string());
+        r.sent_amount = Some(55_000_000);
+        r.sent_fee = Some(1_200);
+        r.rate = Some(90_000.0);
+
+        let mut p = payout("EUR", 5_000, 3);
+        apply_sent_side(&mut p, &r).unwrap();
+        assert_eq!(p.amount, 5_000);
+        assert_eq!(p.fee, 3);
+        assert_eq!(p.currency, "EUR");
+        assert_eq!(p.sent_amount, 55_000_000);
+        assert_eq!(p.sent_fee, 1_200);
+        assert_eq!(p.sent_currency, "BTC");
+        assert_eq!(p.rate, 90_000.0);
+        assert!(p.rate_collected.is_some());
+    }
+
+    /// A caller-supplied quote time survives, so an out-of-band payment can be
+    /// reconciled with the rate that actually applied when it was sent.
+    #[test]
+    fn cross_currency_keeps_a_supplied_quote_time() {
+        let when = chrono::Utc::now() - chrono::Duration::days(2);
+        let mut r = req("EUR", 5_000);
+        r.sent_currency = Some("BTC".to_string());
+        r.sent_amount = Some(55_000_000);
+        r.rate = Some(90_000.0);
+        r.rate_collected = Some(when);
+
+        let mut p = payout("EUR", 5_000, 0);
+        apply_sent_side(&mut p, &r).unwrap();
+        assert_eq!(p.rate_collected, Some(when));
+    }
+
+    /// Same-currency rows must stay identities: a rate or a mismatched sent
+    /// figure there is a caller error, not something to silently normalise.
+    #[test]
+    fn same_currency_rejects_a_rate_or_a_diverging_sent_side() {
+        let mut r = req("BTC", 21_000);
+        r.rate = Some(1.0);
+        let err = apply_sent_side(&mut payout("BTC", 21_000, 0), &r).unwrap_err();
+        assert!(err.contains("rate is only valid"), "{err}");
+
+        let mut r = req("BTC", 21_000);
+        r.sent_currency = Some("btc".to_string());
+        r.sent_amount = Some(20_000);
+        let err = apply_sent_side(&mut payout("BTC", 21_000, 0), &r).unwrap_err();
+        assert!(err.contains("must match amount and fee"), "{err}");
+
+        let mut r = req("BTC", 21_000);
+        r.sent_fee = Some(9);
+        let err = apply_sent_side(&mut payout("BTC", 21_000, 7), &r).unwrap_err();
+        assert!(err.contains("must match amount and fee"), "{err}");
+    }
 }

--- a/lnvps_api_admin/src/admin/referrals.rs
+++ b/lnvps_api_admin/src/admin/referrals.rs
@@ -12,6 +12,7 @@ use lnvps_api_common::{
     deserialize_from_str_optional,
 };
 use lnvps_db::{AdminAction, AdminResource, Referral, ReferralPayout};
+use payments_rs::currency::{Currency, CurrencyAmount};
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -277,8 +278,7 @@ fn apply_sent_side(
                     .to_string(),
             );
         }
-        let settled = payout.clone().unconverted();
-        *payout = settled;
+        *payout = std::mem::take(payout).unconverted();
         return Ok(());
     }
 
@@ -291,11 +291,56 @@ fn apply_sent_side(
                 .to_string(),
         );
     };
+    check_rate_against_amounts(payout.amount, &payout.currency, sent_amount, &sent_currency, rate)?;
+
     payout.sent_amount = sent_amount;
     payout.sent_fee = req.sent_fee.unwrap_or(0);
     payout.sent_currency = sent_currency;
     payout.rate = rate;
     payout.rate_collected = Some(req.rate_collected.unwrap_or_else(chrono::Utc::now));
+    Ok(())
+}
+
+/// Tolerance between the supplied rate and the one the two amounts imply.
+///
+/// Wide enough for rounding, a stale quote and the spread on the transfer;
+/// narrow enough that a wrong order of magnitude cannot pass.
+const RATE_TOLERANCE: f32 = 0.10;
+
+/// Reject a rate that the two amounts contradict.
+///
+/// The rate exists so the conversion is reproducible without a price feed, so a
+/// record that disagrees with itself is worse than one carrying no rate at all.
+/// Nothing here moves money — the balance nets on the settled amount.
+///
+/// A currency neither side of the ledger knows how to scale cannot be checked;
+/// the record is still worth storing, so it passes.
+fn check_rate_against_amounts(
+    amount: u64,
+    currency: &str,
+    sent_amount: u64,
+    sent_currency: &str,
+    rate: f32,
+) -> Result<(), String> {
+    let (Ok(settled), Ok(sent)) = (
+        Currency::from_str(currency),
+        Currency::from_str(sent_currency),
+    ) else {
+        return Ok(());
+    };
+
+    let settled = CurrencyAmount::from_u64(settled, amount).value_f32();
+    let sent = CurrencyAmount::from_u64(sent, sent_amount).value_f32();
+    if settled <= 0.0 || sent <= 0.0 {
+        return Ok(());
+    }
+
+    let implied = settled / sent;
+    if (implied / rate - 1.0).abs() > RATE_TOLERANCE {
+        return Err(format!(
+            "rate {rate} disagrees with the amounts, which imply {implied}"
+        ));
+    }
     Ok(())
 }
 
@@ -443,6 +488,36 @@ mod tests {
         let mut p = payout("EUR", 5_000, 0);
         apply_sent_side(&mut p, &r).unwrap();
         assert_eq!(p.rate_collected, Some(when));
+    }
+
+    /// The rate is what makes the conversion reproducible, so a rate the two
+    /// amounts contradict is rejected rather than stored.
+    #[test]
+    fn cross_currency_rejects_a_rate_the_amounts_contradict() {
+        let mut r = req("EUR", 5_000);
+        r.sent_currency = Some("BTC".to_string());
+        r.sent_amount = Some(55_000_000);
+
+        // 50.00 EUR for 0.00055 BTC implies ~90909 EUR/BTC.
+        r.rate = Some(9_000.0);
+        let err = apply_sent_side(&mut payout("EUR", 5_000, 0), &r).unwrap_err();
+        assert!(err.contains("disagrees with the amounts"), "{err}");
+
+        // Rounding and a stale quote stay inside the tolerance.
+        r.rate = Some(90_000.0);
+        apply_sent_side(&mut payout("EUR", 5_000, 0), &r).unwrap();
+        r.rate = Some(85_000.0);
+        apply_sent_side(&mut payout("EUR", 5_000, 0), &r).unwrap();
+    }
+
+    /// A currency the ledger cannot scale cannot be cross-checked, and the
+    /// record is still worth storing.
+    #[test]
+    fn an_unknown_currency_skips_the_rate_check() {
+        assert!(check_rate_against_amounts(5_000, "XAU", 55_000_000, "BTC", 1.0).is_ok());
+        assert!(check_rate_against_amounts(5_000, "EUR", 55_000_000, "XAU", 1.0).is_ok());
+        // A zero side gives no ratio to compare against.
+        assert!(check_rate_against_amounts(0, "EUR", 55_000_000, "BTC", 90_000.0).is_ok());
     }
 
     /// Same-currency rows must stay identities: a rate or a mismatched sent

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -3123,6 +3123,7 @@ impl LNVpsDbBase for MockDb {
             p.output = payout.output.clone();
             p.pre_image = payout.pre_image.clone();
             p.fee = payout.fee;
+            p.sent_fee = payout.sent_fee;
         }
         Ok(())
     }

--- a/lnvps_db/migrations/20260728180000_referral_payout_cross_currency.sql
+++ b/lnvps_db/migrations/20260728180000_referral_payout_cross_currency.sql
@@ -1,0 +1,40 @@
+-- Record both sides of a referral payout that was settled in one currency and
+-- sent in another.
+--
+-- Commission is earned per currency, and a payout nets against the balance of
+-- the currency it settles. A payout sent in a different currency previously had
+-- nowhere to say so: either the earned balance was never reduced, or it was
+-- reduced by a figure nobody transferred.
+--
+-- `amount`, `fee` and `currency` keep their meaning and stay the settled side —
+-- what this payout discharges against the earned balance. The sent side is what
+-- actually left the wallet. `rate` ties the two together and is stored rather
+-- than re-derived, so the conversion is reproducible without a historical price
+-- feed.
+
+ALTER TABLE referral_payout
+    ADD COLUMN sent_amount   BIGINT UNSIGNED NULL DEFAULT NULL,
+    -- Network/routing fee as the network charged it. `fee` is the same cost
+    -- expressed in the settled currency, which is the one the balance nets in.
+    ADD COLUMN sent_fee      BIGINT UNSIGNED NULL DEFAULT NULL,
+    ADD COLUMN sent_currency VARCHAR(4)      NULL DEFAULT NULL,
+    -- Settled-currency standard units per one sent-currency standard unit, so a
+    -- EUR commission sent as BTC stores the EUR/BTC price. 1 when no conversion
+    -- happened.
+    ADD COLUMN rate           FLOAT          NOT NULL DEFAULT 1,
+    -- When the rate was taken. NULL when the two currencies are the same and no
+    -- rate was ever quoted; a rate of 1 with no timestamp is an identity, not a
+    -- quote that happened to be 1.
+    ADD COLUMN rate_collected TIMESTAMP      NULL DEFAULT NULL;
+
+-- Every existing payout is single-currency: it sent exactly what it settled.
+UPDATE referral_payout
+SET sent_amount   = amount,
+    sent_fee      = fee,
+    sent_currency = currency
+WHERE sent_currency IS NULL;
+
+ALTER TABLE referral_payout
+    MODIFY COLUMN sent_amount   BIGINT UNSIGNED NOT NULL,
+    MODIFY COLUMN sent_fee      BIGINT UNSIGNED NOT NULL,
+    MODIFY COLUMN sent_currency VARCHAR(4)      NOT NULL;

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -1458,22 +1458,61 @@ pub struct Referral {
     pub payout_threshold: Option<u64>,
 }
 
-#[derive(FromRow, Clone, Debug, Default)]
+/// One payout against a referrer's accrued commission.
+///
+/// A payout has two sides. The **settled** side (`amount`, `fee`, `currency`) is
+/// what the payout discharges against the earned balance; commission is earned
+/// per currency and nets in the currency it was earned in, whatever was
+/// actually transferred. The **sent** side (`sent_amount`, `sent_fee`,
+/// `sent_currency`) is what left the wallet. `rate` ties the two together.
+///
+/// The two sides are equal, and `rate` is 1, for a payout that needed no
+/// conversion — which is every payout the automated engine makes today.
+#[derive(FromRow, Clone, Debug)]
 pub struct ReferralPayout {
     /// Unique id of this payout record
     pub id: u64,
     /// The referral this payout belongs to
     pub referral_id: u64,
-    /// Amount in smallest currency unit
+    /// Settled amount in the smallest unit of `currency`: what this payout takes
+    /// off the earned balance.
     pub amount: u64,
     /// Network/routing fee charged to the referrer, in the same smallest
     /// currency unit as `amount`. The referrer bears the fee: it is debited from
     /// their balance together with `amount` when computing what remains owed, so
     /// a fee-induced deficit is recovered from future commission.
+    ///
+    /// The fee is incurred on the sent side and recorded there verbatim as
+    /// `sent_fee`; this is the same cost carried into the currency the balance
+    /// nets in, so it can be subtracted without converting at read time.
     #[sqlx(default)]
     pub fee: u64,
-    /// Currency of this payout
+    /// Currency this payout settles against — the currency the commission was
+    /// earned in.
     pub currency: String,
+    /// Amount that actually left the wallet, in the smallest unit of
+    /// `sent_currency`.
+    #[sqlx(default)]
+    pub sent_amount: u64,
+    /// Network/routing fee as the network charged it, in the smallest unit of
+    /// `sent_currency`.
+    #[sqlx(default)]
+    pub sent_fee: u64,
+    /// Currency that actually left the wallet.
+    #[sqlx(default)]
+    pub sent_currency: String,
+    /// Settled-currency standard units per one sent-currency standard unit, so a
+    /// EUR commission sent as BTC carries the EUR/BTC price. 1 when the two
+    /// currencies are the same.
+    ///
+    /// Stored rather than re-derived so an audit does not depend on a historical
+    /// price feed still being reachable and still agreeing with itself.
+    #[sqlx(default)]
+    pub rate: f32,
+    /// When `rate` was quoted. `None` when no conversion happened: a rate of 1
+    /// with no timestamp is an identity, not a quote that came back as 1.
+    #[sqlx(default)]
+    pub rate_collected: Option<DateTime<Utc>>,
     /// When this payout record was created
     pub created: DateTime<Utc>,
     /// Whether this payout has been completed
@@ -1492,6 +1531,46 @@ pub struct ReferralPayout {
     pub output: Option<String>,
     /// Preimage revealed when a Lightning invoice was paid (32 bytes, SHA256).
     pub pre_image: Option<Vec<u8>>,
+}
+
+impl ReferralPayout {
+    /// Mirror the settled side onto the sent side, for a payout that transferred
+    /// exactly the currency it discharges.
+    ///
+    /// `rate_collected` stays `None`: no rate was quoted, so there is no moment
+    /// to record.
+    pub fn unconverted(mut self) -> Self {
+        self.sent_amount = self.amount;
+        self.sent_fee = self.fee;
+        self.sent_currency = self.currency.clone();
+        self.rate = 1.0;
+        self.rate_collected = None;
+        self
+    }
+}
+
+impl Default for ReferralPayout {
+    /// `rate` defaults to 1, not 0: an unconverted payout is the common case, and
+    /// a zero rate would make the two sides irreconcilable.
+    fn default() -> Self {
+        Self {
+            id: 0,
+            referral_id: 0,
+            amount: 0,
+            fee: 0,
+            currency: String::new(),
+            sent_amount: 0,
+            sent_fee: 0,
+            sent_currency: String::new(),
+            rate: 1.0,
+            rate_collected: None,
+            created: DateTime::<Utc>::default(),
+            is_paid: false,
+            mode: ReferralPayoutMode::default(),
+            output: None,
+            pre_image: None,
+        }
+    }
 }
 
 #[derive(FromRow, Clone, Debug)]

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -3616,12 +3616,19 @@ impl LNVpsDbBase for LNVpsDbMysql {
 
     async fn insert_referral_payout(&self, payout: &ReferralPayout) -> DbResult<u64> {
         let res = sqlx::query(
-            "INSERT INTO referral_payout (referral_id, amount, fee, currency, mode, output) VALUES (?, ?, ?, ?, ?, ?) returning id",
+            "INSERT INTO referral_payout (referral_id, amount, fee, currency, sent_amount, \
+             sent_fee, sent_currency, rate, rate_collected, mode, output) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id",
         )
         .bind(payout.referral_id)
         .bind(payout.amount)
         .bind(payout.fee)
         .bind(&payout.currency)
+        .bind(payout.sent_amount)
+        .bind(payout.sent_fee)
+        .bind(&payout.sent_currency)
+        .bind(payout.rate)
+        .bind(payout.rate_collected)
         .bind(payout.mode)
         .bind(&payout.output)
         .fetch_one(&self.db)
@@ -3631,13 +3638,15 @@ impl LNVpsDbBase for LNVpsDbMysql {
 
     async fn update_referral_payout(&self, payout: &ReferralPayout) -> DbResult<()> {
         sqlx::query(
-            "UPDATE referral_payout SET is_paid = ?, mode = ?, output = ?, pre_image = ?, fee = ? WHERE id = ?",
+            "UPDATE referral_payout SET is_paid = ?, mode = ?, output = ?, pre_image = ?, \
+             fee = ?, sent_fee = ? WHERE id = ?",
         )
         .bind(payout.is_paid)
         .bind(payout.mode)
         .bind(&payout.output)
         .bind(&payout.pre_image)
         .bind(payout.fee)
+        .bind(payout.sent_fee)
         .bind(payout.id)
         .execute(&self.db)
         .await?;

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -3203,6 +3203,133 @@ mod tests {
         crate::db::hard_delete_referral(&pool, ref_b).await.unwrap();
     }
 
+    /// A EUR commission settled by a BTC transfer has to record both sides and
+    /// the rate, and must not be recordable as a conversion with no rate or no
+    /// sent amount — those rows cannot be reconciled against the transfer later.
+    #[tokio::test]
+    async fn test_admin_create_cross_currency_referral_payout() {
+        use nostr::Keys;
+
+        let client = setup().await;
+        let pool = crate::db::connect().await.unwrap();
+
+        let keys = Keys::generate();
+        let user = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let suffix = hex::encode(keys.public_key().to_bytes());
+        let code = format!("X{}", &suffix[..7]);
+        let referral = crate::db::insert_referral(&pool, user, &code, None)
+            .await
+            .unwrap();
+        let path = format!("/api/admin/v1/referrals/{referral}/payouts");
+
+        // A conversion with no sent amount, and one with no rate, are rejected.
+        for body in [
+            serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "rate": 90000.0 }),
+            serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "sent_amount": 55000000 }),
+            serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "sent_amount": 55000000, "rate": 0.0 }),
+        ] {
+            let resp = client.post_auth(&path, &body).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{body}");
+        }
+
+        // A rate on a payout that converted nothing is rejected too.
+        let resp = client
+            .post_auth(
+                &path,
+                &serde_json::json!({ "amount": 5000, "currency": "BTC", "rate": 1.0 }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // The full conversion is recorded on both sides.
+        let resp = client
+            .post_auth(
+                &path,
+                &serde_json::json!({
+                    "amount": 5000,
+                    "currency": "EUR",
+                    "fee": 3,
+                    "sent_currency": "btc",
+                    "sent_amount": 55_000_000u64,
+                    "sent_fee": 1200,
+                    "rate": 90000.0,
+                    "is_paid": true
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        let created = &body["data"];
+        assert_eq!(created["amount"].as_u64().unwrap(), 5000);
+        assert_eq!(created["fee"].as_u64().unwrap(), 3);
+        assert_eq!(created["currency"].as_str().unwrap(), "EUR");
+        assert_eq!(created["sent_amount"].as_u64().unwrap(), 55_000_000);
+        assert_eq!(created["sent_fee"].as_u64().unwrap(), 1200);
+        assert_eq!(created["sent_currency"].as_str().unwrap(), "BTC");
+        assert_eq!(created["rate"].as_f64().unwrap(), 90000.0);
+        assert!(created["rate_collected"].is_string());
+
+        // A single-currency payout mirrors its settled side and quotes no rate.
+        let resp = client
+            .post_auth(
+                &path,
+                &serde_json::json!({ "amount": 21000, "currency": "BTC", "fee": 7 }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(body["data"]["sent_amount"].as_u64().unwrap(), 21000);
+        assert_eq!(body["data"]["sent_fee"].as_u64().unwrap(), 7);
+        assert_eq!(body["data"]["sent_currency"].as_str().unwrap(), "BTC");
+        assert_eq!(body["data"]["rate"].as_f64().unwrap(), 1.0);
+        assert!(body["data"]["rate_collected"].is_null());
+
+        // Both rows read back the same way through the listing.
+        let resp = client.get_auth(&path).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        let rows = body["data"].as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows.iter()
+                .any(|r| r["currency"] == "EUR" && r["sent_currency"] == "BTC")
+        );
+
+        crate::db::hard_delete_referral(&pool, referral).await.unwrap();
+    }
+
+    /// Payout creation is gated on `referral::create`, not merely on being
+    /// authenticated.
+    #[tokio::test]
+    async fn test_admin_create_referral_payout_requires_permission() {
+        use nostr::Keys;
+
+        let pool = crate::db::connect().await.unwrap();
+        let keys = Keys::generate();
+        let user = crate::db::ensure_user(&pool, &keys).await.unwrap();
+        let suffix = hex::encode(keys.public_key().to_bytes());
+        let code = format!("Y{}", &suffix[..7]);
+        let referral = crate::db::insert_referral(&pool, user, &code, None)
+            .await
+            .unwrap();
+
+        // The referrer themself holds no admin role.
+        let client = crate::client::admin_client_with_keys(keys.clone());
+        let resp = client
+            .post_auth(
+                &format!("/api/admin/v1/referrals/{referral}/payouts"),
+                &serde_json::json!({ "amount": 5000, "currency": "EUR" }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        crate::db::hard_delete_referral(&pool, referral).await.unwrap();
+    }
+
     // ========================================================================
     // Payment Methods (Admin)
     // ========================================================================

--- a/lnvps_e2e/src/admin_api.rs
+++ b/lnvps_e2e/src/admin_api.rs
@@ -3227,6 +3227,8 @@ mod tests {
             serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "rate": 90000.0 }),
             serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "sent_amount": 55000000 }),
             serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "sent_amount": 55000000, "rate": 0.0 }),
+            // 50.00 EUR for 0.00055 BTC implies ~90909, not 9000.
+            serde_json::json!({ "amount": 5000, "currency": "EUR", "sent_currency": "BTC", "sent_amount": 55000000, "rate": 9000.0 }),
         ] {
             let resp = client.post_auth(&path, &body).await.unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{body}");


### PR DESCRIPTION
Closes #308.

A `referral_payout` row now has a settled side (`amount`, `fee`, `currency`) and a sent side (`sent_amount`, `sent_fee`, `sent_currency`), tied together by `rate` and `rate_collected`. Netting stays in the settled currency (`lnvps_api/src/referral/mod.rs:60`), so a EUR commission sent as BTC discharges EUR and leaves the BTC balance alone.

- Migration `20260728180000_referral_payout_cross_currency.sql` backfills existing rows as unconverted: sent mirrors settled, rate 1, no quote time.
- `POST /api/admin/v1/referrals/{id}/payouts` accepts the sent side; a conversion must carry `sent_amount` and a positive `rate`, and a same-currency payout may not carry a rate (`lnvps_api_admin/src/admin/referrals.rs:334`).
- Additive on `ApiReferralPayout` and `AdminReferralPayoutInfo`; no existing field changes meaning. `API_CHANGELOG.md` and `ADMIN_API_ENDPOINTS.md` updated.
- Automatic conversion at send time is not implemented — the issue left that open, so a cross-currency payout is recorded by an admin today.

Verified at `b47a39c`: `cargo test --workspace --exclude lnvps_e2e` 850 passed / 0 failed, e2e 163 pass, no new clippy warnings on the touched files.

From the lnvps channel.