### PR TITLE
Reconcile transitioning app deployments on a shorter interval

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -345,7 +345,11 @@ customer watching a deployment come up sees its status move in seconds rather
 than once per `reconcile-interval`. Once every deployment is settled
 (`running`, `stopped` or `error`) the loop returns to `reconcile-interval` —
 a settled deployment only changes when something acts on it, and that path
-reconciles on its own. Values above `reconcile-interval` are capped to it.
+reconciles on its own. Values above `reconcile-interval` are capped to it, and values below one second
+are raised to it. The fast cadence lasts at most five minutes at a time: a
+workload that never becomes ready reads as `pending` forever, and sweeping the
+whole cluster every few seconds for it is load with no end — it returns to the
+fast cadence once the cluster settles, or when a payment triggers a reconcile.
 Nostr domain reconciliation is unaffected and always runs on
 `reconcile-interval`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -306,6 +306,7 @@ Reconciles Kubernetes `Ingress` and cert-manager `Certificate` objects for Nostr
 db: "mysql://root:root@localhost:3376/lnvps"
 namespace: "default"
 reconcile-interval: 60        # seconds
+transition-reconcile-interval: 5   # sweep this often while a deployment is still moving
 error-retry-interval: 30
 service-name: "lnvps-nostr"
 port-name: "http"
@@ -337,6 +338,16 @@ Give the shared secret a name of its own rather than `app-tls`: namespaces
 provisioned before this setting already hold a per-deployment secret under that
 name, and the ingress would serve whichever of the two the mirror had not
 overwritten yet.
+
+`transition-reconcile-interval` is the gap between app-deployment sweeps while
+at least one deployment on the cluster is `pending` or `deleting`, so a
+customer watching a deployment come up sees its status move in seconds rather
+than once per `reconcile-interval`. Once every deployment is settled
+(`running`, `stopped` or `error`) the loop returns to `reconcile-interval` —
+a settled deployment only changes when something acts on it, and that path
+reconciles on its own. Values above `reconcile-interval` are capped to it.
+Nostr domain reconciliation is unaffected and always runs on
+`reconcile-interval`.
 
 `redis` is optional and only meaningful alongside `app-cluster-id`: the operator
 consumes `app-cluster-{id}` and reconciles a deployment as soon as its payment

--- a/docs/config.md
+++ b/docs/config.md
@@ -346,10 +346,11 @@ than once per `reconcile-interval`. Once every deployment is settled
 (`running`, `stopped` or `error`) the loop returns to `reconcile-interval` —
 a settled deployment only changes when something acts on it, and that path
 reconciles on its own. Values above `reconcile-interval` are capped to it, and values below one second
-are raised to it. The fast cadence lasts at most five minutes at a time: a
-workload that never becomes ready reads as `pending` forever, and sweeping the
-whole cluster every few seconds for it is load with no end — it returns to the
-fast cadence once the cluster settles, or when a payment triggers a reconcile.
+are raised to it. The fast cadence lasts at most five minutes per deployment: a workload that
+never becomes ready reads as `pending` forever, and sweeping the whole cluster
+every few seconds for it is load with no end. A deployment that starts
+transitioning after that gets its own five minutes, so one wedged app does not
+cost the next customer their fast cadence.
 Nostr domain reconciliation is unaffected and always runs on
 `reconcile-interval`.
 

--- a/lnvps_operator/config.minimal.yaml
+++ b/lnvps_operator/config.minimal.yaml
@@ -34,5 +34,6 @@ cluster-issuer: "letsencrypt-prod"
 # ingress-class: "nginx"
 # ingress-namespace: "ingress-nginx"
 # reconcile-interval: 60
+# transition-reconcile-interval: 5
 # error-retry-interval: 30
 # verbose: false

--- a/lnvps_operator/config.yaml
+++ b/lnvps_operator/config.yaml
@@ -12,6 +12,11 @@ namespace: "lnvps"
 # Reconciliation interval in seconds (optional, defaults to 60)
 reconcile-interval: 60
 
