### PR TITLE
fix(operator): keep collecting usage past a failed write

### DIFF
--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -95,9 +95,13 @@ pub struct MockDb {
             >,
         >,
     >,
-    /// Deployment ids whose usage writes fail. A failing write is otherwise
-    /// unreachable here, and the callers' job is to survive one.
+    /// Deployment ids whose usage totals write fails. A failing write is
+    /// otherwise unreachable here, and the callers' job is to survive one.
     pub failing_usage_writes: Arc<Mutex<HashSet<u64>>>,
+    /// Deployment ids whose usage breakdown write fails. Separate from the
+    /// totals: a grant can cover `app_deployment` and not the breakdown tables,
+    /// so the two fail independently.
+    pub failing_usage_breakdown_writes: Arc<Mutex<HashSet<u64>>>,
 }
 
 impl MockDb {
@@ -388,6 +392,7 @@ impl Default for MockDb {
             app_deployments: Arc::new(Default::default()),
             app_deployment_usage_breakdown: Arc::new(Default::default()),
             failing_usage_writes: Arc::new(Default::default()),
+            failing_usage_breakdown_writes: Arc::new(Default::default()),
         }
     }
 }
@@ -3674,7 +3679,12 @@ impl LNVpsDbBase for MockDb {
         services: &[AppDeploymentServiceUsage],
         volumes: &[AppDeploymentVolumeUsage],
     ) -> DbResult<()> {
-        if self.failing_usage_writes.lock().await.contains(&id) {
+        if self
+            .failing_usage_breakdown_writes
+            .lock()
+            .await
+            .contains(&id)
+        {
             return Err(DbError::Other(anyhow!(
                 "usage breakdown write denied for {id}"
             )));

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -20,7 +20,7 @@ use lnvps_db::{
 use async_trait::async_trait;
 #[cfg(feature = "admin")]
 use lnvps_db::{AdminRole, AdminRoleAssignment, AdminUserInfo, AdminVmHost, RegionStats};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Add;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -95,6 +95,9 @@ pub struct MockDb {
             >,
         >,
     >,
+    /// Deployment ids whose usage writes fail. A failing write is otherwise
+    /// unreachable here, and the callers' job is to survive one.
+    pub failing_usage_writes: Arc<Mutex<HashSet<u64>>>,
 }
 
 impl MockDb {
@@ -384,6 +387,7 @@ impl Default for MockDb {
             app_clusters: Arc::new(Default::default()),
             app_deployments: Arc::new(Default::default()),
             app_deployment_usage_breakdown: Arc::new(Default::default()),
+            failing_usage_writes: Arc::new(Default::default()),
         }
     }
 }
@@ -3651,6 +3655,9 @@ impl LNVpsDbBase for MockDb {
         memory_bytes: u64,
         storage_bytes: Option<u64>,
     ) -> DbResult<()> {
+        if self.failing_usage_writes.lock().await.contains(&id) {
+            return Err(DbError::Other(anyhow!("usage write denied for {id}")));
+        }
         let mut d = self.app_deployments.lock().await;
         if let Some(x) = d.get_mut(&id) {
             x.usage_cpu_milli = Some(cpu_milli);
@@ -3667,6 +3674,11 @@ impl LNVpsDbBase for MockDb {
         services: &[AppDeploymentServiceUsage],
         volumes: &[AppDeploymentVolumeUsage],
     ) -> DbResult<()> {
+        if self.failing_usage_writes.lock().await.contains(&id) {
+            return Err(DbError::Other(anyhow!(
+                "usage breakdown write denied for {id}"
+            )));
+        }
         let mut b = self.app_deployment_usage_breakdown.lock().await;
         b.insert(id, (services.to_vec(), volumes.to_vec()));
         Ok(())

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -23,11 +23,11 @@ use serde::de::DeserializeOwned;
 use k8s_openapi::NamespaceResourceScope;
 use lnvps_db::{
     AppDeployment, AppDeploymentServiceUsage, AppDeploymentStatus, AppDeploymentVolumeUsage,
-    BillingState, EncryptedString, Subscription,
+    BillingState, EncryptedString, LNVpsDb, Subscription,
 };
 
 use crate::Context;
-use crate::metrics::DeploymentUsage;
+use crate::metrics::{DeploymentUsage, PrometheusClient};
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
 use k8s_openapi::api::core::v1::{
     ConfigMap, Container, ContainerPort, EnvVar, Namespace, PersistentVolumeClaim,
@@ -1329,7 +1329,9 @@ pub async fn reconcile_app_deployments(ctx: &Context) -> Result<()> {
 
     // Best-effort: a metrics outage must not fail a reconcile pass, and stale
     // usage from the previous pass is better than none.
-    if let Err(e) = collect_usage(ctx, &deployments, &active).await {
+    if let Err(e) =
+        collect_usage(ctx.db.as_ref(), ctx.metrics.as_ref(), &deployments, &active).await
+    {
         warn!("usage collection failed: {e}");
     }
 
@@ -1345,12 +1347,16 @@ pub async fn reconcile_app_deployments(ctx: &Context) -> Result<()> {
 /// deployment row it writes: that row is a copy read at the top of the pass, so
 /// one path would overwrite the other's fields with values read before they
 /// were set.
+/// A deployment whose write fails is logged and skipped rather than ending the
+/// pass: usage is per deployment, so one bad row must not blank every row
+/// behind it in the iteration order.
 async fn collect_usage(
-    ctx: &Context,
+    db: &dyn LNVpsDb,
+    metrics: Option<&PrometheusClient>,
     deployments: &[AppDeployment],
     active: &HashSet<u64>,
 ) -> Result<()> {
-    let Some(client) = &ctx.metrics else {
+    let Some(client) = metrics else {
         return Ok(());
     };
     let by_id: BTreeMap<u64, &AppDeployment> = deployments.iter().map(|d| (d.id, d)).collect();
@@ -1363,14 +1369,18 @@ async fn collect_usage(
         if !active.contains(&id) {
             continue;
         }
-        ctx.db
+        if let Err(e) = db
             .update_app_deployment_usage(
                 id,
                 usage.cpu_milli,
                 usage.memory_bytes,
                 usage.storage_bytes,
             )
-            .await?;
+            .await
+        {
+            warn!("app deployment {id} usage write failed: {e}");
+            continue;
+        }
 
         // The breakdown is keyed on compose names, which only the app's compose
         // can supply: a claim name is a `"{service}-{volume}"` string that
@@ -1381,7 +1391,7 @@ async fn collect_usage(
         };
         let app_id = deployment.app_id;
         if let std::collections::btree_map::Entry::Vacant(slot) = composes.entry(app_id) {
-            let parsed = match ctx.db.get_app(app_id).await {
+            let parsed = match db.get_app(app_id).await {
                 Ok(app) => match Compose::parse(&app.compose) {
                     Ok(c) => Some(c),
                     Err(e) => {
@@ -1400,9 +1410,12 @@ async fn collect_usage(
             continue;
         };
         let (services, volumes) = breakdown_rows(id, compose, &usage);
-        ctx.db
+        if let Err(e) = db
             .replace_app_deployment_usage_breakdown(id, &services, &volumes)
-            .await?;
+            .await
+        {
+            warn!("app deployment {id} usage breakdown write failed: {e}");
+        }
     }
     Ok(())
 }
@@ -3694,5 +3707,129 @@ config:
                 .collect::<Vec<_>>(),
             vec![("a", 1), ("b", 2)]
         );
+    }
+    /// Usage is per deployment, so a write that fails for one must not cost
+    /// every deployment behind it in the iteration order its reading.
+    #[tokio::test]
+    async fn a_failed_usage_write_does_not_skip_the_other_deployments() {
+        use chrono::Utc;
+        use lnvps_api_common::MockDb;
+        use lnvps_db::{App, AppDeploymentDesiredState, IntervalType};
+        use std::time::Duration;
+        use wiremock::matchers::{method, path, query_param_contains};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn deployment(id: u64) -> AppDeployment {
+            AppDeployment {
+                id,
+                user_id: 1,
+                app_id: 1,
+                cluster_id: 1,
+                resource_multiplier: 1,
+                subscription_line_item_id: id,
+                name: format!("d{id}"),
+                namespace: namespace_name(id),
+                hostname: None,
+                custom_domain: None,
+                config: None,
+                desired_state: AppDeploymentDesiredState::Running,
+                status: AppDeploymentStatus::Running,
+                status_message: None,
+                usage_cpu_milli: None,
+                usage_memory_bytes: None,
+                usage_storage_bytes: None,
+                usage_collected: None,
+                created: Utc::now(),
+                deleted: false,
+            }
+        }
+
+        async fn mock_query(server: &MockServer, needle: &str, body: String) {
+            Mock::given(method("GET"))
+                .and(path("/api/v1/query"))
+                .and(query_param_contains("query", needle))
+                .respond_with(ResponseTemplate::new(200).set_body_string(body))
+                .mount(server)
+                .await;
+        }
+
+        fn two_series(key_label: &str, key: &str, a: &str, b: &str) -> String {
+            format!(
+                r#"{{"status":"success","data":{{"resultType":"vector","result":[{{"metric":{{"namespace":"app-1","{key_label}":"{key}"}},"value":[1690000000,"{a}"]}},{{"metric":{{"namespace":"app-2","{key_label}":"{key}"}},"value":[1690000000,"{b}"]}}]}}}}"#
+            )
+        }
+
+        let server = MockServer::start().await;
+        mock_query(
+            &server,
+            "container_cpu_usage_seconds_total",
+            two_series("container", "a", "0.5", "0.25"),
+        )
+        .await;
+        mock_query(
+            &server,
+            "container_memory_working_set_bytes",
+            two_series("container", "a", "2097152", "1048576"),
+        )
+        .await;
+        mock_query(
+            &server,
+            "kubelet_volume_stats_used_bytes",
+            two_series("persistentvolumeclaim", "a-data", "8192", "4096"),
+        )
+        .await;
+
+        let db = MockDb::empty();
+        {
+            let mut apps = db.apps.lock().await;
+            apps.insert(
+                1,
+                App {
+                    id: 1,
+                    name: "relay".to_string(),
+                    display_name: "Relay".to_string(),
+                    description: None,
+                    icon: None,
+                    repo_url: None,
+                    category: "Nostr relay".to_string(),
+                    seo_title: None,
+                    seo_description: None,
+                    compose: "services:\n  a:\n    image: x\n    volumes:\n      - name: data\n        path: /d\n        size: 1Gi\n"
+                        .to_string(),
+                    amount: 1000,
+                    currency: "USD".to_string(),
+                    interval_amount: 1,
+                    interval_type: IntervalType::Month,
+                    setup_amount: 0,
+                    cpu_milli: 250,
+                    memory_bytes: 512 * 1024 * 1024,
+                    storage_bytes: 1024 * 1024 * 1024,
+                    enabled: true,
+                    created: Utc::now(),
+                },
+            );
+            let mut deps = db.app_deployments.lock().await;
+            deps.insert(1, deployment(1));
+            deps.insert(2, deployment(2));
+            // Deployment 1 is written first, so before the fix its failure was
+            // enough to leave 2 with no reading at all.
+            db.failing_usage_writes.lock().await.insert(1);
+        }
+
+        let client =
+            PrometheusClient::new(&format!("{}/", server.uri()), Duration::from_secs(5)).unwrap();
+        let deployments = vec![deployment(1), deployment(2)];
+        let active: HashSet<u64> = HashSet::from([1, 2]);
+        collect_usage(&db, Some(&client), &deployments, &active)
+            .await
+            .unwrap();
+
+        let deps = db.app_deployments.lock().await;
+        assert_eq!(deps[&1].usage_cpu_milli, None);
+        assert_eq!(deps[&2].usage_cpu_milli, Some(250));
+        let breakdown = db.app_deployment_usage_breakdown.lock().await;
+        assert!(!breakdown.contains_key(&1));
+        assert_eq!(breakdown[&2].0.len(), 1);
+        assert_eq!(breakdown[&2].1.len(), 1);
     }
 }

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -3709,15 +3709,17 @@ config:
         );
     }
     /// Usage is per deployment, so a write that fails for one must not cost
-    /// every deployment behind it in the iteration order its reading.
+    /// every deployment behind it in the iteration order its reading. The
+    /// breakdown-only failure is the one a too-narrow grant produces: the
+    /// totals land, the two breakdown tables are denied.
     #[tokio::test]
     async fn a_failed_usage_write_does_not_skip_the_other_deployments() {
+        use crate::metrics::tests::{mock_query, vectors};
         use chrono::Utc;
         use lnvps_api_common::MockDb;
         use lnvps_db::{App, AppDeploymentDesiredState, IntervalType};
         use std::time::Duration;
-        use wiremock::matchers::{method, path, query_param_contains};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use wiremock::MockServer;
 
         fn deployment(id: u64) -> AppDeployment {
             AppDeployment {
@@ -3744,38 +3746,44 @@ config:
             }
         }
 
-        async fn mock_query(server: &MockServer, needle: &str, body: String) {
-            Mock::given(method("GET"))
-                .and(path("/api/v1/query"))
-                .and(query_param_contains("query", needle))
-                .respond_with(ResponseTemplate::new(200).set_body_string(body))
-                .mount(server)
-                .await;
-        }
-
-        fn two_series(key_label: &str, key: &str, a: &str, b: &str) -> String {
-            format!(
-                r#"{{"status":"success","data":{{"resultType":"vector","result":[{{"metric":{{"namespace":"app-1","{key_label}":"{key}"}},"value":[1690000000,"{a}"]}},{{"metric":{{"namespace":"app-2","{key_label}":"{key}"}},"value":[1690000000,"{b}"]}}]}}}}"#
-            )
-        }
-
         let server = MockServer::start().await;
         mock_query(
             &server,
             "container_cpu_usage_seconds_total",
-            two_series("container", "a", "0.5", "0.25"),
+            vectors(
+                "container",
+                &[
+                    ("app-1", "a", "0.5"),
+                    ("app-2", "a", "0.25"),
+                    ("app-3", "a", "0.75"),
+                ],
+            ),
         )
         .await;
         mock_query(
             &server,
             "container_memory_working_set_bytes",
-            two_series("container", "a", "2097152", "1048576"),
+            vectors(
+                "container",
+                &[
+                    ("app-1", "a", "2097152"),
+                    ("app-2", "a", "1048576"),
+                    ("app-3", "a", "4194304"),
+                ],
+            ),
         )
         .await;
         mock_query(
             &server,
             "kubelet_volume_stats_used_bytes",
-            two_series("persistentvolumeclaim", "a-data", "8192", "4096"),
+            vectors(
+                "persistentvolumeclaim",
+                &[
+                    ("app-1", "a-data", "8192"),
+                    ("app-2", "a-data", "4096"),
+                    ("app-3", "a-data", "2048"),
+                ],
+            ),
         )
         .await;
 
@@ -3794,8 +3802,9 @@ config:
                     category: "Nostr relay".to_string(),
                     seo_title: None,
                     seo_description: None,
-                    compose: "services:\n  a:\n    image: x\n    volumes:\n      - name: data\n        path: /d\n        size: 1Gi\n"
-                        .to_string(),
+                    compose:
+                        "services:\n  a:\n    image: x\n    volumes:\n      - name: data\n        path: /d\n        size: 1Gi\n"
+                            .to_string(),
                     amount: 1000,
                     currency: "USD".to_string(),
                     interval_amount: 1,
@@ -3809,27 +3818,34 @@ config:
                 },
             );
             let mut deps = db.app_deployments.lock().await;
-            deps.insert(1, deployment(1));
-            deps.insert(2, deployment(2));
-            // Deployment 1 is written first, so before the fix its failure was
-            // enough to leave 2 with no reading at all.
+            for id in 1..=3 {
+                deps.insert(id, deployment(id));
+            }
+            // Written first, so before the fix either failure was enough to
+            // leave everything after it with no reading at all.
             db.failing_usage_writes.lock().await.insert(1);
+            db.failing_usage_breakdown_writes.lock().await.insert(3);
         }
 
         let client =
             PrometheusClient::new(&format!("{}/", server.uri()), Duration::from_secs(5)).unwrap();
-        let deployments = vec![deployment(1), deployment(2)];
-        let active: HashSet<u64> = HashSet::from([1, 2]);
+        let deployments: Vec<AppDeployment> = (1..=3).map(deployment).collect();
+        let active: HashSet<u64> = HashSet::from([1, 2, 3]);
         collect_usage(&db, Some(&client), &deployments, &active)
             .await
             .unwrap();
 
         let deps = db.app_deployments.lock().await;
-        assert_eq!(deps[&1].usage_cpu_milli, None);
-        assert_eq!(deps[&2].usage_cpu_milli, Some(250));
         let breakdown = db.app_deployment_usage_breakdown.lock().await;
+        // Totals denied: no reading, and no breakdown describing one.
+        assert_eq!(deps[&1].usage_cpu_milli, None);
         assert!(!breakdown.contains_key(&1));
+        // Untouched by either failure.
+        assert_eq!(deps[&2].usage_cpu_milli, Some(250));
         assert_eq!(breakdown[&2].0.len(), 1);
         assert_eq!(breakdown[&2].1.len(), 1);
+        // Breakdown denied: the totals still stand on their own.
+        assert_eq!(deps[&3].usage_cpu_milli, Some(750));
+        assert!(!breakdown.contains_key(&3));
     }
 }

--- a/lnvps_operator/src/metrics.rs
+++ b/lnvps_operator/src/metrics.rs
@@ -319,7 +319,7 @@ pub fn collect_usage(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     fn sample(ns: &str, key: &str, value: f64) -> Sample {
@@ -506,7 +506,7 @@ mod tests {
 
     /// Serve `body` for a query matching `needle`, so each assertion pins which
     /// PromQL the client actually sent.
-    async fn mock_query(server: &wiremock::MockServer, needle: &str, body: String) {
+    pub(crate) async fn mock_query(server: &wiremock::MockServer, needle: &str, body: String) {
         use wiremock::matchers::{method, path, query_param_contains};
         use wiremock::{Mock, ResponseTemplate};
         Mock::given(method("GET"))
@@ -520,8 +520,22 @@ mod tests {
     /// An instant vector of one series, labelled with `key_label=key` alongside
     /// the namespace.
     fn vector(ns: &str, key_label: &str, key: &str, value: &str) -> String {
+        vectors(key_label, &[(ns, key, value)])
+    }
+
+    /// An instant vector carrying one series per `(namespace, key, value)`.
+    pub(crate) fn vectors(key_label: &str, rows: &[(&str, &str, &str)]) -> String {
+        let series: Vec<String> = rows
+            .iter()
+            .map(|(ns, key, value)| {
+                format!(
+                    r#"{{"metric":{{"namespace":"{ns}","{key_label}":"{key}"}},"value":[1690000000,"{value}"]}}"#
+                )
+            })
+            .collect();
         format!(
-            r#"{{"status":"success","data":{{"resultType":"vector","result":[{{"metric":{{"namespace":"{ns}","{key_label}":"{key}"}},"value":[1690000000,"{value}"]}}]}}}}"#
+            r#"{{"status":"success","data":{{"resultType":"vector","result":[{}]}}}}"#,
+            series.join(",")
         )
     }
 


### PR DESCRIPTION
Closes #315.

`collect_usage` propagated the first failed write with `?`, so one deployment's error left every deployment behind it in the iteration order with no reading at all (`lnvps_operator/src/app_deployments.rs:1348`). Both writes now log and move on, matching what the compose-parse failures a few lines below already did.

`collect_usage` takes the db and the metrics client rather than the whole `Context`, so the test does not need a kube client. `MockDb` gains `failing_usage_writes`, the only way to reach a failing write from a test.

Verified at `2a1557a`: `cargo test --workspace --exclude lnvps_e2e` 854 passed / 0 failed, e2e 163 pass, fmt clean and no new clippy warnings on either crate. The new test fails on the old code with `usage write denied for 1`.

From the lnvps channel.
