### PR TITLE
docs(db): tunnel owners are customers, not LNVPS

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -4,6 +4,7 @@ volumes:
   e2e-lnd-payer:
   e2e-bitcoind:
   e2e-nostr-relay:
+  e2e-rustfs:
 
 services:
   db:
@@ -153,3 +154,40 @@ services:
       interval: 3s
       timeout: 5s
       retries: 10
+
+  # S3-compatible object storage for the web-hosting product (static sites) and
+  # for app-deployment backups. RustFS runs as uid 10001 and refuses to start on
+  # a root-owned volume, so a one-shot init container fixes ownership first --
+  # Docker creates named volumes root-owned.
+  rustfs-perms:
+    image: alpine
+    user: root
+    volumes:
+      - "e2e-rustfs:/fix"
+    command: chown -R 10001:10001 /fix
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    depends_on:
+      rustfs-perms:
+        condition: service_completed_successfully
+    environment:
+      RUSTFS_ADDRESS: ":9000"
+      RUSTFS_CONSOLE_ADDRESS: ":9001"
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_OBS_LOGGER_LEVEL: error
+      # Never the well-known `rustfsadmin` default -- the server starts with a
+      # warning on those and they must not leak into a config template.
+      RUSTFS_ACCESS_KEY: e2eaccesskey
+      RUSTFS_SECRET_KEY: e2esecretkey
+    command: ["/data"]
+    ports:
+      - "9400:9000"
+      - "9401:9001"
+    volumes:
+      - "e2e-rustfs:/data"
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "9000"]
+      interval: 3s
+      timeout: 5s
+      retries: 20

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -8736,7 +8736,7 @@ mod marketplace_tests {
     #[tokio::test]
     async fn tunnels_list_by_owner() {
         let db = MockDb::default();
-        let (u1, lnvps) = (user(&db, 1).await, user(&db, 9).await);
+        let (u1, bgp_customer) = (user(&db, 1).await, user(&db, 9).await);
         let op = db.insert_marketplace_operator(&operator(u1)).await.unwrap();
         let node_id = db.insert_marketplace_node(&node(op, "a")).await.unwrap();
 
@@ -8749,8 +8749,10 @@ mod marketplace_tests {
 
         // A VPN sold to the same user, linked by nothing yet.
         db.insert_tunnel(&tunnel(u1, "wg-vpn")).await.unwrap();
-        // LNVPS infrastructure is owned too — by the account representing us.
-        db.insert_tunnel(&tunnel(lnvps, "wg-bgp")).await.unwrap();
+        // A BGP tunnel requested by a different customer.
+        db.insert_tunnel(&tunnel(bgp_customer, "wg-bgp"))
+            .await
+            .unwrap();
 
         assert_eq!(db.list_tunnels().await.unwrap().len(), 3);
 
@@ -8758,7 +8760,10 @@ mod marketplace_tests {
         // VPN, and the query returns what they own rather than what it is for.
         let mine = db.list_tunnels_for_user(u1).await.unwrap();
         assert_eq!(mine.len(), 2);
-        assert_eq!(db.list_tunnels_for_user(lnvps).await.unwrap().len(), 1);
+        assert_eq!(
+            db.list_tunnels_for_user(bgp_customer).await.unwrap().len(),
+            1
+        );
 
         // Which of them is the node's is answered by the node, not the tunnel.
         let attached = db.get_marketplace_node(node_id).await.unwrap().tunnel_id;

--- a/lnvps_db/migrations/20260805130000_tunnel.sql
+++ b/lnvps_db/migrations/20260805130000_tunnel.sql
@@ -16,7 +16,10 @@
 -- bolted onto each consumer:
 --   * marketplace node data planes (guest traffic back to a route server),
 --   * plain WireGuard VPNs sold to users,
---   * infrastructure peerings, including tunnels carrying BGP.
+--   * BGP peerings requested by a customer.
+--
+-- Every one of these is sold to somebody; this table is not for LNVPS's own
+-- internal plumbing.
 --
 -- There is no `purpose` column, and `user_id` is not one either. What a tunnel
 -- is *for* is decided by whichever table links to it —
@@ -36,11 +39,14 @@ CREATE TABLE tunnel (
     -- compared without a translation table.
     kind SMALLINT UNSIGNED NOT NULL DEFAULT 2,
 
-    -- Who owns this allocation. Always set: every tunnel belongs to somebody,
-    -- including LNVPS's own infrastructure, which is owned by the account that
-    -- represents us. NOT NULL so "unowned" is not a state that has to be
-    -- handled — an allocation nobody owns is one nobody can be billed for,
-    -- audited against, or have revoked with their account.
+    -- Who owns this allocation. Always set: every tunnel belongs to a real
+    -- customer account — the operator's merchant account for a marketplace
+    -- node, the requesting user for a BGP tunnel or a VPN. These are tunnels
+    -- sold to somebody, not LNVPS internal plumbing.
+    --
+    -- NOT NULL so "unowned" is not a state that has to be handled — an
+    -- allocation nobody owns is one nobody can be billed for, audited against,
+    -- or have revoked with their account.
     --
     -- Ownership says nothing about what the tunnel is for; that is the
     -- referencing table's job.

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -1803,8 +1803,7 @@ pub struct MarketplaceOperator {
 /// a router; the two are reconciled, and a tunnel that disappears from a router
 /// is drift to be reported rather than an allocation that quietly vanished.
 ///
-/// One shape serves marketplace node data planes, user VPNs and infrastructure
-/// peerings. There is no `purpose`, and [`user_id`](Self::user_id) is not one:
+/// One shape serves marketplace node data planes, user VPNs and BGP peerings. There is no `purpose`, and [`user_id`](Self::user_id) is not one:
 /// what a tunnel is *for* is decided by whichever table links to it —
 /// [`MarketplaceNode::tunnel_id`] today, a VPN or BGP table later. This record
 /// answers only who owns the allocation, what key terminates it, and which
@@ -1816,9 +1815,10 @@ pub struct Tunnel {
     /// Encapsulation. Values match [`RouterTunnelKind`] so desired and observed
     /// state compare directly.
     pub kind: RouterTunnelKind,
-    /// Who owns this allocation. Always set: every tunnel belongs to somebody,
-    /// including LNVPS's own infrastructure, which is owned by the account
-    /// representing us. Says nothing about what the tunnel is for.
+    /// The customer account this allocation belongs to: the merchant account
+    /// for a marketplace operator, the requesting user for a BGP tunnel or a
+    /// VPN. Always a real account — these are tunnels sold to somebody, not
+    /// LNVPS's internal plumbing. Says nothing about what the tunnel is for.
     pub user_id: u64,
     /// Route server terminating this tunnel. `None` until one is chosen.
     pub router_id: Option<u64>,

--- a/work/marketplace.md
+++ b/work/marketplace.md
@@ -481,8 +481,9 @@ Migration `20260805120000_marketplace_node_registry.sql`:
 - `tunnel`: the source of truth for what LNVPS has *assigned* — owner, peer key, inner
   addresses, route server — and nothing else. **What a tunnel is for is decided by whichever
   table links to it**: `marketplace_node.tunnel_id` today, a VPN or BGP table later. There is
-  no `purpose` column, and `user_id` (NOT NULL) is ownership, not type: every allocation has
-  an owner, including LNVPS's own infrastructure. `router_tunnel` remains the observed state.
+  no `purpose` column, and `user_id` (NOT NULL) is ownership, not type: every allocation
+  belongs to a real customer account — the operator's merchant account for a node, the
+  requesting user for a BGP tunnel or VPN. `router_tunnel` remains the observed state.
 - `vm_host.marketplace_node_id` NULLABLE UNIQUE FK, `company.marketplace_rate` default 0.
 - `VmHostKind::MarketplaceNode = 2`, `MarketplaceNodeStatus`, `MarketplaceTrustTier`,
   `PayoutMode` (shared with referrals), `lnvps_db` CRUD, mock impl, tests.


### PR DESCRIPTION
Follow-up to #356, correcting a factual error in comments I wrote there.

The `tunnel.user_id` comments said every tunnel belongs to somebody *"including LNVPS's own infrastructure, which is owned by the account that represents us"*. That is not how this works: **`user_id` is always a real customer account** — the operator's merchant account for a marketplace node, the requesting user for a BGP tunnel or a VPN. Tunnels in this table are sold to somebody. LNVPS's internal plumbing is not modelled here.

Worth fixing rather than leaving as sloppy prose, because the wrong version had a consequence attached: it implied a system account representing LNVPS had to exist before any BGP tunnel could be allocated, and I had already flagged that as a prerequisite for the allocator. It is not one. Nothing needs to be built.

Ownership still says nothing about what a tunnel is *for* — that remains the referencing table's job (`marketplace_node.tunnel_id` today, a VPN or BGP table later).

### Scope

Comments, doc comments and test naming. No schema change, no behaviour change.

### Checksum note

`sqlx::migrate!()` checksums migration files, so editing a comment in `20260805130000_tunnel.sql` invalidates it. Any database that already applied that migration will fail startup with `VersionMismatch` until the row is deleted from `_sqlx_migrations` or the schema is rebuilt.

No release tag contains #356, so **production is unaffected** — this is dev databases only. Re-verified by applying every migration in order to a fresh MariaDB: schema comes out identical (`user_id int(10) unsigned NOT NULL`, FK to `users`, `ix_tunnel_user`).