### PR TITLE
Replace ssh2 with russh in SshClient

### DIFF
--- a/.github/e2e/sshd/Dockerfile
+++ b/.github/e2e/sshd/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.21
+
+# socat provides the unix socket the direct-streamlocal tunnel test connects to,
+# standing in for the QEMU serial socket on a Proxmox node.
+RUN apk add --no-cache openssh socat
+
+# sshd takes the first occurrence of a keyword, so the shipped directives are
+# rewritten in place rather than appended to. Alpine defaults
+# AllowTcpForwarding to no, which also denies direct-streamlocal.
+RUN ssh-keygen -A \
+    && sed -i \
+        -e 's|^#*PermitRootLogin .*|PermitRootLogin prohibit-password|' \
+        -e 's|^#*AllowTcpForwarding .*|AllowTcpForwarding yes|' \
+        /etc/ssh/sshd_config \
+    && printf 'AllowStreamLocalForwarding yes\n' >> /etc/ssh/sshd_config
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 22
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/e2e/sshd/entrypoint.sh
+++ b/.github/e2e/sshd/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Test sshd for the SshClient integration tests.
+#
+# The client keypair is generated into the mounted /keys volume on first start
+# rather than committed, so no private key lives in the repository. The host
+# reads /keys/id_ed25519 to authenticate.
+set -eu
+
+KEY=/keys/id_ed25519
+
+if [ ! -f "$KEY" ]; then
+    ssh-keygen -t ed25519 -f "$KEY" -N "" -C lnvps-e2e >/dev/null
+fi
+
+mkdir -p /root/.ssh
+cp "${KEY}.pub" /root/.ssh/authorized_keys
+chmod 700 /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+# World-readable so the test process on the host can read it out of the mounted
+# volume; it is a throwaway key generated per volume and never leaves the stack.
+chmod 644 "${KEY}.pub" "$KEY"
+
+# Echo server on a unix socket: whatever the tunnel writes comes straight back.
+socat UNIX-LISTEN:/tmp/e2e-echo.sock,fork EXEC:cat &
+
+exec /usr/sbin/sshd -D -e

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules/
 lnvps_api/Cargo.lock
 lnvps_db/Cargo.lock
 lnvps_nostr/Cargo.lock
+
+# Docker bind mounts for the e2e stack (includes a generated test ssh key)
+/volumes/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,8 +14,18 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
- "generic-array",
+ "crypto-common 0.1.7",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -25,8 +35,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -35,12 +57,27 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.2",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -141,6 +178,18 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.3.0",
+ "password-hash 0.6.1",
+]
 
 [[package]]
 name = "arraydeque"
@@ -361,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
 dependencies = [
  "futures-util",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "tokio",
  "wasm-bindgen-futures",
 ]
@@ -419,6 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -461,7 +511,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -522,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "tokio",
 ]
 
@@ -531,6 +581,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base58ck"
@@ -568,6 +624,17 @@ dependencies = [
  "base64 0.21.7",
  "pastey",
  "serde",
+]
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.13.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -640,12 +707,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -654,7 +740,26 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+dependencies = [
+ "byteorder",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -687,7 +792,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -721,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -732,8 +846,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -742,10 +858,10 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
- "poly1305",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -769,8 +885,20 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
  "zeroize",
 ]
 
@@ -822,6 +950,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -895,6 +1029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1088,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1048,8 +1194,25 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1060,9 +1223,30 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1071,7 +1255,54 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1110,6 +1341,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,13 +1379,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1217,15 +1484,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1272,12 +1560,53 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1307,16 +1636,38 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1364,6 +1715,18 @@ version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1502,6 +1865,22 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1701,6 +2080,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,9 +2124,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1746,7 +2138,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.3",
 ]
 
 [[package]]
@@ -1762,13 +2163,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1864,7 +2288,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -1902,6 +2326,12 @@ checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hex_lit"
@@ -1985,7 +2415,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1994,7 +2433,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2067,6 +2515,18 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -2341,8 +2801,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
- "generic-array",
+ "block-padding 0.3.3",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2355,6 +2825,18 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2569,6 +3051,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "kube"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,32 +3254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "lightning-invoice"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,12 +3291,12 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41eacdd87b675792f7752f3dd0937a00241a504c3956c47f72986490662e1db4"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "anyhow",
  "base64 0.22.1",
  "bech32",
  "bitcoin",
- "cbc",
+ "cbc 0.1.2",
  "email_address",
  "reqwest 0.12.28",
  "serde",
