### PR TITLE
Move the app catalog into catalog/ and start each one in CI

### DIFF
--- a/.github/workflows/app-catalog.yml
+++ b/.github/workflows/app-catalog.yml
@@ -1,0 +1,89 @@
+name: App Catalog
+
+# Start every catalog app under the hardening the operator applies. Validation
+# checks the document; only a container that runs proves the image can start.
+on:
+  pull_request:
+    paths:
+      - catalog/**
+      - lnvps_compose/**
+      - scripts/app-catalog-test.sh
+      - .github/workflows/app-catalog.yml
+  workflow_dispatch:
+  # Most entries pin a mutable tag, so a green catalog goes stale on its own.
+  schedule:
+    - cron: "0 4 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      apps: ${{ steps.discover.outputs.apps }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: app-catalog-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            app-catalog-${{ runner.os }}-cargo-
+
+      - name: Build compose-to-docker
+        run: cargo build --release -p lnvps_compose --bin compose-to-docker
+
+      - name: Validate every catalog document
+        run: cargo run -q --release -p lnvps_compose --bin compose-validate -- catalog/*.yaml
+
+      # The matrix comes from the directory, so adding a .yaml is enough to get
+      # it tested — a hand-kept list would let a new app ship untested.
+      - name: Discover catalog apps
+        id: discover
+        run: |
+          apps=$(ls catalog/*.yaml | xargs -n1 basename | sed 's/\.yaml$//' | jq -R . | jq -sc .)
+          [ "$apps" != "[]" ] || { echo "no catalog documents found"; exit 1; }
+          echo "apps=$apps" >> "$GITHUB_OUTPUT"
+          echo "$apps"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-to-docker
+          path: target/release/compose-to-docker
+          retention-days: 1
+
+  app:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # One app's image being broken says nothing about the others, so let them
+      # all report.
+      fail-fast: false
+      matrix:
+        app: ${{ fromJson(needs.build.outputs.apps) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: compose-to-docker
+          path: .bin
+
+      - name: Start ${{ matrix.app }}
+        run: |
+          chmod +x .bin/compose-to-docker
+          ./scripts/app-catalog-test.sh "catalog/${{ matrix.app }}.yaml" --bin .bin/compose-to-docker

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ lnvps_nostr/Cargo.lock
 
 # Docker bind mounts for the e2e stack (includes a generated test ssh key)
 /volumes/
+
+# Local catalog test renders
+/.local/

--- a/catalog/blossom-server.yaml
+++ b/catalog/blossom-server.yaml
@@ -1,0 +1,26 @@
+services:
+  blossom:
+    image: ghcr.io/hzrd149/blossom-server:master
+    user: "1000"    # image declares no USER, so it would run as root and be refused
+    resources: { cpu: 250m, memory: 256Mi }
+    ports:
+      - { name: http, container: 3000, protocol: http, expose: ingress }
+    files:
+      - path: /app/config.yml
+        content: |
+          port: 3000
+          host: 0.0.0.0
+          publicDomain: "${HOSTNAME}"
+          database:
+            path: /app/data/sqlite.db
+          storage:
+            backend: local
+            local:
+              dir: /app/data/blobs
+            rules:
+              - { type: "*", expiration: "1 month" }
+          upload:
+            enabled: true
+            requireAuth: true
+    volumes:
+      - { name: data, path: /app/data, size: 20Gi, label: files }

--- a/catalog/buzz.yaml
+++ b/catalog/buzz.yaml
@@ -1,0 +1,136 @@
+services:
+  db:
+    image: postgres:17-alpine
+    user: root    # postgres' entrypoint starts as root, then drops to `postgres`
+    resources: { cpu: 500m, memory: 1Gi }
+    # A port block is what gives the service a DNS name inside the namespace:
+    # no ports, no Service, and `db` in the relay's DATABASE_URL does not
+    # resolve. `expose: none` keeps it internal.
+    ports:
+      - { name: postgres, container: 5432, protocol: tcp, expose: none }
+    env:
+      POSTGRES_DB: buzz
+      POSTGRES_USER: buzz
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      # initdb refuses a non-empty directory, and a fresh ext4 PVC has lost+found
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - { name: data, path: /var/lib/postgresql/data, size: 20Gi, label: database }
+    scratch:
+      # readOnlyRootFilesystem: the postmaster lock + unix socket need a
+      # writable dir, but not a persistent one
+      - { path: /var/run/postgresql, size: 32Mi }
+    backup:
+      command: ["sh", "-c", "exec pg_dumpall -U buzz"]
+      artifact: buzz.sql
+  redis:
+    image: redis:7-alpine
+    user: root    # redis' entrypoint starts as root, then drops to `redis`
+    resources: { cpu: 250m, memory: 512Mi }
+    ports:
+      - { name: redis, container: 6379, protocol: tcp, expose: none }
+    volumes:
+      # RDB snapshots; without a writable /data redis fails its bgsave and then
+      # refuses writes with MISCONF
+      - { name: data, path: /data, size: 2Gi }
+  s3:
+    image: rustfs/rustfs:1.0.0-beta.11
+    user: "10001"    # image sets `USER rustfs` (a name); uid 10001 per its Dockerfile
+    resources: { cpu: 500m, memory: 1Gi }
+    ports:
+      - { name: s3, container: 9000, protocol: http, expose: none }
+    env:
+      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY}
+      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY}
+      RUSTFS_VOLUMES: /data
+      RUSTFS_ADDRESS: ":9000"
+      RUSTFS_CONSOLE_ENABLE: "false"
+      # image default is RUSTFS_OBS_LOG_DIRECTORY=/logs, which is unwritable
+      # under readOnlyRootFilesystem — log to stdout instead
+      RUSTFS_OBS_LOG_DIRECTORY: ""
+      RUSTFS_OBS_USE_STDOUT: "true"
+      RUSTFS_OBS_LOGGER_LEVEL: warn
+    volumes:
+      - { name: blobs, path: /data, size: 50Gi, label: media }
+    backup:
+      volume: blobs
+  relay:
+    image: ghcr.io/block/buzz:latest
+    user: "1000"    # image sets `USER buzz:buzz` (a name); uid 1000 per its Dockerfile
+    resources: { cpu: 1, memory: 2Gi }
+    depends_on: [db, redis, s3]
+    ports:
+      - { name: http, container: 3000, protocol: http, expose: ingress }
+    # The relay never issues CreateBucket — it probes the object store at
+    # startup and dies on NoSuchBucket. This runs before the relay's own
+    # container, and the kubelet retries it while RustFS is still coming up, so
+    # the relay cannot start before the bucket exists.
+    init:
+      - name: create-media-bucket
+        image: minio/mc:latest
+        user: "65534"    # only talks to the in-namespace S3 service
+        env:
+          MC_HOST_s3: "http://${S3_ACCESS_KEY}:${S3_SECRET_KEY}@s3:9000"
+          MC_CONFIG_DIR: /tmp/mc
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+            until mc --quiet ls s3 >/dev/null 2>&1; do
+              echo "waiting for http://s3:9000"
+              sleep 2
+            done
+            mc mb -p s3/buzz-media
+    env:
+      # --- identity / public URL ---
+      RELAY_URL: "wss://${HOSTNAME}"
+      # The relay validates this at startup and exits 1 on anything that does
+      # not end with /media — "invalid media config: public_base_url must end
+      # with /media". It is the public prefix it hands out for blobs,
+      # not the host it binds.
+      BUZZ_MEDIA_BASE_URL: "https://${HOSTNAME}/media"
+      BUZZ_BIND_ADDR: "0.0.0.0:3000"
+      BUZZ_RELAY_PRIVATE_KEY: "${BUZZ_RELAY_PRIVATE_KEY}"
+      RELAY_OWNER_PUBKEY: "${owner_pubkey}"
+      # --- backing services (in-namespace DNS) ---
+      DATABASE_URL: "postgres://buzz:${DB_PASSWORD}@db:5432/buzz"
+      REDIS_URL: "redis://redis:6379"
+      BUZZ_AUTO_MIGRATE: "true"
+      # --- object storage ---
+      BUZZ_S3_ENDPOINT: "http://s3:9000"
+      BUZZ_S3_BUCKET: "buzz-media"
+      BUZZ_S3_REGION: "us-east-1"
+      BUZZ_S3_ACCESS_KEY: "${S3_ACCESS_KEY}"
+      BUZZ_S3_SECRET_KEY: "${S3_SECRET_KEY}"
+      # --- access control ---
+      BUZZ_REQUIRE_AUTH_TOKEN: "true"
+      BUZZ_REQUIRE_RELAY_MEMBERSHIP: "true"
+      BUZZ_ALLOW_NIP_OA_AUTH: "true"
+      BUZZ_PUBKEY_ALLOWLIST: "false"
+      BUZZ_REQUIRE_MEDIA_GET_AUTH: "false"
+      # --- git on object storage ---
+      BUZZ_GIT_REPO_PATH: "/var/lib/buzz/git"
+      BUZZ_GIT_PACK_CACHE_PATH: "/var/cache/buzz/git-packs"
+      BUZZ_GIT_HOOK_HMAC_SECRET: "${GIT_HOOK_HMAC_SECRET}"
+      # RustFS serves 503 under the default 32-way conditional-PUT race; the A3
+      # probe is startup-fatal, so keep the race narrow (verified: 4x1 passes)
+      BUZZ_GIT_PROBE_WRITERS: "4"
+      BUZZ_GIT_PROBE_ROUNDS: "1"
+      # --- capacity / logging ---
+      BUZZ_MAX_CONNECTIONS: "2000"
+      RUST_LOG: "info"
+    volumes:
+      - { name: git, path: /var/lib/buzz/git, size: 20Gi, label: git repositories }
+      - { name: packs, path: /var/cache/buzz/git-packs, size: 5Gi }
+secrets:
+  - { name: DB_PASSWORD, generate: password }
+  - { name: S3_ACCESS_KEY, generate: token }
+  - { name: S3_SECRET_KEY, generate: password }
+  - { name: GIT_HOOK_HMAC_SECRET, generate: token }
+  # 32 bytes exactly: this is the relay's Nostr secret key, and the default 24
+  # is rejected at startup as an invalid secret key.
+  - { name: BUZZ_RELAY_PRIVATE_KEY, generate: token, bytes: 32 }
+config:
+  - { name: owner_pubkey, label: "Owner pubkey (64-char hex)", type: string, required: true,
+      pattern: "[0-9a-fA-F]{64}" }

--- a/catalog/haven.yaml
+++ b/catalog/haven.yaml
@@ -1,0 +1,69 @@
+services:
+  haven:
+    image: holgerhatgarkeinenode/haven-docker:v1.2.2
+    # The image sets `USER nonroot` (a name), which the kubelet cannot verify
+    # under runAsNonRoot. `nonroot` is uid 1000 in this image (Alpine
+    # `adduser -D nonroot`), and 1000 also becomes the fsGroup so the db and
+    # blossom volumes are writable.
+    user: "1000"
+    resources: { cpu: 500m, memory: 512Mi }
+    ports:
+      - { name: ws, container: 3355, protocol: http, expose: ingress }
+    env:
+      OWNER_NPUB: "${owner_npub}"
+      RELAY_URL: "${HOSTNAME}"
+      RELAY_PORT: "3355"
+      RELAY_BIND_ADDRESS: "0.0.0.0"
+      DB_ENGINE: "badger"
+      BLOSSOM_PATH: "blossom/"
+      # Every var below down to IMPORT_START_DATE is read with HAVEN's `getEnv`,
+      # which is `log.Fatalf` on unset — one at a time, so a missing one looks
+      # like an endless queue of missing ones rather than a single fault.
+      PRIVATE_RELAY_NAME: "${private_relay_name}"
+      PRIVATE_RELAY_NPUB: "${owner_npub}"
+      PRIVATE_RELAY_DESCRIPTION: "${private_relay_description}"
+      PRIVATE_RELAY_ICON: ""
+      CHAT_RELAY_NAME: "Chat relay"
+      CHAT_RELAY_NPUB: "${owner_npub}"
+      CHAT_RELAY_DESCRIPTION: "Private chats for ${HOSTNAME}"
+      CHAT_RELAY_ICON: ""
+      OUTBOX_RELAY_NAME: "Outbox relay"
+      OUTBOX_RELAY_NPUB: "${owner_npub}"
+      OUTBOX_RELAY_DESCRIPTION: "Public messages and media for ${HOSTNAME}"
+      OUTBOX_RELAY_ICON: ""
+      INBOX_RELAY_NAME: "Inbox relay"
+      INBOX_RELAY_NPUB: "${owner_npub}"
+      INBOX_RELAY_DESCRIPTION: "Interactions for ${HOSTNAME}"
+      INBOX_RELAY_ICON: ""
+      # Bounds how far back the owner's history imports. Not startup-fatal if
+      # unparseable (import.go prints and returns), which is why it is a fixed
+      # default rather than an order-form field: a bad value silently imports
+      # nothing.
+      IMPORT_START_DATE: "2023-01-01"
+      IMPORT_SEED_RELAYS_FILE: "relays_import.json"
+      BLASTR_RELAYS_FILE: "relays_blastr.json"
+      WHITELISTED_NPUBS_FILE: ""
+      BLACKLISTED_NPUBS_FILE: ""
+      BACKUP_PROVIDER: "none"
+    files:
+      - path: /app/relays_import.json
+        content: |
+          ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"]
+      - path: /app/relays_blastr.json
+        content: |
+          ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"]
+    volumes:
+      - { name: db, path: /app/db, size: 10Gi, label: events }
+      - { name: blossom, path: /app/blossom, size: 20Gi, label: media }
+config:
+  # HAVEN panics in nPubToPubkey on anything that is not an npub, so a mistyped
+  # character is a paid-for deployment that crashloops. The pattern
+  # is bech32: `npub1` + 58 characters from the bech32 alphabet (no 1/b/i/o).
+  - { name: owner_npub, label: "Owner npub", type: string, required: true,
+      pattern: "npub1[02-9ac-hj-np-z]{58}" }
+  # The private relay's name and description are served as NIP-11 metadata, so
+  # they are customer-visible. The chat/outbox/inbox sets are functional relays
+  # rather than branding surfaces and stay fixed — eight more order-form fields
+  # would undo the one-click point of the catalog.
+  - { name: private_relay_name, label: "Relay name", type: string, default: "My private relay" }
+  - { name: private_relay_description, label: "Relay description", type: string, default: "A HAVEN relay" }

--- a/catalog/nostr-rs-relay.yaml
+++ b/catalog/nostr-rs-relay.yaml
@@ -1,0 +1,24 @@
+services:
+  relay:
+    image: scsibug/nostr-rs-relay:latest
+    user: "1000"    # image sets `USER appuser` (a name); uid 1000 per its /etc/passwd
+    resources: { cpu: 250m, memory: 256Mi }
+    ports:
+      - { name: ws, container: 8080, protocol: http, expose: ingress }
+    files:
+      - path: /usr/src/app/config.toml
+        content: |
+          [info]
+          relay_url = "wss://${HOSTNAME}/"
+          name = "${relay_name}"
+          description = "${relay_description}"
+          [database]
+          data_directory = "/usr/src/app/db"
+          [network]
+          address = "0.0.0.0"
+          port = 8080
+    volumes:
+      - { name: db, path: /usr/src/app/db, size: 10Gi, label: events }
+config:
+  - { name: relay_name, label: "Relay name", type: string, default: "My nostr-rs-relay" }
+  - { name: relay_description, label: "Description", type: string, default: "A personal Nostr relay" }

--- a/catalog/pyramid.yaml
+++ b/catalog/pyramid.yaml
@@ -1,0 +1,14 @@
+services:
+  pyramid:
+    image: ghcr.io/fiatjaf/pyramid:latest
+    user: "1000"    # image declares no USER, so it would run as root and be refused
+    resources: { cpu: 500m, memory: 512Mi }
+    ports:
+      - { name: http, container: 3334, protocol: http, expose: ingress }
+    env:
+      HOST: "0.0.0.0"
+      PORT: "3334"
+      DATA_PATH: "/app/data"
+      NO_AUTO_UPDATES: "true"
+    volumes:
+      - { name: data, path: /app/data, size: 20Gi, label: events }

--- a/catalog/route96.yaml
+++ b/catalog/route96.yaml
@@ -1,0 +1,43 @@
+services:
+  db:
+    image: mariadb:11
+    user: root    # mariadb's entrypoint starts as root, then drops to `mysql`
+    resources: { cpu: 500m, memory: 512Mi }
+    # No ports, no Service, no DNS name — `db:3306` in route96's config would
+    # not resolve. `expose: none` keeps it in-namespace.
+    ports:
+      - { name: mysql, container: 3306, protocol: tcp, expose: none }
+    env:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MARIADB_DATABASE: route96
+    volumes:
+      - { name: data, path: /var/lib/mysql, size: 5Gi, label: database }
+    scratch:
+      # readOnlyRootFilesystem: InnoDB's temporary files, and the pid file +
+      # unix socket mariadbd writes before it accepts a connection
+      - { path: /tmp }
+      - { path: /run/mysqld, size: 32Mi }
+    backup:
+      command: ["sh", "-c", "exec mariadb-dump --all-databases -uroot -p\"$MARIADB_ROOT_PASSWORD\""]
+      artifact: route96.sql
+  route96:
+    image: voidic/route96:latest
+    user: "1000"    # image declares no USER, so it would run as root and be refused
+    resources: { cpu: 500m, memory: 512Mi }
+    depends_on: [db]
+    ports:
+      - { name: http, container: 8000, protocol: http, expose: ingress }
+    files:
+      - path: /app/config.yaml
+        content: |
+          listen: "0.0.0.0:8000"
+          database: "mysql://root:${DB_ROOT_PASSWORD}@db:3306/route96"
+          storage_dir: "/app/data"
+          max_upload_bytes: 104857600
+          public_url: "https://${HOSTNAME}"
+    volumes:
+      - { name: blobs, path: /app/data, size: 20Gi, label: files }
+    backup:
+      volume: blobs
+secrets:
+  - { name: DB_ROOT_PASSWORD, generate: password }

--- a/catalog/strfry.yaml
+++ b/catalog/strfry.yaml
@@ -1,0 +1,24 @@
+services:
+  strfry:
+    image: dockurr/strfry:latest
+    user: "1000"    # image declares no USER, so it would run as root and be refused
+    resources: { cpu: 500m, memory: 512Mi }
+    ports:
+      - { name: ws, container: 7777, protocol: http, expose: ingress }
+    files:
+      - path: /etc/strfry.conf
+        content: |
+          db = "/app/strfry-db/"
+          relay {
+              bind = "0.0.0.0"
+              port = 7777
+              info {
+                  name = "${relay_name}"
+                  description = "${relay_description}"
+              }
+          }
+    volumes:
+      - { name: db, path: /app/strfry-db, size: 5Gi, label: events }
+config:
+  - { name: relay_name, label: "Relay name", type: string, default: "My strfry relay" }
+  - { name: relay_description, label: "Description", type: string, default: "A personal Nostr relay" }

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -1,8 +1,14 @@
 # Managed App — catalog examples
 
 Reference `compose` documents for adding **managed apps** to the catalog via the
-admin API. These are **not** auto-seeded; create them manually and set your own
-pricing / enable them when ready.
+admin API. Each one lives as a standalone document in [`catalog/`](../catalog),
+so it can be validated, started and shipped without being pasted out of a
+Markdown fence. They are **not** auto-seeded; create them manually and set your
+own pricing / enable them when ready.
+
+CI starts every `catalog/*.yaml` one at a time on each change to the directory,
+the grammar or the renderer (`.github/workflows/app-catalog.yml`), so an entry
+that can no longer start fails the build rather than a customer's order.
 
 ## How to add one
 
@@ -16,7 +22,7 @@ the created app (create it disabled, then `PATCH .../apps/{id}` with
   "name": "strfry",                 // DNS-safe slug, unique
   "display_name": "strfry Relay",
   "description": "A high-performance personal Nostr relay.",
-  "compose": "<the YAML below, as a string>",
+  "compose": "<the document from catalog/strfry.yaml, as a string>",
   "amount": 500,                    // price in the smallest currency unit (e.g. cents)
   "currency": "USD",
   "interval_amount": 1,
@@ -428,6 +434,23 @@ broken apps cleanly.
 A green `docker compose up` means the image starts and the app's own startup
 checks pass under our security context. **It is not a deployment test.**
 
+### One command, and the same one CI runs
+
+`scripts/app-catalog-test.sh catalog/<app>.yaml` does the whole loop: render,
+create and chown the volumes, `up --wait`, then re-read the state after a settle
+period and check every ingress port is listening. It fails if a service exits
+non-zero, restarts, or never binds — the three shapes a broken image takes.
+
+```sh
+scripts/app-catalog-test.sh catalog/strfry.yaml
+```
+
+Ingress ports are published on loopback at the container number, so the script
+stops early if one is already taken on your machine rather than reporting it as
+the app's fault. Config fields the customer supplies at order time come from
+`app_config()` in that script; an entry with a required field and no value there
+fails the render loudly.
+
 ### Known non-equivalences
 
 - **Volume ownership.** Kubernetes sets `fsGroup` from `user:` so a fresh PVC is
@@ -463,32 +486,8 @@ checks pass under our security context. **It is not a deployment test.**
   to `127.0.0.1` (must be `0.0.0.0` in a container), port `7777`, data in
   `./strfry-db/`. The `dockurr/strfry` image reads `/etc/strfry.conf`.
 
-```yaml
-services:
-  strfry:
-    image: dockurr/strfry:latest
-    user: "1000"    # image declares no USER, so it would run as root and be refused
-    resources: { cpu: 500m, memory: 512Mi }
-    ports:
-      - { name: ws, container: 7777, protocol: http, expose: ingress }
-    files:
-      - path: /etc/strfry.conf
-        content: |
-          db = "/app/strfry-db/"
-          relay {
-              bind = "0.0.0.0"
-              port = 7777
-              info {
-                  name = "${relay_name}"
-                  description = "${relay_description}"
-              }
-          }
-    volumes:
-      - { name: db, path: /app/strfry-db, size: 5Gi, label: events }
-config:
-  - { name: relay_name, label: "Relay name", type: string, default: "My strfry relay" }
-  - { name: relay_description, label: "Description", type: string, default: "A personal Nostr relay" }
-```
+**Document:** [`catalog/strfry.yaml`](../catalog/strfry.yaml) —
+`scripts/app-catalog-test.sh catalog/strfry.yaml` starts it locally.
 
 ---
 
@@ -501,51 +500,8 @@ config:
   `8000`. Mirrors route96's `config.prod.yaml` + `docker-compose.prod.yml`
   (app reaches the DB via the service name `db`).
 
-```yaml
-services:
-  db:
-    image: mariadb:11
-    user: root    # mariadb's entrypoint starts as root, then drops to `mysql`
-    resources: { cpu: 500m, memory: 512Mi }
-    # No ports, no Service, no DNS name — `db:3306` in route96's config would
-    # not resolve (#281). `expose: none` keeps it in-namespace.
-    ports:
-      - { name: mysql, container: 3306, protocol: tcp, expose: none }
-    env:
-      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
-      MARIADB_DATABASE: route96
-    volumes:
-      - { name: data, path: /var/lib/mysql, size: 5Gi, label: database }
-    scratch:
-      # readOnlyRootFilesystem: InnoDB's temporary files, and the pid file +
-      # unix socket mariadbd writes before it accepts a connection
-      - { path: /tmp }
-      - { path: /run/mysqld, size: 32Mi }
-    backup:
-      command: ["sh", "-c", "exec mariadb-dump --all-databases -uroot -p\"$MARIADB_ROOT_PASSWORD\""]
-      artifact: route96.sql
-  route96:
-    image: voidic/route96:latest
-    user: "1000"    # image declares no USER, so it would run as root and be refused
-    resources: { cpu: 500m, memory: 512Mi }
-    depends_on: [db]
-    ports:
-      - { name: http, container: 8000, protocol: http, expose: ingress }
-    files:
-      - path: /app/config.yaml
-        content: |
-          listen: "0.0.0.0:8000"
-          database: "mysql://root:${DB_ROOT_PASSWORD}@db:3306/route96"
-          storage_dir: "/app/data"
-          max_upload_bytes: 104857600
-          public_url: "https://${HOSTNAME}"
-    volumes:
-      - { name: blobs, path: /app/data, size: 20Gi, label: files }
-    backup:
-      volume: blobs
-secrets:
-  - { name: DB_ROOT_PASSWORD, generate: password }
-```
+**Document:** [`catalog/route96.yaml`](../catalog/route96.yaml) —
+`scripts/app-catalog-test.sh catalog/route96.yaml` starts it locally.
 
 ---
 
@@ -557,34 +513,8 @@ secrets:
   `/app/config.yml`; listens on `3000`; SQLite + blobs under `/app/data`.
   `publicDomain` is a **bare** hostname (no scheme).
 
-```yaml
-services:
-  blossom:
-    image: ghcr.io/hzrd149/blossom-server:master
-    user: "1000"    # image declares no USER, so it would run as root and be refused
-    resources: { cpu: 250m, memory: 256Mi }
-    ports:
-      - { name: http, container: 3000, protocol: http, expose: ingress }
-    files:
-      - path: /app/config.yml
-        content: |
-          port: 3000
-          host: 0.0.0.0
-          publicDomain: "${HOSTNAME}"
-          database:
-            path: /app/data/sqlite.db
-          storage:
-            backend: local
-            local:
-              dir: /app/data/blobs
-            rules:
-              - { type: "*", expiration: "1 month" }
-          upload:
-            enabled: true
-            requireAuth: true
-    volumes:
-      - { name: data, path: /app/data, size: 20Gi, label: files }
-```
+**Document:** [`catalog/blossom-server.yaml`](../catalog/blossom-server.yaml) —
+`scripts/app-catalog-test.sh catalog/blossom-server.yaml` starts it locally.
 
 ---
 
@@ -597,32 +527,8 @@ services:
   `/usr/src/app/db`. Set `network.address = "0.0.0.0"` so it's reachable in the
   pod.
 
-```yaml
-services:
-  relay:
-    image: scsibug/nostr-rs-relay:latest
-    user: "1000"    # image sets `USER appuser` (a name); uid 1000 per its /etc/passwd
-    resources: { cpu: 250m, memory: 256Mi }
-    ports:
-      - { name: ws, container: 8080, protocol: http, expose: ingress }
-    files:
-      - path: /usr/src/app/config.toml
-        content: |
-          [info]
-          relay_url = "wss://${HOSTNAME}/"
-          name = "${relay_name}"
-          description = "${relay_description}"
-          [database]
-          data_directory = "/usr/src/app/db"
-          [network]
-          address = "0.0.0.0"
-          port = 8080
-    volumes:
-      - { name: db, path: /usr/src/app/db, size: 10Gi, label: events }
-config:
-  - { name: relay_name, label: "Relay name", type: string, default: "My nostr-rs-relay" }
-  - { name: relay_description, label: "Description", type: string, default: "A personal Nostr relay" }
-```
+**Document:** [`catalog/nostr-rs-relay.yaml`](../catalog/nostr-rs-relay.yaml) —
+`scripts/app-catalog-test.sh catalog/nostr-rs-relay.yaml` starts it locally.
 
 ---
 
@@ -645,22 +551,8 @@ config:
   manager (`2222`) and audio/video via embedded LiveKit — aren't reachable
   until the `expose: tcp/udp` path exists.
 
-```yaml
-services:
-  pyramid:
-    image: ghcr.io/fiatjaf/pyramid:latest
-    user: "1000"    # image declares no USER, so it would run as root and be refused
-    resources: { cpu: 500m, memory: 512Mi }
-    ports:
-      - { name: http, container: 3334, protocol: http, expose: ingress }
-    env:
-      HOST: "0.0.0.0"
-      PORT: "3334"
-      DATA_PATH: "/app/data"
-      NO_AUTO_UPDATES: "true"
-    volumes:
-      - { name: data, path: /app/data, size: 20Gi, label: events }
-```
+**Document:** [`catalog/pyramid.yaml`](../catalog/pyramid.yaml) —
+`scripts/app-catalog-test.sh catalog/pyramid.yaml` starts it locally.
 
 ---
 
@@ -674,7 +566,7 @@ services:
   vars; listens on `RELAY_PORT` (default `3355`), `RELAY_BIND_ADDRESS` must be
   `0.0.0.0`. Databases (badger) live under `/app/db`, Blossom media under
   `/app/blossom`. It **fatally requires** the two relay-list files
-  `relays_import.json` and `relays_blastr.json` at startup (provided below via
+  `relays_import.json` and `relays_blastr.json` at startup (provided via
   `files:`); the whitelist/blacklist files are optional and disabled by setting
   their env vars to `""` (owner-only).
 - **Caveat:** current published community images do **not** bundle HAVEN's
@@ -684,77 +576,8 @@ services:
   (<https://github.com/HolgerHatGarKeineNode/haven-docker/pull/8>); once merged
   and released the dashboard works out of the box.
 
-```yaml
-services:
-  haven:
-    image: holgerhatgarkeinenode/haven-docker:v1.2.2
-    # The image sets `USER nonroot` (a name), which the kubelet cannot verify
-    # under runAsNonRoot. `nonroot` is uid 1000 in this image (Alpine
-    # `adduser -D nonroot`), and 1000 also becomes the fsGroup so the db and
-    # blossom volumes are writable.
-    user: "1000"
-    resources: { cpu: 500m, memory: 512Mi }
-    ports:
-      - { name: ws, container: 3355, protocol: http, expose: ingress }
-    env:
-      OWNER_NPUB: "${owner_npub}"
-      RELAY_URL: "${HOSTNAME}"
-      RELAY_PORT: "3355"
-      RELAY_BIND_ADDRESS: "0.0.0.0"
-      DB_ENGINE: "badger"
-      BLOSSOM_PATH: "blossom/"
-      # Every var below down to IMPORT_START_DATE is read with HAVEN's `getEnv`,
-      # which is `log.Fatalf` on unset — one at a time, so a missing one looks
-      # like an endless queue of missing ones rather than a single fault (#248).
-      PRIVATE_RELAY_NAME: "${private_relay_name}"
-      PRIVATE_RELAY_NPUB: "${owner_npub}"
-      PRIVATE_RELAY_DESCRIPTION: "${private_relay_description}"
-      PRIVATE_RELAY_ICON: ""
-      CHAT_RELAY_NAME: "Chat relay"
-      CHAT_RELAY_NPUB: "${owner_npub}"
-      CHAT_RELAY_DESCRIPTION: "Private chats for ${HOSTNAME}"
-      CHAT_RELAY_ICON: ""
-      OUTBOX_RELAY_NAME: "Outbox relay"
-      OUTBOX_RELAY_NPUB: "${owner_npub}"
-      OUTBOX_RELAY_DESCRIPTION: "Public messages and media for ${HOSTNAME}"
-      OUTBOX_RELAY_ICON: ""
-      INBOX_RELAY_NAME: "Inbox relay"
-      INBOX_RELAY_NPUB: "${owner_npub}"
-      INBOX_RELAY_DESCRIPTION: "Interactions for ${HOSTNAME}"
-      INBOX_RELAY_ICON: ""
-      # Bounds how far back the owner's history imports. Not startup-fatal if
-      # unparseable (import.go prints and returns), which is why it is a fixed
-      # default rather than an order-form field: a bad value silently imports
-      # nothing.
-      IMPORT_START_DATE: "2023-01-01"
-      IMPORT_SEED_RELAYS_FILE: "relays_import.json"
-      BLASTR_RELAYS_FILE: "relays_blastr.json"
-      WHITELISTED_NPUBS_FILE: ""
-      BLACKLISTED_NPUBS_FILE: ""
-      BACKUP_PROVIDER: "none"
-    files:
-      - path: /app/relays_import.json
-        content: |
-          ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"]
-      - path: /app/relays_blastr.json
-        content: |
-          ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"]
-    volumes:
-      - { name: db, path: /app/db, size: 10Gi, label: events }
-      - { name: blossom, path: /app/blossom, size: 20Gi, label: media }
-config:
-  # HAVEN panics in nPubToPubkey on anything that is not an npub, so a mistyped
-  # character became a paid-for deployment that crashlooped (#271). The pattern
-  # is bech32: `npub1` + 58 characters from the bech32 alphabet (no 1/b/i/o).
-  - { name: owner_npub, label: "Owner npub", type: string, required: true,
-      pattern: "npub1[02-9ac-hj-np-z]{58}" }
-  # The private relay's name and description are served as NIP-11 metadata, so
-  # they are customer-visible. The chat/outbox/inbox sets are functional relays
-  # rather than branding surfaces and stay fixed — eight more order-form fields
-  # would undo the one-click point of the catalog.
-  - { name: private_relay_name, label: "Relay name", type: string, default: "My private relay" }
-  - { name: private_relay_description, label: "Relay description", type: string, default: "A HAVEN relay" }
-```
+**Document:** [`catalog/haven.yaml`](../catalog/haven.yaml) —
+`scripts/app-catalog-test.sh catalog/haven.yaml` starts it locally.
 
 ---
 
@@ -785,7 +608,7 @@ config:
     (a linearizable conditional-write race backing git pointer CAS) and
     *exits* if it fails. RustFS answers the default 32-way race with HTTP 503;
     a 4-way single-round race passes. Hence `BUZZ_GIT_PROBE_WRITERS=4` /
-    `BUZZ_GIT_PROBE_ROUNDS=1` above — do not remove them, and do not paper
+    `BUZZ_GIT_PROBE_ROUNDS=1` in the document — do not remove them, and do not paper
     over a failure with `BUZZ_GIT_CONFORMANCE_PROBE=false` (that disables the
     gate, not the requirement).
   - Every container runs with `readOnlyRootFilesystem`, which is why `db`
@@ -800,155 +623,19 @@ config:
     this deployment — it runs wherever the customer's agent runs and connects
     over `wss://` with its own key.
 
-```yaml
-services:
-  db:
-    image: postgres:17-alpine
-    user: root    # postgres' entrypoint starts as root, then drops to `postgres`
-    resources: { cpu: 500m, memory: 1Gi }
-    # A port block is what gives the service a DNS name inside the namespace:
-    # no ports, no Service, and `db` in the relay's DATABASE_URL does not
-    # resolve (#281). `expose: none` keeps it internal.
-    ports:
-      - { name: postgres, container: 5432, protocol: tcp, expose: none }
-    env:
-      POSTGRES_DB: buzz
-      POSTGRES_USER: buzz
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      # initdb refuses a non-empty directory, and a fresh ext4 PVC has lost+found
-      PGDATA: /var/lib/postgresql/data/pgdata
-    volumes:
-      - { name: data, path: /var/lib/postgresql/data, size: 20Gi, label: database }
-    scratch:
-      # readOnlyRootFilesystem: the postmaster lock + unix socket need a
-      # writable dir, but not a persistent one
-      - { path: /var/run/postgresql, size: 32Mi }
-    backup:
-      command: ["sh", "-c", "exec pg_dumpall -U buzz"]
-      artifact: buzz.sql
-  redis:
-    image: redis:7-alpine
-    user: root    # redis' entrypoint starts as root, then drops to `redis`
-    resources: { cpu: 250m, memory: 512Mi }
-    ports:
-      - { name: redis, container: 6379, protocol: tcp, expose: none }
-    volumes:
-      # RDB snapshots; without a writable /data redis fails its bgsave and then
-      # refuses writes with MISCONF
-      - { name: data, path: /data, size: 2Gi }
-  s3:
-    image: rustfs/rustfs:1.0.0-beta.11
-    user: "10001"    # image sets `USER rustfs` (a name); uid 10001 per its Dockerfile
-    resources: { cpu: 500m, memory: 1Gi }
-    ports:
-      - { name: s3, container: 9000, protocol: http, expose: none }
-    env:
-      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY}
-      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY}
-      RUSTFS_VOLUMES: /data
-      RUSTFS_ADDRESS: ":9000"
-      RUSTFS_CONSOLE_ENABLE: "false"
-      # image default is RUSTFS_OBS_LOG_DIRECTORY=/logs, which is unwritable
-      # under readOnlyRootFilesystem — log to stdout instead
-      RUSTFS_OBS_LOG_DIRECTORY: ""
-      RUSTFS_OBS_USE_STDOUT: "true"
-      RUSTFS_OBS_LOGGER_LEVEL: warn
-    volumes:
-      - { name: blobs, path: /data, size: 50Gi, label: media }
-    backup:
-      volume: blobs
-  relay:
-    image: ghcr.io/block/buzz:latest
-    user: "1000"    # image sets `USER buzz:buzz` (a name); uid 1000 per its Dockerfile
-    resources: { cpu: 1, memory: 2Gi }
-    depends_on: [db, redis, s3]
-    ports:
-      - { name: http, container: 3000, protocol: http, expose: ingress }
-    # The relay never issues CreateBucket — it probes the object store at
-    # startup and dies on NoSuchBucket. This runs before the relay's own
-    # container, and the kubelet retries it while RustFS is still coming up, so
-    # the relay cannot start before the bucket exists.
-    init:
-      - name: create-media-bucket
-        image: minio/mc:latest
-        user: "65534"    # only talks to the in-namespace S3 service
-        env:
-          MC_HOST_s3: "http://${S3_ACCESS_KEY}:${S3_SECRET_KEY}@s3:9000"
-          MC_CONFIG_DIR: /tmp/mc
-        command:
-          - sh
-          - -c
-          - |
-            set -e
-            until mc --quiet ls s3 >/dev/null 2>&1; do
-              echo "waiting for http://s3:9000"
-              sleep 2
-            done
-            mc mb -p s3/buzz-media
-    env:
-      # --- identity / public URL ---
-      RELAY_URL: "wss://${HOSTNAME}"
-      # The relay validates this at startup and exits 1 on anything that does
-      # not end with /media — "invalid media config: public_base_url must end
-      # with /media" (#269). It is the public prefix it hands out for blobs,
-      # not the host it binds.
-      BUZZ_MEDIA_BASE_URL: "https://${HOSTNAME}/media"
-      BUZZ_BIND_ADDR: "0.0.0.0:3000"
-      BUZZ_RELAY_PRIVATE_KEY: "${BUZZ_RELAY_PRIVATE_KEY}"
-      RELAY_OWNER_PUBKEY: "${owner_pubkey}"
-      # --- backing services (in-namespace DNS) ---
-      DATABASE_URL: "postgres://buzz:${DB_PASSWORD}@db:5432/buzz"
-      REDIS_URL: "redis://redis:6379"
-      BUZZ_AUTO_MIGRATE: "true"
-      # --- object storage ---
-      BUZZ_S3_ENDPOINT: "http://s3:9000"
-      BUZZ_S3_BUCKET: "buzz-media"
-      BUZZ_S3_REGION: "us-east-1"
-      BUZZ_S3_ACCESS_KEY: "${S3_ACCESS_KEY}"
-      BUZZ_S3_SECRET_KEY: "${S3_SECRET_KEY}"
-      # --- access control ---
-      BUZZ_REQUIRE_AUTH_TOKEN: "true"
-      BUZZ_REQUIRE_RELAY_MEMBERSHIP: "true"
-      BUZZ_ALLOW_NIP_OA_AUTH: "true"
-      BUZZ_PUBKEY_ALLOWLIST: "false"
-      BUZZ_REQUIRE_MEDIA_GET_AUTH: "false"
-      # --- git on object storage ---
-      BUZZ_GIT_REPO_PATH: "/var/lib/buzz/git"
-      BUZZ_GIT_PACK_CACHE_PATH: "/var/cache/buzz/git-packs"
-      BUZZ_GIT_HOOK_HMAC_SECRET: "${GIT_HOOK_HMAC_SECRET}"
-      # RustFS serves 503 under the default 32-way conditional-PUT race; the A3
-      # probe is startup-fatal, so keep the race narrow (verified: 4x1 passes)
-      BUZZ_GIT_PROBE_WRITERS: "4"
-      BUZZ_GIT_PROBE_ROUNDS: "1"
-      # --- capacity / logging ---
-      BUZZ_MAX_CONNECTIONS: "2000"
-      RUST_LOG: "info"
-    volumes:
-      - { name: git, path: /var/lib/buzz/git, size: 20Gi, label: git repositories }
-      - { name: packs, path: /var/cache/buzz/git-packs, size: 5Gi }
-secrets:
-  - { name: DB_PASSWORD, generate: password }
-  - { name: S3_ACCESS_KEY, generate: token }
-  - { name: S3_SECRET_KEY, generate: password }
-  - { name: GIT_HOOK_HMAC_SECRET, generate: token }
-  # 32 bytes exactly: this is the relay's Nostr secret key, and the default 24
-  # is rejected at startup as an invalid secret key.
-  - { name: BUZZ_RELAY_PRIVATE_KEY, generate: token, bytes: 32 }
-config:
-  - { name: owner_pubkey, label: "Owner pubkey (64-char hex)", type: string, required: true,
-      pattern: "[0-9a-fA-F]{64}" }
-```
+**Document:** [`catalog/buzz.yaml`](../catalog/buzz.yaml) —
+`scripts/app-catalog-test.sh catalog/buzz.yaml` starts it locally.
 
 ### Before this one can be enabled
 
 Both compose-grammar gaps this entry was blocked on have landed: the 32-byte
-generated secret (#243, `bytes:` on a secret declaration, used above for
+generated secret (#243, `bytes:` on a secret declaration, used in the document for
 `BUZZ_RELAY_PRIVATE_KEY`) and bucket creation (#244, `init:` on the `relay`
 service). The customer no longer pastes the relay's identity key into the
 order form, and nothing in the deployment has to pre-exist.
 
 What is **not** yet done is a run of this exact compose through the operator
-against a live cluster — the composition above has never been reconciled end to
+against a live cluster — the composition has never been reconciled end to
 end with the init step in place. Do that before enabling it in the catalog:
 validation checks the document, not whether the app starts.
 

--- a/lnvps_compose/src/bin/compose-to-docker.rs
+++ b/lnvps_compose/src/bin/compose-to-docker.rs
@@ -325,6 +325,17 @@ fn scratch_mounts(svc: &Service) -> Result<Vec<Value>> {
     Ok(out)
 }
 
+/// `KEY=value` list form. A mapping would re-emit an env value as whatever
+/// YAML type it looks like — a bare date becomes a timestamp and compose
+/// rejects the file — and every env value here is a string.
+fn env_sequence<'a>(env: impl IntoIterator<Item = (&'a String, &'a String)>) -> Value {
+    Value::Sequence(
+        env.into_iter()
+            .map(|(k, v)| Value::from(format!("{k}={v}")))
+            .collect(),
+    )
+}
+
 /// Turn one compose service into its docker-compose service mapping.
 fn service_mapping(name: &str, svc: &Service, r: &Rendered) -> Result<Mapping> {
     let mut m = Mapping::new();
@@ -332,11 +343,7 @@ fn service_mapping(name: &str, svc: &Service, r: &Rendered) -> Result<Mapping> {
 
     if let Some(env) = r.env.get(name).filter(|e| !e.is_empty()) {
         let sorted: BTreeMap<_, _> = env.iter().collect();
-        let mut em = Mapping::new();
-        for (k, v) in sorted {
-            em.insert(k.as_str().into(), v.as_str().into());
-        }
-        m.insert("environment".into(), Value::Mapping(em));
+        m.insert("environment".into(), env_sequence(sorted));
     }
 
     // Data volumes (PVC equivalent) followed by read-only file bind mounts.
@@ -430,11 +437,8 @@ fn init_mapping(
     let mut m = Mapping::new();
     m.insert("image".into(), step.image.as_str().into());
     if !step.env.is_empty() {
-        let mut em = Mapping::new();
-        for (k, v) in &step.env {
-            em.insert(k.as_str().into(), v.as_str().into());
-        }
-        m.insert("environment".into(), Value::Mapping(em));
+        let sorted: BTreeMap<_, _> = step.env.iter().collect();
+        m.insert("environment".into(), env_sequence(sorted));
     }
     if let Some(cmd) = &step.command {
         m.insert(
@@ -748,6 +752,27 @@ mod tests {
         doc["services"][name].as_mapping().expect("service")
     }
 
+    /// Env values are strings whatever they look like: serialised as a mapping,
+    /// a date- or number-shaped value comes back as a typed scalar and compose
+    /// refuses the file.
+    #[test]
+    fn env_values_stay_strings_when_serialised() {
+        let doc = render(
+            "services:\n  app:\n    image: example/app:latest\n    user: \"1000\"\n    \
+             env:\n      SINCE: \"2023-01-01\"\n      REPLICAS: \"3\"\n      DEBUG: \"true\"\n",
+        );
+        let text = serde_yaml::to_string(&Value::Mapping(doc)).expect("serialise");
+        let back: Value = serde_yaml::from_str(&text).expect("reparse");
+        assert_eq!(
+            back["services"]["app"]["environment"],
+            Value::Sequence(vec![
+                "DEBUG=true".into(),
+                "REPLICAS=3".into(),
+                "SINCE=2023-01-01".into(),
+            ])
+        );
+    }
+
     const DB_APP: &str = "services:\n  db:\n    image: mariadb:11\n    user: root\n    \
          resources: { cpu: 500m, memory: 512Mi }\n    \
          env:\n      MARIADB_ROOT_PASSWORD: ${DB_PASSWORD}\n    \
@@ -828,8 +853,8 @@ mod tests {
         assert_eq!(db["cpus"], Value::from(0.5));
         assert_eq!(db["mem_limit"], Value::from(536870912u64));
         assert_eq!(
-            db["environment"]["MARIADB_ROOT_PASSWORD"],
-            Value::from("sekret")
+            db["environment"],
+            Value::Sequence(vec!["MARIADB_ROOT_PASSWORD=sekret".into()])
         );
         // The named volume is declared, so `docker compose up` creates it.
         assert!(doc["volumes"].as_mapping().unwrap().contains_key("db-data"));
@@ -887,8 +912,8 @@ mod tests {
             Value::Sequence(vec!["mb".into(), "-p".into(), "s3/media".into()])
         );
         assert_eq!(
-            step["environment"]["MC_HOST_s3"],
-            Value::from("http://k:sekret@s3:9000")
+            step["environment"],
+            Value::Sequence(vec!["MC_HOST_s3=http://k:sekret@s3:9000".into()])
         );
         // Sees the service's volume, plus scratch it can write to.
         assert_eq!(

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -3188,31 +3188,26 @@ config:
         assert_eq!(stopped.spec.unwrap().replicas, Some(0));
     }
 
-    /// Extract every ```yaml fenced block from a markdown doc, tagged with the
-    /// nearest preceding `## ` heading (used to name the fixture in failures).
-    fn extract_yaml_blocks(md: &str) -> Vec<(String, String)> {
-        let mut out = Vec::new();
-        let mut heading = String::new();
-        let mut lines = md.lines();
-        while let Some(line) = lines.next() {
-            if let Some(h) = line.strip_prefix("## ") {
-                heading = h.trim().to_string();
-            } else if line.trim_start() == "```yaml" {
-                let mut body = String::new();
-                for l in lines.by_ref() {
-                    if l.trim_start() == "```" {
-                        break;
-                    }
-                    body.push_str(l);
-                    body.push('\n');
-                }
-                out.push((heading.clone(), body));
-            }
-        }
+    /// Every catalog document, named by its file stem so a failure points at
+    /// the file to fix.
+    fn catalog_documents() -> Vec<(String, String)> {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../catalog");
+        let mut out: Vec<(String, String)> = std::fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("read {dir}: {e}"))
+            .map(|e| e.expect("dir entry").path())
+            .filter(|p| p.extension().is_some_and(|e| e == "yaml"))
+            .map(|p| {
+                let name = p.file_stem().unwrap().to_string_lossy().into_owned();
+                let body = std::fs::read_to_string(&p)
+                    .unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+                (name, body)
+            })
+            .collect();
+        out.sort();
         out
     }
 
-    /// Every app compose published in `docs/managed-app-examples.md` must run
+    /// Every app compose in `catalog/` must run
     /// through the full compose → Kubernetes pipeline: parse, validate, compute
     /// a footprint, resolve secrets/config/files, and render each service's
     /// Deployment / Service / PVC / ConfigMap / Secret plus the shared Ingress /
@@ -3220,17 +3215,11 @@ config:
     /// invariants intact. This keeps the documented fixtures from drifting out
     /// of the grammar the operator actually implements.
     #[test]
-    fn documented_examples_map_to_k8s() {
-        let doc = std::fs::read_to_string(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../docs/managed-app-examples.md"
-        ))
-        .expect("read docs/managed-app-examples.md");
-
-        let examples = extract_yaml_blocks(&doc);
+    fn catalog_documents_map_to_k8s() {
+        let examples = catalog_documents();
         assert!(
             examples.len() >= 6,
-            "expected at least the 6 documented app composes, found {}",
+            "expected at least the 6 catalog composes, found {}",
             examples.len()
         );
 

--- a/scripts/app-catalog-test.sh
+++ b/scripts/app-catalog-test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Start one catalog compose document locally and prove it comes up.
+#
+# Validation checks the document; this checks the images. A container that
+# cannot start under the hardening the operator applies is invisible in the
+# document and only shows up when something runs it.
+#
+#   scripts/app-catalog-test.sh catalog/strfry.yaml [--bin path/to/compose-to-docker]
+#
+# Exits non-zero if a service exits, restarts, or an ingress port never answers.
+set -euo pipefail
+
+APP_FILE=""
+BIN=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --bin) BIN="$2"; shift 2 ;;
+        -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+        *) APP_FILE="$1"; shift ;;
+    esac
+done
+[ -n "$APP_FILE" ] || { echo "usage: $0 <catalog/app.yaml> [--bin <compose-to-docker>]" >&2; exit 2; }
+[ -f "$APP_FILE" ] || { echo "no such file: $APP_FILE" >&2; exit 2; }
+
+APP="$(basename "$APP_FILE" .yaml)"
+OUT_DIR="${OUT_DIR:-.local/catalog/$APP}"
+# How long the whole stack gets to reach running, and how long an ingress port
+# gets to answer once it is.
+START_TIMEOUT="${START_TIMEOUT:-300}"
+PROBE_TIMEOUT="${PROBE_TIMEOUT:-120}"
+# Long enough to catch an app that starts, reads its config and then exits —
+# the shape of every outage this script exists to catch.
+SETTLE="${SETTLE:-20}"
+
+# Config values for fields the customer must supply at order time. A required
+# field with no value here fails the render loudly rather than being skipped.
+app_config() {
+    case "$1" in
+        # A real bech32 npub (pubkey 0x…01): HAVEN decodes it at startup, so a
+        # merely pattern-shaped string would crashloop the container.
+        haven) echo "--config owner_npub=npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqshp52w2" ;;
+        buzz)  echo "--config owner_pubkey=0000000000000000000000000000000000000000000000000000000000000001" ;;
+        *)     echo "" ;;
+    esac
+}
+
+if [ -z "$BIN" ]; then
+    cargo build -q -p lnvps_compose --bin compose-to-docker
+    BIN="target/debug/compose-to-docker"
+fi
+
+COMPOSE_FILE="$OUT_DIR/docker-compose.yaml"
+rm -rf "$OUT_DIR"
+
+cleanup() {
+    docker compose -f "$COMPOSE_FILE" down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> rendering $APP_FILE"
+# shellcheck disable=SC2046  # app_config emits separate arguments on purpose
+RENDER="$("$BIN" "$APP_FILE" --out-dir "$OUT_DIR" --hostname localhost $(app_config "$APP"))"
+echo "$RENDER"
+
+# Ingress ports are published on loopback at the container number, which on a
+# developer machine can already be taken by something unrelated. Shifting the
+# host side keeps the container side — the number the app was configured with —
+# untouched.
+if [ -n "${HOST_PORT_OFFSET:-}" ]; then
+    while read -r port; do
+        sed -i "s/127\.0\.0\.1:$port:/127.0.0.1:$((port + HOST_PORT_OFFSET)):/" "$COMPOSE_FILE"
+    done < <(grep -oE '127\.0\.0\.1:[0-9]+:' "$COMPOSE_FILE" | cut -d: -f2 | sort -un)
+fi
+
+# A port already taken on this machine stops the stack before it starts. Say so
+# here rather than leaving it to read as an app failure.
+for port in $(grep -oE '127\.0\.0\.1:[0-9]+:' "$COMPOSE_FILE" | cut -d: -f2 | sort -un); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+        echo "FAIL $APP: port $port is already in use on this host"
+        exit 1
+    fi
+done
+
+echo "==> creating volumes"
+docker compose -f "$COMPOSE_FILE" up --no-start
+
+# Docker has no fsGroup, so a fresh named volume is root-owned and a non-root
+# service cannot write to it. The renderer prints the chown that stands in for
+# it; run exactly those, so the local difference stays in one place.
+echo "$RENDER" | grep -E '^\s+docker run --rm -u 0 ' | while read -r cmd; do
+    echo "==> $cmd"
+    eval "$cmd"
+done
+
+echo "==> starting $APP"
+if ! docker compose -f "$COMPOSE_FILE" up -d --wait --wait-timeout "$START_TIMEOUT"; then
+    echo "FAIL $APP: did not reach running within ${START_TIMEOUT}s"
+    docker compose -f "$COMPOSE_FILE" ps -a
+    docker compose -f "$COMPOSE_FILE" logs --no-color --tail 200
+    exit 1
+fi
+
+echo "==> settling ${SETTLE}s"
+sleep "$SETTLE"
+
+# `--wait` returns once containers are up; an app that exits a moment later is
+# the failure we are looking for, so the state is re-read after settling. An
+# exited init step is expected — it renders as a one-shot service the app waits
+# on — so only a non-zero exit or a restart counts against it.
+failed=0
+states="$(docker compose -f "$COMPOSE_FILE" ps -a --format '{{.Name}} {{.State}} {{.ExitCode}}')"
+while read -r name state status || [ -n "${name:-}" ]; do
+    # `read` leaves the fields unset when it stops at EOF without a newline.
+    name="${name:-}"; state="${state:-}"; status="${status:-}"
+    [ -n "$name" ] || continue
+    restarts="$(docker inspect -f '{{.RestartCount}}' "$name" 2>/dev/null || echo 0)"
+    case "$state" in
+        running) [ "$restarts" -eq 0 ] || { echo "FAIL $name restarted $restarts time(s)"; failed=1; } ;;
+        exited)  [ "$status" = "0" ] || { echo "FAIL $name exited with status $status"; failed=1; } ;;
+        *)       echo "FAIL $name is $state"; failed=1 ;;
+    esac
+done <<EOF
+$states
+EOF
+
+# An ingress port is what a customer reaches, so a stack that is "running" but
+# never binds is not up. The renderer publishes those on loopback at the
+# container number, so the rendered file is where the list comes from — reading
+# it back off `docker compose ps` would leave the probe silently skipped if that
+# output format ever changes.
+ports="$(grep -oE '127\.0\.0\.1:[0-9]+:' "$COMPOSE_FILE" | cut -d: -f2 | sort -un)"
+if grep -q 'expose: ingress' "$APP_FILE" && [ -z "$ports" ]; then
+    echo "FAIL $APP: declares an ingress port but nothing was published"
+    failed=1
+fi
+if [ "$failed" -eq 0 ]; then
+    for port in $ports; do
+        # Accepting a connection is the only signal that generalises: an
+        # ingress port can be a websocket relay, and asking one for a page can
+        # legitimately return nothing. The HTTP status, when there is one, is
+        # printed as information rather than asserted on.
+        echo "==> probing 127.0.0.1:$port"
+        deadline=$((SECONDS + PROBE_TIMEOUT))
+        until (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "FAIL $APP: nothing listening on port $port within ${PROBE_TIMEOUT}s"
+                failed=1
+                break
+            fi
+            sleep 2
+        done
+        if [ "$failed" -eq 0 ]; then
+            code="$(curl -s -o /dev/null -m 5 -w '%{http_code}' "http://127.0.0.1:$port/" 2>/dev/null || true)"
+            echo "    open (HTTP ${code:-000})"
+        fi
+    done
+fi
+
+if [ "$failed" -ne 0 ]; then
+    docker compose -f "$COMPOSE_FILE" ps -a
+    docker compose -f "$COMPOSE_FILE" logs --no-color --tail 200
+    exit 1
+fi
+
+echo "PASS $APP"

--- a/scripts/app-catalog-test.sh
+++ b/scripts/app-catalog-test.sh
@@ -109,11 +109,10 @@ sleep "$SETTLE"
 # on — so only a non-zero exit or a restart counts against it.
 failed=0
 states="$(docker compose -f "$COMPOSE_FILE" ps -a --format '{{.Name}} {{.State}} {{.ExitCode}}')"
-while read -r name state status || [ -n "${name:-}" ]; do
-    # `read` leaves the fields unset when it stops at EOF without a newline.
-    name="${name:-}"; state="${state:-}"; status="${status:-}"
+while read -r name state status; do
     [ -n "$name" ] || continue
-    restarts="$(docker inspect -f '{{.RestartCount}}' "$name" 2>/dev/null || echo 0)"
+    # Without a stdin of its own, docker would eat the rest of the loop's input.
+    restarts="$(docker inspect -f '{{.RestartCount}}' "$name" </dev/null 2>/dev/null || echo 0)"
     case "$state" in
         running) [ "$restarts" -eq 0 ] || { echo "FAIL $name restarted $restarts time(s)"; failed=1; } ;;
         exited)  [ "$status" = "0" ] || { echo "FAIL $name exited with status $status"; failed=1; } ;;
@@ -129,7 +128,16 @@ EOF
 # it back off `docker compose ps` would leave the probe silently skipped if that
 # output format ever changes.
 ports="$(grep -oE '127\.0\.0\.1:[0-9]+:' "$COMPOSE_FILE" | cut -d: -f2 | sort -un)"
-if grep -q 'expose: ingress' "$APP_FILE" && [ -z "$ports" ]; then
+# An expose value written in a form this does not recognise would drop the
+# guard silently, so anything but the two known values fails the run instead.
+doc_body="$(sed 's/^[[:space:]]*#.*$//; s/[[:space:]]#.*$//' "$APP_FILE")"
+unknown="$(printf '%s\n' "$doc_body" | grep -oE 'expose:[[:space:]]*[^,}[:space:]]+' \
+    | grep -vE 'expose:[[:space:]]*"?(none|ingress)"?$' || true)"
+if [ -n "$unknown" ]; then
+    echo "FAIL $APP: unrecognised expose value: $unknown"
+    failed=1
+fi
+if printf '%s\n' "$doc_body" | grep -qE 'expose:[[:space:]]*"?ingress"?' && [ -z "$ports" ]; then
     echo "FAIL $APP: declares an ingress port but nothing was published"
     failed=1
 fi


### PR DESCRIPTION
Extracts the example managed-app composes out of `docs/managed-app-examples.md` into a flat `catalog/` directory, and adds CI that starts each one.

- `catalog/*.yaml` — 7 standalone documents (blossom-server, buzz, haven, nostr-rs-relay, pyramid, route96, strfry). The doc keeps the grammar notes and now links the files instead of carrying 350 lines of fenced YAML.
- `scripts/app-catalog-test.sh` — renders one document with `compose-to-docker`, applies the volume chowns the renderer prints (docker has no `fsGroup`), starts the stack, and fails on a service that exits non-zero, restarts, or an ingress port that never answers. `HOST_PORT_OFFSET` shifts published ports for local runs.
- `.github/workflows/app-catalog.yml` — validates every document, then one matrix job per file, discovered from the directory so adding a `.yaml` is enough to get it tested. Weekly cron because most entries pin a mutable tag.
- `lnvps_operator` test `catalog_documents_map_to_k8s` now reads `catalog/` instead of parsing markdown fences (`lnvps_operator/src/app_deployments.rs:3191`).

Validation checks the document's grammar; it cannot know whether a third-party image can start under the hardening the operator applies. This runs them.

All 7 pass locally on this branch. `cargo test --workspace --exclude lnvps_e2e` green at 50d05ff (`lnvps_e2e` needs the live stack, not started here); clippy unchanged on the touched file.

Channel: 721a8a6c-c36c-5fa1-ae07-822ddc8567c5