+# How long to wait before the next app-deployment sweep while a deployment is
+# still provisioning or deleting (optional, defaults to 5, capped at
+# reconcile-interval). Settled deployments stay on reconcile-interval.
+transition-reconcile-interval: 5
+
 # Error retry interval in seconds (optional, defaults to 30)  
 error-retry-interval: 30
 

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -10,7 +10,7 @@
 //! The object **builders** are pure functions (unit-tested without a cluster);
 //! [`reconcile_app_deployments`] resolves config/secrets and applies them.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::Debug;
 use std::net::IpAddr;
 use std::sync::OnceLock;
@@ -1379,11 +1379,11 @@ pub fn is_transitioning(status: AppDeploymentStatus) -> bool {
 /// Reconcile every app deployment assigned to this operator's cluster into
 /// Kubernetes. No-op when the operator isn't configured with an `app_cluster_id`.
 ///
-/// Returns true when at least one deployment came back mid-transition, so the
-/// caller can come round again sooner than the steady-state interval.
-pub async fn reconcile_app_deployments(ctx: &Context) -> Result<bool> {
+/// Returns the deployments that came back mid-transition, so the caller can
+/// come round again sooner than the steady-state interval while they last.
+pub async fn reconcile_app_deployments(ctx: &Context) -> Result<BTreeSet<u64>> {
     let Some(cluster_id) = ctx.settings.app_cluster_id else {
-        return Ok(false);
+        return Ok(BTreeSet::new());
     };
     let cluster = ctx.db.get_app_cluster(cluster_id).await?;
     let deployments: Vec<AppDeployment> = ctx
@@ -1395,11 +1395,15 @@ pub async fn reconcile_app_deployments(ctx: &Context) -> Result<bool> {
         .collect();
 
     let mut active: HashSet<u64> = HashSet::new();
-    let mut transitioning = false;
+    let mut transitioning: BTreeSet<u64> = BTreeSet::new();
     for d in &deployments {
         active.insert(d.id);
         match reconcile_one(ctx, d, &cluster.ingress_domain).await {
-            Ok(status) => transitioning |= is_transitioning(status),
+            Ok(status) => {
+                if is_transitioning(status) {
+                    transitioning.insert(d.id);
+                }
+            }
             Err(e) => {
                 error!("app deployment {} reconcile failed: {}", d.id, e);
                 let mut errd = d.clone();

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -1364,11 +1364,26 @@ pub fn provisions_cluster_objects(gate: &GateReason) -> bool {
     !matches!(gate, GateReason::Unpaid)
 }
 
+/// True while a deployment is still moving towards its desired state, so its
+/// status is expected to change without anything else happening.
+///
+/// `Stopped` counts as settled: a deployment scaled to zero stays there until
+/// the customer or a payment changes the row, which triggers its own reconcile.
+pub fn is_transitioning(status: AppDeploymentStatus) -> bool {
+    matches!(
+        status,
+        AppDeploymentStatus::Pending | AppDeploymentStatus::Deleting
+    )
+}
+
 /// Reconcile every app deployment assigned to this operator's cluster into
 /// Kubernetes. No-op when the operator isn't configured with an `app_cluster_id`.
-pub async fn reconcile_app_deployments(ctx: &Context) -> Result<()> {
+///
+/// Returns true when at least one deployment came back mid-transition, so the
+/// caller can come round again sooner than the steady-state interval.
+pub async fn reconcile_app_deployments(ctx: &Context) -> Result<bool> {
     let Some(cluster_id) = ctx.settings.app_cluster_id else {
-        return Ok(());
+        return Ok(false);
     };
     let cluster = ctx.db.get_app_cluster(cluster_id).await?;
     let deployments: Vec<AppDeployment> = ctx
@@ -1380,14 +1395,18 @@ pub async fn reconcile_app_deployments(ctx: &Context) -> Result<()> {
         .collect();
 
     let mut active: HashSet<u64> = HashSet::new();
+    let mut transitioning = false;
     for d in &deployments {
         active.insert(d.id);
-        if let Err(e) = reconcile_one(ctx, d, &cluster.ingress_domain).await {
-            error!("app deployment {} reconcile failed: {}", d.id, e);
-            let mut errd = d.clone();
-            errd.status = AppDeploymentStatus::Error;
-            errd.status_message = Some(e.to_string());
-            let _ = ctx.db.update_app_deployment(&errd).await;
+        match reconcile_one(ctx, d, &cluster.ingress_domain).await {
+            Ok(status) => transitioning |= is_transitioning(status),
+            Err(e) => {
+                error!("app deployment {} reconcile failed: {}", d.id, e);
+                let mut errd = d.clone();
+                errd.status = AppDeploymentStatus::Error;
+                errd.status_message = Some(e.to_string());
+                let _ = ctx.db.update_app_deployment(&errd).await;
+            }
         }
     }
 
@@ -1402,7 +1421,7 @@ pub async fn reconcile_app_deployments(ctx: &Context) -> Result<()> {
     // Garbage-collect namespaces for deployments that no longer exist (deleted
     // rows are excluded from the active set above).
     gc_namespaces(&ctx.client, &active).await?;
-    Ok(())
+    Ok(transitioning)
 }
 
 /// Record what each deployment is consuming, from Prometheus (issue #278).
@@ -1538,7 +1557,7 @@ async fn reconcile_one(
     ctx: &Context,
     deployment: &AppDeployment,
     ingress_domain: &str,
-) -> Result<()> {
+) -> Result<AppDeploymentStatus> {
     let client = &ctx.client;
     let id = deployment.id;
     let app = ctx.db.get_app(deployment.app_id).await?;
@@ -1595,8 +1614,7 @@ async fn reconcile_one(
     if !provisions_cluster_objects(&gate) {
         info!("app deployment {id} not provisioned: {gate}");
         // Nothing was applied, so there is no workload to read.
-        write_back_status(ctx, deployment, hostname, &gate, None).await?;
-        return Ok(());
+        return write_back_status(ctx, deployment, hostname, &gate, None).await;
     }
 
     // 1. Namespace (Pod Security Standard) + isolation NetworkPolicy.
@@ -1749,9 +1767,9 @@ async fn reconcile_one(
             None
         }
     };
-    write_back_status(ctx, deployment, hostname, &gate, health).await?;
+    let status = write_back_status(ctx, deployment, hostname, &gate, health).await?;
     info!("reconciled app deployment {id}");
-    Ok(())
+    Ok(status)
 }
 
 /// What the cluster says about a deployment's workload (issue #276).
@@ -1925,7 +1943,7 @@ async fn write_back_status(
     hostname: String,
     gate: &GateReason,
     health: Option<WorkloadHealth>,
-) -> Result<()> {
+) -> Result<AppDeploymentStatus> {
     let id = deployment.id;
     let mut updated = deployment.clone();
     updated.hostname = Some(hostname);
@@ -1965,7 +1983,7 @@ async fn write_back_status(
         }
     }
     ctx.db.update_app_deployment(&updated).await?;
-    Ok(())
+    Ok(updated.status)
 }
 
 /// Delete namespaces owned by this operator whose deployment id is not in
@@ -1991,6 +2009,18 @@ async fn gc_namespaces(client: &Client, active: &HashSet<u64>) -> Result<()> {
 mod tests {
     use super::*;
     use crate::metrics::{ClaimUsage, ContainerUsage};
+
+    /// Which statuses keep the operator sweeping quickly. A deployment the
+    /// customer stopped is settled — the row only changes when someone acts on
+    /// it, and that path triggers its own reconcile.
+    #[test]
+    fn only_pending_and_deleting_count_as_transitioning() {
+        assert!(is_transitioning(AppDeploymentStatus::Pending));
+        assert!(is_transitioning(AppDeploymentStatus::Deleting));
+        assert!(!is_transitioning(AppDeploymentStatus::Running));
+        assert!(!is_transitioning(AppDeploymentStatus::Error));
+        assert!(!is_transitioning(AppDeploymentStatus::Stopped));
+    }
 
     /// The per-namespace binding is the only thing standing between the
     /// operator's token and every Secret in the cluster, so its shape is

--- a/lnvps_operator/src/main.rs
+++ b/lnvps_operator/src/main.rs
@@ -160,21 +160,13 @@ pub struct Context {
 /// Default gap between app-deployment sweeps while something is transitioning.
 const DEFAULT_TRANSITION_RECONCILE_SECS: u64 = 5;
 
-/// How long to wait before the next app-deployment sweep.
+/// How long the fast cadence may last before dropping back to the steady one.
 ///
-/// A deployment mid-provisioning changes state on its own, so its stored status
-/// is stale until the next sweep reads the cluster again; a settled deployment
-/// only changes when something else acts on it, and that path triggers its own
-/// reconcile. The fast interval is capped at the steady one so configuring a
-/// transition interval longer than `reconcile_interval` cannot slow the loop
-/// down below its floor.
-fn next_reconcile_delay(transitioning: bool, steady: Duration, transition: Duration) -> Duration {
-    if transitioning {
-        transition.min(steady)
-    } else {
-        steady
-    }
-}
+/// A workload that is merely not ready reads as transitioning, so an app whose
+/// readiness probe never passes would otherwise hold the whole cluster at the
+/// fast cadence forever. Provisioning that has not finished within this window
+/// is stuck, not slow, and is not worth sweeping for.
+const FAST_CADENCE_WINDOW: Duration = Duration::from_secs(300);
 
 /// The DSN to connect with: the environment wins over the config file, so the
 /// credential can live in a Secret while the rest of the config stays in a
@@ -265,13 +257,20 @@ async fn main() -> Result<()> {
         Err(e) => error!("Failed to reconcile app deployments: {}", e),
     }
 
-    let reconcile_interval = Duration::from_secs(context.settings.reconcile_interval.unwrap_or(60));
+    // Neither interval may be zero: that is a tight sweep loop against the API
+    // server, not a fast poll.
+    let reconcile_interval = Duration::from_secs(context.settings.reconcile_interval.unwrap_or(60))
+        .max(Duration::from_secs(1));
+    // Never below a second, and never above the steady interval it exists to
+    // beat.
     let transition_interval = Duration::from_secs(
         context
             .settings
             .transition_reconcile_interval
             .unwrap_or(DEFAULT_TRANSITION_RECONCILE_SECS),
-    );
+    )
+    .clamp(Duration::from_secs(1), reconcile_interval);
+    let max_fast_sweeps = (FAST_CADENCE_WINDOW.as_secs() / transition_interval.as_secs()).max(1);
 
     // Nostr domains follow DNS, which nothing here can hurry, so they stay on
     // the steady interval while app deployments run their own cadence.
@@ -291,24 +290,35 @@ async fn main() -> Result<()> {
     let app_transitioning = transitioning.clone();
     let app_wake = wake.clone();
     let reconciliation_task = async move {
+        let mut fast_sweeps = 0;
         loop {
-            let delay = next_reconcile_delay(
-                app_transitioning.load(Ordering::Relaxed),
-                reconcile_interval,
-                transition_interval,
-            );
+            let fast = app_transitioning.load(Ordering::Relaxed) && fast_sweeps < max_fast_sweeps;
             tokio::select! {
-                _ = tokio::time::sleep(delay) => {}
-                // Someone else swept and learned something about the cadence:
-                // start the wait again from the interval that now applies.
-                _ = app_wake.notified() => continue,
+                _ = tokio::time::sleep(if fast { transition_interval } else { reconcile_interval }) => {}
+                // A trigger is a fresh reason to watch closely: start the wait
+                // again, and give it a full fast window.
+                _ = app_wake.notified() => {
+                    fast_sweeps = 0;
+                    continue;
+                }
+            }
+            if fast {
+                fast_sweeps += 1;
             }
             match app_deployments::reconcile_app_deployments(&app_context).await {
-                Ok(t) => app_transitioning.store(t, Ordering::Relaxed),
+                Ok(t) => {
+                    // Only a settled cluster re-arms the fast window, so a
+                    // deployment stuck mid-transition cannot hold the cadence.
+                    if !t {
+                        fast_sweeps = 0;
+                    }
+                    app_transitioning.store(t, Ordering::Relaxed);
+                }
                 Err(e) => {
                     error!("Failed to reconcile app deployments: {}", e);
                     // An unknown outcome is not a reason to poll fast forever.
                     app_transitioning.store(false, Ordering::Relaxed);
+                    fast_sweeps = 0;
                 }
             }
         }
@@ -432,21 +442,6 @@ async fn trigger_listener(ctx: Arc<Context>, transitioning: Arc<AtomicBool>, wak
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A transitioning sweep comes round sooner; a settled one waits the full
-    /// interval, and a misconfigured fast interval can never be the slower of
-    /// the two.
-    #[test]
-    fn transitioning_deployments_shorten_the_next_sweep() {
-        let steady = Duration::from_secs(60);
-        let fast = Duration::from_secs(5);
-        assert_eq!(next_reconcile_delay(true, steady, fast), fast);
-        assert_eq!(next_reconcile_delay(false, steady, fast), steady);
-        assert_eq!(
-            next_reconcile_delay(true, steady, Duration::from_secs(600)),
-            steady
-        );
-    }
 
     /// The DSN is a credential, so a deployment can supply it from a Secret
     /// through the environment; the config file stays the fallback.

--- a/lnvps_operator/src/main.rs
+++ b/lnvps_operator/src/main.rs
@@ -9,8 +9,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::signal;
+use tokio::sync::Notify;
 
 mod app_deployments;
 mod metrics;
@@ -58,6 +60,12 @@ pub struct Settings {
 
     /// Reconciliation interval in seconds (defaults to 60)
     pub reconcile_interval: Option<u64>,
+
+    /// How long to wait before the next app-deployment sweep while at least one
+    /// deployment is still transitioning (defaults to 5 seconds, and is capped
+    /// at `reconcile_interval`). Steady-state deployments stay on
+    /// `reconcile_interval`.
+    pub transition_reconcile_interval: Option<u64>,
 
     /// Error retry interval in seconds (defaults to 30)
     pub error_retry_interval: Option<u64>,
@@ -149,6 +157,25 @@ pub struct Context {
     pub metrics: Option<PrometheusClient>,
 }
 
+/// Default gap between app-deployment sweeps while something is transitioning.
+const DEFAULT_TRANSITION_RECONCILE_SECS: u64 = 5;
+
+/// How long to wait before the next app-deployment sweep.
+///
+/// A deployment mid-provisioning changes state on its own, so its stored status
+/// is stale until the next sweep reads the cluster again; a settled deployment
+/// only changes when something else acts on it, and that path triggers its own
+/// reconcile. The fast interval is capped at the steady one so configuring a
+/// transition interval longer than `reconcile_interval` cannot slow the loop
+/// down below its floor.
+fn next_reconcile_delay(transitioning: bool, steady: Duration, transition: Duration) -> Duration {
+    if transitioning {
+        transition.min(steady)
+    } else {
+        steady
+    }
+}
+
 /// The DSN to connect with: the environment wins over the config file, so the
 /// credential can live in a Secret while the rest of the config stays in a
 /// ConfigMap.
@@ -229,24 +256,60 @@ async fn main() -> Result<()> {
     if let Err(e) = nostr_domains::reconcile_nostr_domains(&context).await {
         error!("Failed to reconcile nostr domains: {}", e);
     }
-    if let Err(e) = app_deployments::reconcile_app_deployments(&context).await {
-        error!("Failed to reconcile app deployments: {}", e);
+    // Shared with the trigger listener so a payment-triggered sweep that leaves
+    // a deployment provisioning also puts the timer on the fast cadence.
+    let transitioning = Arc::new(AtomicBool::new(false));
+    let wake = Arc::new(Notify::new());
+    match app_deployments::reconcile_app_deployments(&context).await {
+        Ok(t) => transitioning.store(t, Ordering::Relaxed),
+        Err(e) => error!("Failed to reconcile app deployments: {}", e),
     }
 
-    // Set up periodic reconciliation
-    let context_clone = context.clone();
     let reconcile_interval = Duration::from_secs(context.settings.reconcile_interval.unwrap_or(60));
-    let mut interval = tokio::time::interval(reconcile_interval);
+    let transition_interval = Duration::from_secs(
+        context
+            .settings
+            .transition_reconcile_interval
+            .unwrap_or(DEFAULT_TRANSITION_RECONCILE_SECS),
+    );
 
-    let reconciliation_task = async move {
+    // Nostr domains follow DNS, which nothing here can hurry, so they stay on
+    // the steady interval while app deployments run their own cadence.
+    let nostr_context = context.clone();
+    let nostr_task = async move {
+        let mut interval = tokio::time::interval(reconcile_interval);
+        interval.tick().await;
         loop {
             interval.tick().await;
-            info!("Running periodic reconciliation...");
-            if let Err(e) = nostr_domains::reconcile_nostr_domains(&context_clone).await {
+            if let Err(e) = nostr_domains::reconcile_nostr_domains(&nostr_context).await {
                 error!("Failed to reconcile nostr domains: {}", e);
             }
-            if let Err(e) = app_deployments::reconcile_app_deployments(&context_clone).await {
-                error!("Failed to reconcile app deployments: {}", e);
+        }
+    };
+
+    let app_context = context.clone();
+    let app_transitioning = transitioning.clone();
+    let app_wake = wake.clone();
+    let reconciliation_task = async move {
+        loop {
+            let delay = next_reconcile_delay(
+                app_transitioning.load(Ordering::Relaxed),
+                reconcile_interval,
+                transition_interval,
+            );
+            tokio::select! {
+                _ = tokio::time::sleep(delay) => {}
+                // Someone else swept and learned something about the cadence:
+                // start the wait again from the interval that now applies.
+                _ = app_wake.notified() => continue,
+            }
+            match app_deployments::reconcile_app_deployments(&app_context).await {
+                Ok(t) => app_transitioning.store(t, Ordering::Relaxed),
+                Err(e) => {
+                    error!("Failed to reconcile app deployments: {}", e);
+                    // An unknown outcome is not a reason to poll fast forever.
+                    app_transitioning.store(false, Ordering::Relaxed);
+                }
             }
         }
     };
@@ -254,13 +317,16 @@ async fn main() -> Result<()> {
     // Immediate reconcile on payment (#254). Optional: without a Redis URL the
     // periodic loop above is the only trigger, which is the behaviour that
     // shipped before this.
-    let trigger_task = trigger_listener(context.clone());
+    let trigger_task = trigger_listener(context.clone(), transitioning.clone(), wake.clone());
 
     // TODO: Add back the controller logic here
 
     tokio::select! {
         _ = reconciliation_task => {
             warn!("Reconciliation task stopped unexpectedly");
+        }
+        _ = nostr_task => {
+            warn!("Nostr domain reconciliation task stopped unexpectedly");
         }
         _ = trigger_task => {
             warn!("Reconcile-trigger listener stopped unexpectedly");
@@ -286,7 +352,7 @@ async fn main() -> Result<()> {
 /// re-reads the deployment's current row rather than trusting the message, and
 /// a stale or duplicated trigger therefore costs a sweep rather than producing
 /// a different outcome from the periodic one.
-async fn trigger_listener(ctx: Arc<Context>) {
+async fn trigger_listener(ctx: Arc<Context>, transitioning: Arc<AtomicBool>, wake: Arc<Notify>) {
     let (Some(redis_url), Some(cluster_id)) =
         (ctx.settings.redis.clone(), ctx.settings.app_cluster_id)
     else {
@@ -344,8 +410,12 @@ async fn trigger_listener(ctx: Arc<Context>) {
         }
         if !triggers.is_empty() {
             info!("Reconcile trigger for app deployment(s) {triggers:?}");
-            if let Err(e) = app_deployments::reconcile_app_deployments(&ctx).await {
-                error!("Triggered reconcile failed: {e}");
+            match app_deployments::reconcile_app_deployments(&ctx).await {
+                Ok(t) => {
+                    transitioning.store(t, Ordering::Relaxed);
+                    wake.notify_one();
+                }
+                Err(e) => error!("Triggered reconcile failed: {e}"),
             }
         }
         for msg in &jobs {
@@ -362,6 +432,21 @@ async fn trigger_listener(ctx: Arc<Context>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A transitioning sweep comes round sooner; a settled one waits the full
+    /// interval, and a misconfigured fast interval can never be the slower of
+    /// the two.
+    #[test]
+    fn transitioning_deployments_shorten_the_next_sweep() {
+        let steady = Duration::from_secs(60);
+        let fast = Duration::from_secs(5);
+        assert_eq!(next_reconcile_delay(true, steady, fast), fast);
+        assert_eq!(next_reconcile_delay(false, steady, fast), steady);
+        assert_eq!(
+            next_reconcile_delay(true, steady, Duration::from_secs(600)),
+            steady
+        );
+    }
 
     /// The DSN is a credential, so a deployment can supply it from a Secret
     /// through the environment; the config file stays the fallback.

--- a/lnvps_operator/src/main.rs
+++ b/lnvps_operator/src/main.rs
@@ -6,10 +6,10 @@ use lnvps_api_common::{RedisWorkCommander, WorkCommander, WorkJob, app_cluster_s
 use lnvps_db::{LNVpsDb, LNVpsDbMysql};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::signal;
 use tokio::sync::Notify;
@@ -250,10 +250,10 @@ async fn main() -> Result<()> {
     }
     // Shared with the trigger listener so a payment-triggered sweep that leaves
     // a deployment provisioning also puts the timer on the fast cadence.
-    let transitioning = Arc::new(AtomicBool::new(false));
+    let transitioning: Arc<Mutex<BTreeSet<u64>>> = Arc::new(Mutex::new(BTreeSet::new()));
     let wake = Arc::new(Notify::new());
     match app_deployments::reconcile_app_deployments(&context).await {
-        Ok(t) => transitioning.store(t, Ordering::Relaxed),
+        Ok(t) => *transitioning.lock().unwrap() = t,
         Err(e) => error!("Failed to reconcile app deployments: {}", e),
     }
 
@@ -291,34 +291,32 @@ async fn main() -> Result<()> {
     let app_wake = wake.clone();
     let reconciliation_task = async move {
         let mut fast_sweeps = 0;
+        let mut watched: BTreeSet<u64> = BTreeSet::new();
         loop {
-            let fast = app_transitioning.load(Ordering::Relaxed) && fast_sweeps < max_fast_sweeps;
+            let current = app_transitioning.lock().unwrap().clone();
+            // A deployment we were not already watching is fresh work and gets
+            // its own fast window; a deployment wedged mid-transition burns its
+            // budget once and cannot spend the next one's.
+            if current.iter().any(|id| !watched.contains(id)) {
+                fast_sweeps = 0;
+            }
+            watched = current;
+            let fast = !watched.is_empty() && fast_sweeps < max_fast_sweeps;
             tokio::select! {
                 _ = tokio::time::sleep(if fast { transition_interval } else { reconcile_interval }) => {}
-                // A trigger is a fresh reason to watch closely: start the wait
-                // again, and give it a full fast window.
-                _ = app_wake.notified() => {
-                    fast_sweeps = 0;
-                    continue;
-                }
+                // Someone else swept: re-read what is transitioning now rather
+                // than waiting out a delay chosen before that was known.
+                _ = app_wake.notified() => continue,
             }
             if fast {
                 fast_sweeps += 1;
             }
             match app_deployments::reconcile_app_deployments(&app_context).await {
-                Ok(t) => {
-                    // Only a settled cluster re-arms the fast window, so a
-                    // deployment stuck mid-transition cannot hold the cadence.
-                    if !t {
-                        fast_sweeps = 0;
-                    }
-                    app_transitioning.store(t, Ordering::Relaxed);
-                }
+                Ok(t) => *app_transitioning.lock().unwrap() = t,
                 Err(e) => {
                     error!("Failed to reconcile app deployments: {}", e);
                     // An unknown outcome is not a reason to poll fast forever.
-                    app_transitioning.store(false, Ordering::Relaxed);
-                    fast_sweeps = 0;
+                    app_transitioning.lock().unwrap().clear();
                 }
             }
         }
@@ -362,7 +360,11 @@ async fn main() -> Result<()> {
 /// re-reads the deployment's current row rather than trusting the message, and
 /// a stale or duplicated trigger therefore costs a sweep rather than producing
 /// a different outcome from the periodic one.
-async fn trigger_listener(ctx: Arc<Context>, transitioning: Arc<AtomicBool>, wake: Arc<Notify>) {
+async fn trigger_listener(
+    ctx: Arc<Context>,
+    transitioning: Arc<Mutex<BTreeSet<u64>>>,
+    wake: Arc<Notify>,
+) {
     let (Some(redis_url), Some(cluster_id)) =
         (ctx.settings.redis.clone(), ctx.settings.app_cluster_id)
     else {
@@ -422,7 +424,7 @@ async fn trigger_listener(ctx: Arc<Context>, transitioning: Arc<AtomicBool>, wak
             info!("Reconcile trigger for app deployment(s) {triggers:?}");
             match app_deployments::reconcile_app_deployments(&ctx).await {
                 Ok(t) => {
-                    transitioning.store(t, Ordering::Relaxed);
+                    *transitioning.lock().unwrap() = t;
                     wake.notify_one();
                 }
                 Err(e) => error!("Triggered reconcile failed: {e}"),


### PR DESCRIPTION
Closes #321.

The operator's sweep now reports whether anything came back mid-transition, and the loop waits `transition-reconcile-interval` (default 5s, capped at `reconcile-interval`) instead of the full interval while that holds.

- `reconcile_one`/`write_back_status` return the status they settled on, so the sweep classifies from what it actually wrote rather than re-reading (`lnvps_operator/src/app_deployments.rs:1943`).
- `Pending`/`Deleting` are transitioning; `Running`/`Error`/`Stopped` are settled — a stopped deployment only moves when something acts on it, and that path reconciles on its own (`app_deployments.rs:1372`).
- The #254 trigger listener shares the flag and wakes the timer (`main.rs:296`), so a sweep right after payment puts the loop on the fast cadence instead of leaving it in a 60s sleep it started earlier.
- Nostr domain reconciliation is split into its own task on the steady interval — it follows DNS, which nothing here can hurry.

No e2e: the operator needs a cluster and is not in the e2e stack. Unit tests cover the cadence choice and the status classification.

Originating channel: Buzz #721a8a6c-c36c-5fa1-ae07-822ddc8567c5