@@ -2886,16 +3362,17 @@ dependencies = [
  "nostr-sdk",
  "nwc",
  "openapi-build-gen",
- "p256",
+ "p256 0.13.2",
  "payments-rs",
  "quick-xml",
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.4",
+ "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
- "ssh-key",
- "ssh2",
+ "ssh-key 0.6.7",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tower-http",
@@ -2949,7 +3426,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "ipnetwork",
  "isocountry",
  "lnvps_db",
@@ -2962,8 +3439,8 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "sqlx",
  "tokio",
  "try-procedure",
@@ -2985,7 +3462,7 @@ dependencies = [
 name = "lnvps_db"
 version = "0.4.7"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -2994,7 +3471,7 @@ dependencies = [
  "log 0.4.32",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -3015,13 +3492,13 @@ dependencies = [
  "chrono",
  "hex",
  "nostr 0.44.3",
- "p256",
+ "p256 0.13.2",
  "rand_core 0.6.4",
  "redis",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "tokio",
  "webauthn-rs",
@@ -3153,8 +3630,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -3203,6 +3686,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -3268,6 +3776,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,19 +3811,19 @@ name = "nostr"
 version = "0.44.1"
 source = "git+https://github.com/rust-nostr/nostr?rev=c69c4ae2bf1a5f340aba70c20d09323f5309a4e2#c69c4ae2bf1a5f340aba70c20d09323f5309a4e2"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "base64 0.22.1",
  "bech32",
  "bip39",
  "bitcoin_hashes",
- "cbc",
+ "cbc 0.1.2",
  "chacha20 0.9.1",
  "chacha20poly1305",
  "hex",
  "instant",
  "once_cell",
  "rand 0.9.4",
- "scrypt",
+ "scrypt 0.11.0",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3321,13 +3841,13 @@ dependencies = [
  "bech32",
  "bip39",
  "bitcoin_hashes",
- "cbc",
+ "cbc 0.1.2",
  "chacha20 0.9.1",
  "chacha20poly1305",
  "getrandom 0.2.17",
  "hex",
  "instant",
- "scrypt",
+ "scrypt 0.11.0",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3599,10 +4119,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3611,10 +4144,24 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "fiat-crypto",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3623,12 +4170,46 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
+dependencies = [
+ "base16ct 1.0.0",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+dependencies = [
+ "base16ct 1.0.0",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log 0.4.32",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "windows",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3672,6 +4253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
+]
+
+[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3695,7 +4285,7 @@ dependencies = [
  "fedimint-tonic-lnd",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "lightning-invoice",
  "log 0.4.32",
  "reqwest 0.13.4",
@@ -3703,7 +4293,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tokio-stream",
 ]
@@ -3714,8 +4304,18 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3733,6 +4333,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -3783,7 +4392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3794,6 +4403,16 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -3834,9 +4453,36 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes 0.9.2",
+ "aes-gcm 0.11.0",
+ "cbc 0.2.1",
+ "der 0.8.1",
+ "pbkdf2 0.13.0",
+ "rand_core 0.10.1",
+ "scrypt 0.12.0",
+ "sha2 0.11.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3845,8 +4491,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "pkcs5",
+ "rand_core 0.10.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3869,7 +4527,18 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3881,7 +4550,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -3945,12 +4625,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4406,8 +5113,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4420,7 +5137,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4444,19 +5161,154 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+dependencies = [
+ "aes 0.9.2",
+ "aws-lc-rs",
+ "bitflags",
+ "block-padding 0.4.2",
+ "byteorder",
+ "bytes",
+ "cbc 0.2.1",
+ "cipher 0.5.2",
+ "crypto-bigint 0.7.5",
+ "ctr 0.10.1",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der 0.8.1",
+ "digest 0.11.3",
+ "ecdsa 0.17.0",
+ "ed25519-dalek",
+ "elliptic-curve 0.14.1",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.4",
+ "getrandom 0.4.3",
+ "ghash 0.6.0",
+ "hex-literal",
+ "hmac 0.13.0",
+ "inout 0.2.2",
+ "internal-russh-num-bigint",
+ "keccak",
+ "log 0.4.32",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256 0.14.0",
+ "p384 0.14.0",
+ "p521 0.14.0",
+ "pageant",
+ "pbkdf2 0.13.0",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs5",
+ "pkcs8 0.11.0",
+ "polyval 0.7.3",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "rsa 0.10.0-rc.18",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20 0.11.0",
+ "scrypt 0.12.0",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "ssh-encoding 0.3.0",
+ "ssh-key 0.7.0-rc.11",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash 0.6.1",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
+dependencies = [
+ "log 0.4.32",
+ "nix",
+ "ssh-encoding 0.3.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "gloo-timers 0.4.0",
+ "log 0.4.32",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4611,7 +5463,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4632,7 +5484,17 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -4689,10 +5551,22 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2",
+ "password-hash 0.5.0",
+ "pbkdf2 0.12.2",
+ "salsa20 0.10.2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20 0.11.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -4701,10 +5575,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4821,6 +5709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_cbor_2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,6 +5831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,7 +5848,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4957,7 +5876,39 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -4982,8 +5933,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5059,8 +6020,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlx"
@@ -5101,7 +6078,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5138,7 +6115,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5161,17 +6138,17 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log 0.4.32",
  "md-5",
@@ -5179,10 +6156,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
- "rsa",
+ "rsa 0.9.10",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5209,8 +6186,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log 0.4.32",
@@ -5220,7 +6197,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5260,8 +6237,26 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
- "cipher",
- "ssh-encoding",
+ "cipher 0.4.4",
+ "ssh-encoding 0.2.0",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.2",
+ "aes-gcm 0.11.0",
+ "chacha20 0.10.0",
+ "cipher 0.5.2",
+ "ctutils",
+ "des",
+ "poly1305 0.9.1",
+ "ssh-encoding 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5271,8 +6266,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
- "pem-rfc7468",
- "sha2",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "crypto-bigint 0.7.5",
+ "ctutils",
+ "digest 0.11.3",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5281,30 +6291,44 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
- "p256",
- "p384",
- "p521",
+ "p256 0.13.2",
+ "p384 0.13.1",
+ "p521 0.13.3",
  "rand_core 0.6.4",
- "rsa",
- "sec1",
- "sha2",
- "signature",
- "ssh-cipher",
- "ssh-encoding",
+ "rsa 0.9.10",
+ "sec1 0.7.3",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "ssh-cipher 0.2.0",
+ "ssh-encoding 0.2.0",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ssh2"
-version = "0.9.5"
+name = "ssh-key"
+version = "0.7.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
 dependencies = [
- "bitflags",
- "libc",
- "libssh2-sys",
- "parking_lot",
+ "argon2",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.13.0",
+ "p256 0.14.0",
+ "p384 0.14.0",
+ "p521 0.14.0",
+ "rand_core 0.10.1",
+ "rsa 0.10.0-rc.18",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "ssh-cipher 0.3.0",
+ "ssh-encoding 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5645,6 +6669,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -5838,7 +6863,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -5856,7 +6881,7 @@ dependencies = [
  "log 0.4.32",
  "native-tls",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -5873,7 +6898,7 @@ dependencies = [
  "httparse",
  "log 0.4.32",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -5940,8 +6965,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -5949,6 +6984,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6285,6 +7326,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6295,6 +7357,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6324,6 +7397,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -6436,6 +7519,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6613,6 +7705,17 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
 
 [[package]]
 name = "writeable"

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -127,6 +127,21 @@ services:
       retries: 30
       start_period: 10s
 
+  # Real sshd for the SshClient integration tests (exec, SFTP upload, unix
+  # socket tunnel). Without it nothing exercises the SSH plumbing outside of
+  # live Proxmox hosts.
+  sshd:
+    build: .github/e2e/sshd
+    ports:
+      - "2222:22"
+    volumes:
+      - "./volumes/e2e-sshd:/keys"
+    healthcheck:
+      test: ["CMD", "sh", "-c", "test -f /keys/id_ed25519 && nc -z localhost 22"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
   nostr-relay:
     image: dockurr/strfry
     ports:

--- a/docs/agents/e2e-tests.md
+++ b/docs/agents/e2e-tests.md
@@ -43,6 +43,8 @@ docker compose up -d
 cargo test --workspace --exclude lnvps_e2e -- --test-threads=1
 ```
 
+After the `lnvps_e2e` suite, `run-e2e.sh` also runs `cargo test -p lnvps_api --test ssh_client`: `SshClient` talks SSH rather than HTTP, so it is covered against the `sshd` service in `docker-compose.e2e.yaml` (command exec, SFTP upload, unix-socket tunnel, auth failure) instead of through the API. Those tests skip themselves when `LNVPS_TEST_SSH_ADDR` / `LNVPS_TEST_SSH_KEY` are unset, so a plain `cargo test --workspace` does not need the stack.
+
 The `run-e2e.sh` script sets `LNVPS_NO_DEV_SETUP=1` when starting the API servers so that `dev_setup.sql` is not executed. The lifecycle test creates and cleans up all its own infrastructure; the dev setup data would conflict with it.
 
 ## Per-run Database Isolation
@@ -66,6 +68,8 @@ The API servers must be configured to connect to the same per-run database. In C
 | `LNVPS_DB_URL` | `mysql://root:root@localhost:3376/lnvps` | Full DB URL — only used to derive `LNVPS_DB_BASE_URL` when the latter is not set. |
 | `LNVPS_E2E_RUN_ID` | *(current timestamp ms)* | Unique ID for this test run; determines the per-run DB name `lnvps_e2e_{run_id}`. |
 | `LNVPS_NO_DEV_SETUP` | *(unset)* | Set to any value to suppress `dev_setup.sql` on startup (debug builds only). Always set by `run-e2e.sh`. |
+| `LNVPS_TEST_SSH_ADDR` | *(unset)* | `host:port` of the compose `sshd` service; set by `run-e2e.sh` to `localhost:2222`. |
+| `LNVPS_TEST_SSH_KEY` | *(unset)* | Client private key for that sshd, generated into `volumes/e2e-sshd/` on first start. |
 | `NOSTR_SECRET_KEY` | *(random)* | Hex Nostr secret key for user identity |
 | `ADMIN_NOSTR_SECRET_KEY` | *(random)* | Hex Nostr secret key for admin identity |
 

--- a/lnvps_api/Cargo.toml
+++ b/lnvps_api/Cargo.toml
@@ -36,13 +36,13 @@ default = [
 ]
 openapi = ["dep:openapi-build-gen"]
 mikrotik = []
-# Linux router managed over SSH (shares the ssh2-based SshClient with proxmox)
-linux-ssh = ["dep:ssh2"]
+# Linux router managed over SSH (shares the SshClient with proxmox)
+linux-ssh = ["dep:russh", "dep:russh-sftp"]
 nostr-dm = ["dep:nostr-sdk", "nostr-sdk/nip44", "nostr-sdk/nip59"]
 nostr-dvm = ["dep:nostr-sdk"]
 nostr-domain = ["lnvps_db/nostr-domain", "dep:uuid"]
 nostr-nwc = ["dep:nostr-sdk", "dep:nwc", "nostr-sdk/nip47"]
-proxmox = ["dep:ssh2", "dep:tokio-tungstenite"]
+proxmox = ["dep:russh", "dep:russh-sftp", "dep:tokio-tungstenite"]
 libvirt = ["dep:virt", "dep:uuid", "dep:quick-xml"]
 lnd = ["payments-rs/method-lnd"]
 # On-chain Bitcoin payments (LND wallet backend)
@@ -117,7 +117,6 @@ nwc = { rev = "c69c4ae2bf1a5f340aba70c20d09323f5309a4e2", git = "https://github.
 
 #proxmox
 tokio-tungstenite = { version = "0.28", features = ["native-tls"], optional = true }
-ssh2 = { version = "0.9", optional = true }
 reqwest = { workspace = true }
 
 #libvirt
@@ -125,6 +124,8 @@ virt = { git = "https://gitlab.com/libvirt/libvirt-rust.git", optional = true }
 #virtxml = {git = "https://gitlab.com/libvirt/libvirt-rust-xml.git", optional = true}/
 uuid = { version = "1.16", features = ["v4", "serde"], optional = true }
 quick-xml = { version = "0.39", features = ["serde", "serialize"], optional = true }
+russh = { version = "0.62", optional = true }
+russh-sftp = { version = "2", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/lnvps_api/src/host/proxmox.rs
+++ b/lnvps_api/src/host/proxmox.rs
@@ -2006,12 +2006,8 @@ impl VmHostClient for ProxmoxClient {
 
         let ssh_channel = client
             .tunnel_unix_socket(std::path::Path::new(&socket_path))
+            .await
             .map_err(OpError::Transient)?;
-
-        // Enable non-blocking mode *after* the channel is fully established.
-        // Setting it before causes the channel_direct_streamlocal handshake to
-        // fail with WouldBlock.
-        client.set_blocking(false);
 
         // mpsc channels: the TerminalStream returned to the caller exposes
         // client_rx (bytes from VM) and server_tx (bytes to VM).
@@ -2019,10 +2015,11 @@ impl VmHostClient for ProxmoxClient {
         let (client_tx, client_rx) = mpsc_channel::<Vec<u8>>(256);
         let (server_tx, server_rx) = mpsc_channel::<Vec<u8>>(256);
 
-        // Run the blocking I/O bridge in a dedicated thread so the non-Send
-        // ssh2::Channel does not cross async task boundaries.
-        tokio::task::spawn_blocking(move || {
-            ssh_terminal_bridge(ssh_channel, client_tx, server_rx);
+        // The client owns the SSH session the tunnel channel belongs to, so it
+        // has to outlive the bridge.
+        tokio::spawn(async move {
+            ssh_terminal_bridge(ssh_channel, client_tx, server_rx).await;
+            drop(client);
         });
 
         info!("Terminal proxy opened for VM {}", vm_id);
@@ -2043,11 +2040,7 @@ impl ProxmoxClient {
 
     /// Run a shell command on the Proxmox node over SSH.
     ///
-    /// Delegates to [`SshClient::run_command`], which performs the blocking
-    /// libssh2 connect + exec on a dedicated blocking thread. This is important
-    /// for long-running commands (image downloads, decompression): doing the
-    /// blocking SSH I/O directly on an async worker thread would stall the entire
-    /// tokio runtime for the command's full duration.
+    /// Delegates to [`SshClient::run_command`], which opens a session per call.
     async fn ssh_run(&self, command: String) -> Result<(i32, String)> {
         let ssh_cfg = match &self.ssh {
             Some(s) => s,
@@ -2795,63 +2788,46 @@ pub struct VmFirewallRule {
     pub rule_type: VmFirewallRuleType,
 }
 
-/// Blocking I/O bridge between an SSH channel (QEMU serial socket) and the
-/// async mpsc channels exposed as a [`TerminalStream`].
-///
-/// This function is intended to be executed via [`tokio::task::spawn_blocking`]
-/// so that the non-`Send` [`ssh2::Channel`] never crosses async task boundaries.
-fn ssh_terminal_bridge(
-    mut channel: ssh2::Channel,
+/// I/O bridge between an SSH channel (QEMU serial socket) and the async mpsc
+/// channels exposed as a [`TerminalStream`].
+async fn ssh_terminal_bridge(
+    mut channel: russh::Channel<russh::client::Msg>,
     client_tx: tokio::sync::mpsc::Sender<Vec<u8>>,
     mut server_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
 ) {
-    use std::io::{Read, Write};
-
-    // Non-blocking mode is already set on the session by the caller.
-    let mut buf = [0u8; 4096];
     loop {
-        // --- upstream: serial socket → WebSocket client ---
-        match channel.stream(0).read(&mut buf) {
-            Ok(0) => {
-                // EOF: the channel was closed by the remote side.
-                break;
-            }
-            Ok(n) => {
-                if client_tx.blocking_send(buf[..n].to_vec()).is_err() {
-                    // Receiver dropped (WebSocket closed).
-                    break;
+        tokio::select! {
+            // --- upstream: serial socket → WebSocket client ---
+            msg = channel.wait() => {
+                match msg {
+                    Some(russh::ChannelMsg::Data { data }) => {
+                        if client_tx.send(data.to_vec()).await.is_err() {
+                            // Receiver dropped (WebSocket closed).
+                            break;
+                        }
+                    }
+                    // EOF or channel closed by the remote side.
+                    Some(russh::ChannelMsg::Eof) | Some(russh::ChannelMsg::Close) | None => break,
+                    Some(_) => {}
                 }
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // No data available right now — fall through to check
-                // downstream direction, then sleep briefly.
-            }
-            Err(e) => {
-                log::warn!("Terminal read error: {}", e);
-                break;
-            }
-        }
-
-        // --- downstream: WebSocket client → serial socket ---
-        match server_rx.try_recv() {
-            Ok(data) => {
-                if let Err(e) = channel.stream(0).write_all(&data) {
-                    log::warn!("Terminal write error: {}", e);
-                    break;
+            // --- downstream: WebSocket client → serial socket ---
+            data = server_rx.recv() => {
+                match data {
+                    Some(data) => {
+                        if let Err(e) = channel.data(data.as_slice()).await {
+                            log::warn!("Terminal write error: {}", e);
+                            break;
+                        }
+                    }
+                    // Sender dropped (WebSocket closed).
+                    None => break,
                 }
-            }
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
-                // Nothing to write right now.
-                std::thread::sleep(std::time::Duration::from_millis(5));
-            }
-            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
-                // Sender dropped (WebSocket closed).
-                break;
             }
         }
     }
 
-    let _ = channel.close();
+    let _ = channel.close().await;
     info!("Terminal proxy connection closed");
 }
 

--- a/lnvps_api/src/host/proxmox.rs
+++ b/lnvps_api/src/host/proxmox.rs
@@ -372,7 +372,7 @@ impl ProxmoxClient {
         let ssh_user = ssh_config.user.clone();
         let ssh_key = ssh_config.key.clone();
 
-        let mut ssh = SshClient::new().map_err(OpError::Transient)?;
+        let mut ssh = SshClient::new();
         ssh.connect((host.clone(), 22), &ssh_user, &ssh_key)
             .await
             .map_err(OpError::Transient)?;
@@ -480,7 +480,7 @@ impl ProxmoxClient {
             );
 
             // SSH connection and execution with retry
-            let mut s = SshClient::new().map_err(OpError::Transient)?;
+            let mut s = SshClient::new();
             s.connect((host.clone(), 22), &ssh_user, &ssh_key)
                 .await
                 .map_err(OpError::Transient)?;
@@ -1210,7 +1210,7 @@ impl ProxmoxClient {
         self.stop_vm(&self.node, vm_id).await.ok();
 
         {
-            let mut ses = SshClient::new().map_err(OpError::Transient)?;
+            let mut ses = SshClient::new();
             ses.connect(
                 (self.api.base().host().unwrap().to_string(), 22),
                 &ssh.user,
@@ -1998,7 +1998,7 @@ impl VmHostClient for ProxmoxClient {
         let ssh_user = ssh.user.clone();
         let ssh_key = ssh.key.clone();
 
-        let mut client = SshClient::new().map_err(OpError::Transient)?;
+        let mut client = SshClient::new();
         client
             .connect((host, 22), &ssh_user, &ssh_key)
             .await

--- a/lnvps_api/src/mocks.rs
+++ b/lnvps_api/src/mocks.rs
@@ -39,7 +39,6 @@ use payments_rs::onchain::{
     ChainPaymentUpdate, NewAddressRequest, NewAddressResponse, OnChainProvider, PaymentCursor,
     SendCoinsRequest, SendCoinsResponse,
 };
-use ssh2::HashType::Sha256;
 use std::collections::HashMap;
 use std::ops::Add;
 use std::pin::Pin;

--- a/lnvps_api/src/router/linux_ssh.rs
+++ b/lnvps_api/src/router/linux_ssh.rs
@@ -66,7 +66,7 @@ impl LinuxSshRouter {
     /// live SSH session, and is naturally resilient to dropped
     /// connections.
     async fn connect(&self) -> Result<SshClient> {
-        let mut client = SshClient::new()?;
+        let mut client = SshClient::new();
         client
             .connect_with_key(&self.host, &self.username, &self.key)
             .await?;

--- a/lnvps_api/src/router/linux_ssh.rs
+++ b/lnvps_api/src/router/linux_ssh.rs
@@ -63,7 +63,7 @@ impl LinuxSshRouter {
     /// Open a fresh SSH connection for a single operation.
     ///
     /// Connecting per-operation keeps the router `Send + Sync` without holding a
-    /// live (non-`Sync`) ssh2 session, and is naturally resilient to dropped
+    /// live SSH session, and is naturally resilient to dropped
     /// connections.
     async fn connect(&self) -> Result<SshClient> {
         let mut client = SshClient::new()?;

--- a/lnvps_api/src/ssh_client.rs
+++ b/lnvps_api/src/ssh_client.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, anyhow, bail};
 use log::info;
 use russh::client::{self, Handle, Msg};
 use russh::keys::{PrivateKeyWithHashAlg, decode_secret_key, load_secret_key};
-use russh::{Channel, ChannelMsg, Disconnect};
+use russh::{Channel, ChannelMsg};
 use russh_sftp::client::SftpSession;
 use russh_sftp::protocol::FileAttributes;
 use std::path::{Path, PathBuf};
@@ -32,13 +32,14 @@ impl client::Handler for Handler {
     }
 }
 
+#[derive(Default)]
 pub struct SshClient {
     session: Option<Handle<Handler>>,
 }
 
 impl SshClient {
-    pub fn new() -> Result<SshClient> {
-        Ok(SshClient { session: None })
+    pub fn new() -> SshClient {
+        SshClient { session: None }
     }
 
     pub async fn connect(
@@ -72,19 +73,24 @@ impl SshClient {
             inactivity_timeout: None,
             ..Default::default()
         });
-        let mut session =
-            tokio::time::timeout(CONNECT_TIMEOUT, client::connect(config, host, Handler)).await??;
+        // A host can finish key exchange and then stall in auth, so the timeout
+        // has to cover the whole handshake and not just the connect.
+        let session = tokio::time::timeout(CONNECT_TIMEOUT, async move {
+            let mut session = client::connect(config, host, Handler).await?;
+            let hash_alg = session.best_supported_rsa_hash().await?.flatten();
+            let res = session
+                .authenticate_publickey(
+                    username,
+                    PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg),
+                )
+                .await?;
+            if !res.success() {
+                bail!("SSH public key authentication failed for user {username}");
+            }
+            Ok::<_, anyhow::Error>(session)
+        })
+        .await??;
 
-        let hash_alg = session.best_supported_rsa_hash().await?.flatten();
-        let res = session
-            .authenticate_publickey(
-                username,
-                PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg),
-            )
-            .await?;
-        if !res.success() {
-            bail!("SSH public key authentication failed for user {username}");
-        }
         self.session = Some(session);
         Ok(())
     }
@@ -122,7 +128,7 @@ impl SshClient {
         key: PathBuf,
         command: String,
     ) -> Result<(i32, String)> {
-        let mut client = SshClient::new()?;
+        let mut client = SshClient::new();
         client.connect((host, port), &username, &key).await?;
         client.execute(&command).await
     }
@@ -208,16 +214,6 @@ impl SshClient {
         sftp.close().await?;
 
         info!("SFTP upload complete");
-        Ok(())
-    }
-
-    /// Close the session cleanly, if one is open.
-    pub async fn disconnect(&mut self) -> Result<()> {
-        if let Some(session) = self.session.take() {
-            session
-                .disconnect(Disconnect::ByApplication, "", "en")
-                .await?;
-        }
         Ok(())
     }
 }

--- a/lnvps_api/src/ssh_client.rs
+++ b/lnvps_api/src/ssh_client.rs
@@ -1,18 +1,44 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use log::info;
-use ssh2::Channel;
-use std::io::Read;
+use russh::client::{self, Handle, Msg};
+use russh::keys::{PrivateKeyWithHashAlg, decode_secret_key, load_secret_key};
+use russh::{Channel, ChannelMsg, Disconnect};
+use russh_sftp::client::SftpSession;
+use russh_sftp::protocol::FileAttributes;
 use std::path::{Path, PathBuf};
-use tokio::net::{TcpStream, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::ToSocketAddrs;
+
+/// How long a connect/auth attempt may take before it is abandoned.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Session event handler.
+///
+/// Host keys are accepted unconditionally: hosts are addressed by IP from the
+/// database and there is no key store to pin them against, so verifying here
+/// would reject every connection rather than add security.
+struct Handler;
+
+impl client::Handler for Handler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _server_public_key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
 
 pub struct SshClient {
-    session: ssh2::Session,
+    session: Option<Handle<Handler>>,
 }
 
 impl SshClient {
     pub fn new() -> Result<SshClient> {
-        let session = ssh2::Session::new()?;
-        Ok(SshClient { session })
+        Ok(SshClient { session: None })
     }
 
     pub async fn connect(
@@ -21,12 +47,8 @@ impl SshClient {
         username: &str,
         key: &PathBuf,
     ) -> Result<()> {
-        let tcp = TcpStream::connect(host).await?;
-        self.session.set_tcp_stream(tcp);
-        self.session.handshake()?;
-        self.session
-            .userauth_pubkey_file(username, None, key, None)?;
-        Ok(())
+        let key = load_secret_key(key, None)?;
+        self.authenticate(host, username, key).await
     }
 
     /// Connect using a private key from memory (PEM format)
@@ -36,42 +58,63 @@ impl SshClient {
         username: &str,
         private_key_pem: &str,
     ) -> Result<()> {
-        let tcp = TcpStream::connect(host).await?;
-        self.session.set_tcp_stream(tcp);
-        self.session.handshake()?;
-        self.session
-            .userauth_pubkey_memory(username, None, private_key_pem, None)?;
+        let key = decode_secret_key(private_key_pem, None)?;
+        self.authenticate(host, username, key).await
+    }
+
+    async fn authenticate(
+        &mut self,
+        host: impl ToSocketAddrs,
+        username: &str,
+        key: russh::keys::PrivateKey,
+    ) -> Result<()> {
+        let config = Arc::new(client::Config {
+            inactivity_timeout: None,
+            ..Default::default()
+        });
+        let mut session =
+            tokio::time::timeout(CONNECT_TIMEOUT, client::connect(config, host, Handler)).await??;
+
+        let hash_alg = session.best_supported_rsa_hash().await?.flatten();
+        let res = session
+            .authenticate_publickey(
+                username,
+                PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg),
+            )
+            .await?;
+        if !res.success() {
+            bail!("SSH public key authentication failed for user {username}");
+        }
+        self.session = Some(session);
         Ok(())
     }
 
-    pub async fn open_channel(&mut self) -> Result<Channel> {
-        let channel = self.session.channel_session()?;
-        Ok(channel)
-    }
-
-    pub fn tunnel_unix_socket(&mut self, remote_path: &Path) -> Result<Channel> {
+    fn session(&self) -> Result<&Handle<Handler>> {
         self.session
-            .channel_direct_streamlocal(remote_path.to_str().unwrap(), None)
-            .map_err(|e| anyhow!(e))
+            .as_ref()
+            .ok_or_else(|| anyhow!("SSH session is not connected"))
     }
 
-    /// Toggle blocking mode on the underlying SSH session.
-    ///
-    /// Set to `false` before calling [`tunnel_unix_socket`] when you need
-    /// non-blocking I/O (e.g. for the terminal proxy bridge thread).
-    pub fn set_blocking(&self, blocking: bool) {
-        self.session.set_blocking(blocking);
+    pub async fn open_channel(&mut self) -> Result<Channel<Msg>> {
+        Ok(self.session()?.channel_open_session().await?)
     }
 
-    /// Connect and run a single command entirely on a blocking thread.
+    /// Open a direct-streamlocal channel to a unix socket on the remote host.
     ///
-    /// libssh2 I/O is synchronous and blocking; running it directly inside an
-    /// async task (as [`connect`](Self::connect) + [`execute`](Self::execute)
-    /// do) stalls the tokio worker thread for the whole duration of the command.
-    /// For long-running commands — image downloads, decompression — that freezes
-    /// the entire runtime. This helper performs the connect + exec on a dedicated
-    /// blocking thread (via `spawn_blocking`) using a synchronous
-    /// [`std::net::TcpStream`], so the async runtime keeps making progress.
+    /// The returned channel borrows nothing from this client, but the session it
+    /// belongs to lives on the client: keep the [`SshClient`] alive for as long
+    /// as the channel is in use.
+    pub async fn tunnel_unix_socket(&mut self, remote_path: &Path) -> Result<Channel<Msg>> {
+        let path = remote_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Remote socket path is not valid UTF-8"))?;
+        Ok(self
+            .session()?
+            .channel_open_direct_streamlocal(path)
+            .await?)
+    }
+
+    /// Connect and run a single command.
     pub async fn run_command(
         host: String,
         port: u16,
@@ -79,50 +122,41 @@ impl SshClient {
         key: PathBuf,
         command: String,
     ) -> Result<(i32, String)> {
-        tokio::task::spawn_blocking(move || -> Result<(i32, String)> {
-            let tcp = std::net::TcpStream::connect((host.as_str(), port))?;
-            let mut session = ssh2::Session::new()?;
-            session.set_tcp_stream(tcp);
-            session.handshake()?;
-            session.userauth_pubkey_file(&username, None, &key, None)?;
-
-            let mut channel = session.channel_session()?;
-            channel.exec(&command)?;
-            let mut s = String::new();
-            channel.read_to_string(&mut s)?;
-            // Drain stderr and fold it into the output on failure (see `execute`).
-            let mut err = String::new();
-            channel.stderr().read_to_string(&mut err)?;
-            channel.wait_close()?;
-            let code = channel.exit_status()?;
-            if code != 0 && !err.trim().is_empty() {
-                if !s.is_empty() && !s.ends_with('\n') {
-                    s.push('\n');
-                }
-                s.push_str("stderr: ");
-                s.push_str(err.trim_end());
-            }
-            Ok((code, s))
-        })
-        .await?
+        let mut client = SshClient::new()?;
+        client.connect((host, port), &username, &key).await?;
+        client.execute(&command).await
     }
 
     pub async fn execute(&mut self, command: &str) -> Result<(i32, String)> {
         info!("Executing command: {}", command);
-        let mut channel = self.session.channel_session()?;
-        channel.exec(command)?;
-        let mut s = String::new();
-        channel.read_to_string(&mut s)?;
-        // Also drain stderr. Tools like `qm`/`qemu-img` print the actual failure
-        // reason here (stdout only carries the terse "update VM ..." echo and
-        // syslog only logs "creating disks failed"), so without this the real
-        // cause of a non-zero exit is invisible. Fold it into the returned
-        // output on failure so callers that log the string surface it; on
-        // success stderr is left out to avoid disturbing output parsers.
-        let mut err = String::new();
-        channel.stderr().read_to_string(&mut err)?;
-        channel.wait_close()?;
-        let code = channel.exit_status()?;
+        let mut channel = self.session()?.channel_open_session().await?;
+        channel.exec(true, command).await?;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut code = None;
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                ChannelMsg::Data { ref data } => out.extend_from_slice(data),
+                // Also collect stderr. Tools like `qm`/`qemu-img` print the
+                // actual failure reason there (stdout only carries the terse
+                // "update VM ..." echo and syslog only logs "creating disks
+                // failed"), so without this the real cause of a non-zero exit is
+                // invisible.
+                ChannelMsg::ExtendedData { ref data, ext: 1 } => err.extend_from_slice(data),
+                ChannelMsg::ExitStatus { exit_status } => code = Some(exit_status as i32),
+                _ => {}
+            }
+        }
+
+        let mut s = String::from_utf8_lossy(&out).into_owned();
+        let err = String::from_utf8_lossy(&err).into_owned();
+        // A server that closes the channel without an exit-status is treated as
+        // a failure so callers cannot mistake it for a clean run.
+        let code = code.ok_or_else(|| anyhow!("Command did not report an exit status"))?;
+        // Fold stderr into the returned output on failure so callers that log
+        // the string surface it; on success it is left out to avoid disturbing
+        // output parsers.
         if code != 0 && !err.trim().is_empty() {
             if !s.is_empty() && !s.ends_with('\n') {
                 s.push('\n');
@@ -134,8 +168,16 @@ impl SshClient {
     }
 
     /// Upload a file to the remote host via SFTP
-    pub fn scp_upload(&self, local_data: &[u8], remote_path: &Path, mode: i32) -> Result<()> {
-        use std::io::Write;
+    pub async fn scp_upload(
+        &mut self,
+        local_data: &[u8],
+        remote_path: &Path,
+        mode: i32,
+    ) -> Result<()> {
+        let path = remote_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Remote path is not valid UTF-8"))?
+            .to_string();
 
         info!(
             "SFTP upload to {:?} ({} bytes, mode {:o})",
@@ -144,16 +186,38 @@ impl SshClient {
             mode
         );
 
-        let sftp = self.session.sftp()?;
-        let mut file = sftp.create(remote_path)?;
-        file.write_all(local_data)?;
+        let channel = self.session()?.channel_open_session().await?;
+        channel.request_subsystem(true, "sftp").await?;
+        let sftp = SftpSession::new(channel.into_stream()).await?;
 
-        // Set file permissions
-        let mut stat = sftp.stat(remote_path)?;
-        stat.perm = Some(mode as u32);
-        sftp.setstat(remote_path, stat)?;
+        let mut file = sftp.create(path.clone()).await?;
+        file.write_all(local_data).await?;
+        file.shutdown().await?;
+
+        // Only the permission bits are sent. `FileAttributes::default()` is not
+        // an empty attribute set — it carries `size: Some(0)`, which the server
+        // applies and truncates the file we just wrote.
+        sftp.set_metadata(
+            path,
+            FileAttributes {
+                permissions: Some(mode as u32),
+                ..FileAttributes::empty()
+            },
+        )
+        .await?;
+        sftp.close().await?;
 
         info!("SFTP upload complete");
+        Ok(())
+    }
+
+    /// Close the session cleanly, if one is open.
+    pub async fn disconnect(&mut self) -> Result<()> {
+        if let Some(session) = self.session.take() {
+            session
+                .disconnect(Disconnect::ByApplication, "", "en")
+                .await?;
+        }
         Ok(())
     }
 }

--- a/lnvps_api/src/worker.rs
+++ b/lnvps_api/src/worker.rs
@@ -1060,13 +1060,7 @@ impl Worker {
         };
         let ssh_user = host.ssh_user.as_deref().unwrap_or("root");
 
-        let mut ssh = match SshClient::new() {
-            Ok(c) => c,
-            Err(e) => {
-                warn!("[host-keys] vm {}: ssh client failed: {}", vm.id, e);
-                return;
-            }
-        };
+        let mut ssh = SshClient::new();
         let ssh_host = extract_host_from_url(&host.ip);
         if let Err(e) = ssh
             .connect_with_key((ssh_host.as_str(), 22), ssh_user, ssh_key.as_str())
@@ -1672,7 +1666,7 @@ impl Worker {
         let ssh_host = extract_host_from_url(&host.ip);
 
         // Connect to host via SSH
-        let mut ssh = SshClient::new()?;
+        let mut ssh = SshClient::new();
         ssh.connect_with_key((ssh_host.as_str(), 22), ssh_user, &ssh_key)
             .await
             .with_context(|| {

--- a/lnvps_api/src/worker.rs
+++ b/lnvps_api/src/worker.rs
@@ -1727,6 +1727,7 @@ impl Worker {
 
         // Upload the binary
         ssh.scp_upload(&binary_data, Path::new(HOST_INFO_REMOTE_PATH), 0o755)
+            .await
             .with_context(|| format!("Failed to upload host-info to {}", host.name))?;
 
         info!("Uploaded host-info to {}", host.name);
@@ -3574,14 +3575,10 @@ pub(crate) async fn download_images_on_hosts(
     clients: Vec<(String, Arc<dyn VmHostClient>)>,
     images: &[VmOsImage],
 ) {
-    // Spawn each host on its own task rather than combining them with
-    // `join_all`. Host image downloads run over SSH (wget/decompress/checksum),
-    // and `SshClient::execute` performs *blocking* socket I/O for the full
-    // duration of each command. Under `join_all` all host futures share a single
-    // task, so one host's blocking download stalls every other host (serialising
-    // them). Independent tasks let the multi-threaded runtime run the blocking
-    // downloads concurrently across worker threads. Images on a single host are
-    // still processed sequentially to avoid saturating that host's storage.
+    // One task per host rather than one shared `join_all` future, so a single
+    // host's long download (wget/decompress/checksum over SSH) cannot delay the
+    // others. Images on a single host are still processed sequentially to avoid
+    // saturating that host's storage.
     let tasks: Vec<_> = clients
         .into_iter()
         .map(|(host_name, client)| {

--- a/lnvps_api/tests/ssh_client.rs
+++ b/lnvps_api/tests/ssh_client.rs
@@ -44,7 +44,7 @@ macro_rules! target_or_skip {
 }
 
 async fn connected(t: &Target) -> Result<SshClient> {
-    let mut client = SshClient::new()?;
+    let mut client = SshClient::new();
     client.connect(t.addr.as_str(), "root", &t.key).await?;
     Ok(client)
 }
@@ -149,7 +149,7 @@ async fn tunnel_unix_socket_round_trips() -> Result<()> {
 async fn connect_rejects_unauthorised_user() -> Result<()> {
     let t = target_or_skip!();
 
-    let mut client = SshClient::new()?;
+    let mut client = SshClient::new();
     let err = client
         .connect(t.addr.as_str(), "nobody", &t.key)
         .await

--- a/lnvps_api/tests/ssh_client.rs
+++ b/lnvps_api/tests/ssh_client.rs
@@ -1,0 +1,166 @@
+//! Integration tests for [`SshClient`] against a real sshd.
+//!
+//! The server is the `sshd` service in `docker-compose.e2e.yaml`; the address
+//! and client key come from the environment, so these tests are skipped when the
+//! e2e infrastructure is not running.
+//!
+//! - `LNVPS_TEST_SSH_ADDR` — `host:port` of the test sshd (e.g. `localhost:2222`)
+//! - `LNVPS_TEST_SSH_KEY`  — path to the client private key
+#![cfg(any(feature = "proxmox", feature = "linux-ssh"))]
+
+use anyhow::Result;
+use lnvps_api::ssh_client::SshClient;
+use std::path::{Path, PathBuf};
+
+/// Socket the test sshd's echo server listens on.
+const ECHO_SOCKET: &str = "/tmp/e2e-echo.sock";
+
+struct Target {
+    addr: String,
+    key: PathBuf,
+}
+
+fn target() -> Option<Target> {
+    let addr = std::env::var("LNVPS_TEST_SSH_ADDR").ok()?;
+    let key = std::env::var("LNVPS_TEST_SSH_KEY").ok()?;
+    Some(Target {
+        addr,
+        key: PathBuf::from(key),
+    })
+}
+
+/// Skip rather than fail when the e2e stack is not up: `cargo test --workspace`
+/// runs these on developer machines too.
+macro_rules! target_or_skip {
+    () => {
+        match target() {
+            Some(t) => t,
+            None => {
+                eprintln!("skipping: LNVPS_TEST_SSH_ADDR / LNVPS_TEST_SSH_KEY not set");
+                return Ok(());
+            }
+        }
+    };
+}
+
+async fn connected(t: &Target) -> Result<SshClient> {
+    let mut client = SshClient::new()?;
+    client.connect(t.addr.as_str(), "root", &t.key).await?;
+    Ok(client)
+}
+
+#[tokio::test]
+async fn exec_captures_stdout_and_exit_code() -> Result<()> {
+    let t = target_or_skip!();
+    let mut client = connected(&t).await?;
+
+    let (code, out) = client.execute("echo hello").await?;
+    assert_eq!(0, code);
+    assert_eq!("hello\n", out);
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_folds_stderr_into_output_on_failure() -> Result<()> {
+    let t = target_or_skip!();
+    let mut client = connected(&t).await?;
+
+    let (code, out) = client.execute("echo oops >&2; exit 3").await?;
+    assert_eq!(3, code);
+    assert!(out.contains("stderr: oops"), "unexpected output: {out}");
+
+    // Stderr is deliberately left out when the command succeeds so output
+    // parsers are undisturbed.
+    let (code, out) = client.execute("echo noise >&2; echo fine").await?;
+    assert_eq!(0, code);
+    assert_eq!("fine\n", out);
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_command_connects_and_executes() -> Result<()> {
+    let t = target_or_skip!();
+    let (host, port) = t.addr.rsplit_once(':').expect("addr must be host:port");
+
+    let (code, out) = SshClient::run_command(
+        host.to_string(),
+        port.parse()?,
+        "root".to_string(),
+        t.key.clone(),
+        "echo remote".to_string(),
+    )
+    .await?;
+    assert_eq!(0, code);
+    assert_eq!("remote\n", out);
+    Ok(())
+}
+
+#[tokio::test]
+async fn sftp_upload_writes_content_and_mode() -> Result<()> {
+    let t = target_or_skip!();
+    let mut client = connected(&t).await?;
+    let remote = format!("/tmp/upload-{}", std::process::id());
+
+    client
+        .scp_upload(b"payload\n", Path::new(&remote), 0o755)
+        .await?;
+
+    let (code, out) = client.execute(&format!("cat '{remote}'")).await?;
+    assert_eq!(0, code);
+    assert_eq!("payload\n", out);
+
+    let (code, out) = client.execute(&format!("stat -c %a '{remote}'")).await?;
+    assert_eq!(0, code);
+    assert_eq!("755", out.trim());
+
+    // Overwriting a longer file must not leave a tail of the previous content.
+    client
+        .scp_upload(b"short\n", Path::new(&remote), 0o644)
+        .await?;
+    let (_, out) = client.execute(&format!("cat '{remote}'")).await?;
+    assert_eq!("short\n", out);
+
+    client.execute(&format!("rm -f '{remote}'")).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tunnel_unix_socket_round_trips() -> Result<()> {
+    let t = target_or_skip!();
+    let mut client = connected(&t).await?;
+
+    let mut channel = client.tunnel_unix_socket(Path::new(ECHO_SOCKET)).await?;
+    channel.data(&b"ping\n"[..]).await?;
+
+    let mut got = Vec::new();
+    while let Some(msg) = channel.wait().await {
+        if let russh::ChannelMsg::Data { data } = msg {
+            got.extend_from_slice(&data);
+            if got.ends_with(b"\n") {
+                break;
+            }
+        }
+    }
+    assert_eq!(b"ping\n".to_vec(), got);
+    Ok(())
+}
+
+#[tokio::test]
+async fn connect_rejects_unauthorised_user() -> Result<()> {
+    let t = target_or_skip!();
+
+    let mut client = SshClient::new()?;
+    let err = client
+        .connect(t.addr.as_str(), "nobody", &t.key)
+        .await
+        .expect_err("authentication as an unauthorised user must fail");
+    assert!(
+        err.to_string().contains("authentication failed"),
+        "unexpected error: {err}"
+    );
+
+    // A failed connect must not leave a session behind that later calls could
+    // use as if authenticated.
+    assert!(client.execute("echo nope").await.is_err());
+    Ok(())
+}

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -295,3 +295,19 @@ if [[ -n "$FILTER" ]]; then
     TEST_CMD="$TEST_CMD $FILTER"
 fi
 eval "$TEST_CMD"
+
+# ---------------------------------------------------------------------------
+# 10. SshClient integration tests against the compose sshd
+#
+# These live in lnvps_api (they use the library directly, not HTTP) and skip
+# themselves unless these two variables are set.
+# ---------------------------------------------------------------------------
+SSH_KEY="$REPO_ROOT/volumes/e2e-sshd/id_ed25519"
+if [[ -f "$SSH_KEY" ]]; then
+    echo "=== Running SshClient integration tests ==="
+    LNVPS_TEST_SSH_ADDR="${LNVPS_TEST_SSH_ADDR:-localhost:2222}" \
+    LNVPS_TEST_SSH_KEY="$SSH_KEY" \
+        cargo test -p lnvps_api --test ssh_client
+else
+    echo "WARNING: $SSH_KEY missing, skipping SshClient integration tests" >&2
+fi

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -303,11 +303,15 @@ eval "$TEST_CMD"
 # themselves unless these two variables are set.
 # ---------------------------------------------------------------------------
 SSH_KEY="$REPO_ROOT/volumes/e2e-sshd/id_ed25519"
-if [[ -f "$SSH_KEY" ]]; then
-    echo "=== Running SshClient integration tests ==="
-    LNVPS_TEST_SSH_ADDR="${LNVPS_TEST_SSH_ADDR:-localhost:2222}" \
-    LNVPS_TEST_SSH_KEY="$SSH_KEY" \
-        cargo test -p lnvps_api --test ssh_client
-else
-    echo "WARNING: $SSH_KEY missing, skipping SshClient integration tests" >&2
+if [[ ! -f "$SSH_KEY" ]]; then
+    # The tests skip themselves without these variables, so a missing key would
+    # otherwise pass the run without ever touching SSH.
+    echo "ERROR: $SSH_KEY missing — the sshd service did not start" >&2
+    docker compose -f "$COMPOSE_FILE" logs --tail=40 sshd >&2 || true
+    exit 1
 fi
+
+echo "=== Running SshClient integration tests ==="
+LNVPS_TEST_SSH_ADDR="${LNVPS_TEST_SSH_ADDR:-localhost:2222}" \
+LNVPS_TEST_SSH_KEY="$SSH_KEY" \
+    cargo test -p lnvps_api --test ssh_client


### PR DESCRIPTION
Closes #198.

`SshClient` now talks SSH over russh + russh-sftp instead of libssh2 (`lnvps_api/src/ssh_client.rs`). All four consumers keep their call shapes; only `scp_upload` became `async`.

What changed beyond a straight swap:

- The terminal proxy no longer needs the blocking bridge thread or non-blocking session toggling: a russh `Channel` is `Send`, so `ssh_terminal_bridge` is a plain `tokio::select!` loop (`lnvps_api/src/host/proxmox.rs:2787`). The client is moved into the task because it owns the session the tunnel channel belongs to.
- `SshClient::run_command` no longer spawns a blocking thread — nothing in the client blocks now. `set_blocking` is gone.
- `execute` collects stdout and `ExtendedData{ext:1}` and keeps the existing behaviour: stderr folded into the output on non-zero exit only. A channel that closes with no exit status is now an error rather than a silent success.

Runtime verification: an `sshd` service is added to `docker-compose.e2e.yaml` (`.github/e2e/sshd/`), and `lnvps_api/tests/ssh_client.rs` exercises exec, exit codes, stderr folding, SFTP upload (content + mode + overwrite), the unix-socket tunnel round-trip and an auth failure against it. `scripts/run-e2e.sh` runs them after the e2e suite; they skip themselves when the stack is not up. The client keypair is generated into a gitignored volume, so no private key is committed.

Two bugs the runtime tests caught, both invisible to a compile-only port:

- `FileAttributes::default()` is not an empty attribute set — it carries `size: Some(0)`, so a `setstat` built from it truncated every uploaded file to zero bytes. Now `FileAttributes::empty()`.
- Alpine's sshd defaults `AllowTcpForwarding no`, which also denies `direct-streamlocal`, so the serial-socket tunnel was rejected server-side.

Results at e39e7fa: `cargo test --workspace` green except `lnvps_e2e`, which needs live servers; full `./scripts/run-e2e.sh` 165 passed in 15.15s plus the 6 SshClient tests in 0.28s. Clean `cargo clippy` on every file touched.

Originating channel: general.
