### PR TITLE
feat(node): HTTPS control listener, authenticated on every request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +558,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1958,6 +1989,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,6 +2624,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2770,6 +2812,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3552,18 +3604,25 @@ name = "lnvps_node"
 version = "0.4.7"
 dependencies = [
  "anyhow",
+ "axum",
+ "axum-server",
  "base64 0.22.1",
  "clap",
  "config",
  "env_logger",
+ "if-addrs",
  "lnvps_host_util",
  "log 0.4.32",
  "nostr 0.44.3",
  "rcgen",
+ "reqwest 0.12.28",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-rustls",
+ "tower",
 ]
 
 [[package]]
@@ -5114,6 +5173,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -7554,6 +7614,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/lnvps_host_util/src/lib.rs
+++ b/lnvps_host_util/src/lib.rs
@@ -17,11 +17,11 @@ use cros_libva::Display;
 // Used only by the VA-API probe, so it is gated the same way; without this the
 // default build (which is what CI builds) fails while a no-default-features
 // build succeeds.
-#[cfg(all(target_os = "linux", feature = "vaapi"))]
-use std::path::Path;
 #[cfg(target_arch = "x86_64")]
 use raw_cpuid::CpuId;
 use serde::Serialize;
+#[cfg(all(target_os = "linux", feature = "vaapi"))]
+use std::path::Path;
 
 /// CPU manufacturer
 #[derive(Debug, Clone, Serialize)]

--- a/lnvps_node/Cargo.toml
+++ b/lnvps_node/Cargo.toml
@@ -21,7 +21,17 @@ rcgen = "0.13"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
 
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "fs"] }
+# Control API: axum over rustls. HTTPS is not optional — LNVPS pins the
+# certificate (decision 14), which is what authenticates the node's replies.
+axum = { workspace = true }
+axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+# Reads the tunnel interface's real addresses, so the bind check (decision 13)
+# is made against the machine rather than against the config file restating
+# itself.
+if-addrs = "0.13"
+
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "fs", "net", "signal"] }
 anyhow.workspace = true
 log.workspace = true
 env_logger.workspace = true
@@ -31,3 +41,10 @@ config.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+# Drives the router directly in tests, so authentication is exercised without
+# binding a socket or terminating TLS.
+tower = { version = "0.5", features = ["util"] }
+# Integration tests speak real TLS to the daemon: reqwest as the pinned client
+# LNVPS will be, tokio-rustls to observe the certificate actually presented.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }

--- a/lnvps_node/config.example.yaml
+++ b/lnvps_node/config.example.yaml
@@ -1,0 +1,33 @@
+# Example configuration for lnvps-node.
+#
+# Keys are kebab-case, and unknown keys are rejected rather than ignored — a
+# typo fails at startup instead of quietly leaving a default in place.
+
+# LNVPS API, used for registration, heartbeat and telemetry (outbound only).
+api-url: "https://api.lnvps.net"
+
+# Where the node keeps state it must not lose. Holds the TLS identity whose
+# fingerprint LNVPS pins at registration: delete it and the node must be
+# re-registered before it can be reached again.
+state-dir: "/var/lib/lnvps-node"
+
+# The node's own credential, used to sign outbound calls to LNVPS.
+credential:
+  # nostr-key (nsec1... or 64 hex characters) or session-token.
+  kind: nostr-key
+  # Must not be readable by other users; the daemon refuses to start otherwise.
+  file: "/etc/lnvps-node/node.key"
+
+# Seconds between heartbeats.
+heartbeat-secs: 60
+
+# Inbound control API. Omit this section until the node is paired — without it
+# the daemon has nothing to serve and will say so.
+control:
+  # Must be an address of tunnel-interface below, and never a wildcard. The
+  # control API can start and stop other people's virtual machines, so it is
+  # reachable over the tunnel and nowhere else. Checked against the interface's
+  # real addresses at startup.
+  listen: "10.66.0.2"
+  port: 8890
+  tunnel-interface: "wg0"

--- a/lnvps_node/src/config.rs
+++ b/lnvps_node/src/config.rs
@@ -133,6 +133,29 @@ pub fn validate_listen_address(listen: IpAddr, interface_addrs: &[IpAddr]) -> Re
     Ok(())
 }
 
+/// Addresses currently assigned to `interface`.
+///
+/// Split out from [`validate_listen_address`] so the rule is testable without a
+/// tunnel: this function is the only part that touches the machine.
+pub fn interface_addresses(interface: &str) -> Result<Vec<IpAddr>> {
+    let addrs = if_addrs::get_if_addrs()
+        .with_context(|| format!("Cannot read network interfaces to find {interface}"))?;
+
+    let found: Vec<IpAddr> = addrs
+        .iter()
+        .filter(|i| i.name == interface)
+        .map(|i| i.addr.ip())
+        .collect();
+
+    if found.is_empty() {
+        bail!(
+            "Tunnel interface {interface} has no addresses (is it up?); the control API cannot \
+             be bound to the tunnel, so it will not be started"
+        );
+    }
+    Ok(found)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lnvps_node/src/control.rs
+++ b/lnvps_node/src/control.rs
@@ -1,0 +1,404 @@
+//! The inbound control API: HTTPS, bound to the tunnel address, every request
+//! authenticated with NIP-98 against the LNVPS key compiled into the binary.
+//!
+//! Decision 13 says the tunnel is not by itself a trust boundary — guests can
+//! route to the node's tunnel address — so there are two independent defences,
+//! and neither is documentation:
+//!
+//! 1. The listener binds **only** the tunnel interface address, checked against
+//!    the interface's real addresses at startup ([`crate::config`]).
+//! 2. Every request is authenticated ([`crate::control_auth`]). The middleware
+//!    is layered over the whole router rather than per-route, so a route added
+//!    later cannot forget it. The tests prove this by hitting a path that does
+//!    not exist and getting 401 rather than 404.
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::body::{Body, to_bytes};
+use axum::extract::{DefaultBodyLimit, Request, State};
+use axum::http::{StatusCode, header};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use nostr::PublicKey;
+use serde::Serialize;
+
+use crate::control_auth::{self, ReplayGuard};
+use crate::tls::NodeTls;
+
+/// Commands are small JSON documents. Anything larger is not a command this
+/// node knows how to run, and should not be read into memory before deciding
+/// that.
+const MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// How long a used request id is remembered. Must exceed the clock window, or
+/// a request could age out of the replay cache while still inside the window
+/// that makes it acceptable.
+const REPLAY_WINDOW: Duration = Duration::from_secs(600);
+
+/// Bound on the replay cache, so a flood of signed requests cannot grow it
+/// without limit. Only LNVPS can add entries, but a bug on their side should
+/// not be able to exhaust a node's memory.
+const REPLAY_CAPACITY: usize = 10_000;
+
+/// Shared control-plane state.
+pub struct ControlState {
+    /// The only key permitted to command this node.
+    pub control_pubkey: PublicKey,
+    /// Seen request ids, so a captured request cannot be run twice.
+    pub replay: Mutex<ReplayGuard>,
+    /// The node's own base URL (`https://<tunnel-ip>:<port>`).
+    ///
+    /// Deliberately **not** derived from the `Host` header. The NIP-98 `u` tag
+    /// is compared against this, so a request signed for one node cannot be
+    /// replayed against another by setting `Host` to the first node's address.
+    pub base_url: String,
+}
+
+impl ControlState {
+    /// Build state for a node serving on `addr`.
+    pub fn new(control_pubkey: PublicKey, addr: SocketAddr) -> Self {
+        Self {
+            control_pubkey,
+            replay: Mutex::new(ReplayGuard::new(REPLAY_WINDOW, REPLAY_CAPACITY)),
+            base_url: format!("https://{addr}"),
+        }
+    }
+}
+
+/// What the node reports about itself.
+#[derive(Debug, Serialize)]
+pub struct NodeStatus {
+    /// Daemon version, so LNVPS can tell what a node is running.
+    pub version: &'static str,
+    /// Host inventory, the same view `lnvps-node inventory` prints.
+    pub inventory: crate::inventory::Inventory,
+}
+
+/// The control router, with authentication layered over everything.
+pub fn router(state: Arc<ControlState>) -> Router {
+    Router::new()
+        .route("/api/v1/status", get(get_status))
+        // Order matters: the body limit is outermost so an oversized body is
+        // rejected before authentication reads it into memory.
+        .layer(middleware::from_fn_with_state(state.clone(), authenticate))
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
+        .with_state(state)
+}
+
+/// Serve the control API over HTTPS until the process exits.
+pub async fn serve(state: Arc<ControlState>, addr: SocketAddr, tls: NodeTls) -> Result<()> {
+    // rustls needs a process-wide crypto provider; installing twice is not an
+    // error worth failing a startup over.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let cfg = axum_server::tls_rustls::RustlsConfig::from_pem(tls.cert_pem, tls.key_pem)
+        .await
+        .context("Control API TLS configuration is invalid")?;
+
+    log::info!(
+        "Control API listening on https://{addr} (certificate fingerprint {})",
+        tls.fingerprint
+    );
+    axum_server::bind_rustls(addr, cfg)
+        .serve(router(state).into_make_service())
+        .await
+        .context("Control API server stopped")
+}
+
+/// Reject anything not signed by LNVPS for exactly this request.
+///
+/// The body is buffered so its hash can be bound into the signature check, then
+/// handed on to the handler unchanged.
+async fn authenticate(
+    State(state): State<Arc<ControlState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let (parts, body) = request.into_parts();
+
+    let authorization = parts
+        .headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+
+    let bytes = match to_bytes(body, MAX_BODY_BYTES).await {
+        Ok(b) => b,
+        Err(_) => return unauthorized("Request body could not be read"),
+    };
+
+    // Built from the node's own address, never from the request's Host header.
+    let url = format!("{}{}", state.base_url, parts.uri.path());
+    let verified = {
+        let mut replay = match state.replay.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        control_auth::verify(
+            &control_auth::Request {
+                authorization: &authorization,
+                url: &url,
+                method: parts.method.as_str(),
+                body: &bytes,
+            },
+            &state.control_pubkey,
+            &mut replay,
+            control_auth::now_unix(),
+        )
+    };
+
+    match verified {
+        Ok(id) => {
+            log::debug!("Control request {} {} authorised ({id})", parts.method, url);
+            next.run(Request::from_parts(parts, Body::from(bytes)))
+                .await
+        }
+        Err(e) => {
+            // Logged at warn: on a healthy node every control request is from
+            // LNVPS and valid, so a failure is either a bug or someone probing.
+            log::warn!("Rejected control request {} {url}: {e:#}", parts.method);
+            unauthorized(&format!("{e:#}"))
+        }
+    }
+}
+
+fn unauthorized(reason: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({ "error": reason })),
+    )
+        .into_response()
+}
+
+/// Report what this node is and what it is running.
+async fn get_status() -> Json<NodeStatus> {
+    Json(NodeStatus {
+        version: env!("CARGO_PKG_VERSION"),
+        inventory: crate::inventory::Inventory::collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{Method, Request as HttpRequest};
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use nostr::{EventBuilder, Keys, Kind, Tag, TagKind};
+    use tower::ServiceExt;
+
+    const ADDR: &str = "10.66.0.7:8890";
+
+    fn state_for(keys: &Keys, addr: &str) -> Arc<ControlState> {
+        Arc::new(ControlState::new(keys.public_key(), addr.parse().unwrap()))
+    }
+
+    /// A NIP-98 header, with every field overridable so tests can tamper with
+    /// exactly one thing at a time.
+    fn auth_header(keys: &Keys, url: &str, method: &str, body: &[u8]) -> String {
+        let mut tags = vec![
+            Tag::custom(TagKind::custom("u"), [url.to_string()]),
+            Tag::custom(TagKind::custom("method"), [method.to_string()]),
+        ];
+        if !body.is_empty() {
+            tags.push(Tag::custom(
+                TagKind::custom("payload"),
+                [control_auth::sha256_hex(body)],
+            ));
+        }
+        let event = EventBuilder::new(Kind::HttpAuth, "")
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap();
+        format!(
+            "Nostr {}",
+            BASE64.encode(serde_json::to_vec(&event).unwrap())
+        )
+    }
+
+    fn get(path: &str, auth: Option<&str>) -> HttpRequest<Body> {
+        let mut b = HttpRequest::builder().method(Method::GET).uri(path);
+        if let Some(a) = auth {
+            b = b.header(header::AUTHORIZATION, a);
+        }
+        b.body(Body::empty()).unwrap()
+    }
+
+    async fn status_of(state: Arc<ControlState>, req: HttpRequest<Body>) -> StatusCode {
+        router(state).oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn a_signed_request_from_lnvps_is_served() {
+        let keys = Keys::generate();
+        let url = format!("https://{ADDR}/api/v1/status");
+        let auth = auth_header(&keys, &url, "GET", b"");
+
+        let code = status_of(state_for(&keys, ADDR), get("/api/v1/status", Some(&auth))).await;
+        assert_eq!(code, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn an_unsigned_request_is_refused() {
+        let keys = Keys::generate();
+        let code = status_of(state_for(&keys, ADDR), get("/api/v1/status", None)).await;
+        assert_eq!(code, StatusCode::UNAUTHORIZED);
+    }
+
+    /// A guest on this machine can reach the tunnel address (decision 13). It
+    /// holds no LNVPS key, and that must be the end of it.
+    #[tokio::test]
+    async fn a_request_signed_by_anyone_else_is_refused() {
+        let lnvps = Keys::generate();
+        let attacker = Keys::generate();
+        let url = format!("https://{ADDR}/api/v1/status");
+        let auth = auth_header(&attacker, &url, "GET", b"");
+
+        let code = status_of(state_for(&lnvps, ADDR), get("/api/v1/status", Some(&auth))).await;
+        assert_eq!(code, StatusCode::UNAUTHORIZED);
+    }
+
+    /// The `u` tag is checked against the node's own address, not the Host
+    /// header. Otherwise a request captured from node A could be sent to node B
+    /// with `Host: <node A>`, and node B would authorise it.
+    #[tokio::test]
+    async fn a_request_for_another_node_is_refused_here() {
+        let keys = Keys::generate();
+        let other_node = "10.66.0.9:8890";
+        let signed_for_other = auth_header(
+            &keys,
+            &format!("https://{other_node}/api/v1/status"),
+            "GET",
+            b"",
+        );
+
+        // Same operator key, same path, and the attacker sets Host to the node
+        // the request was signed for.
+        let mut req = get("/api/v1/status", Some(&signed_for_other));
+        req.headers_mut()
+            .insert(header::HOST, other_node.parse().unwrap());
+
+        let code = status_of(state_for(&keys, ADDR), req).await;
+        assert_eq!(
+            code,
+            StatusCode::UNAUTHORIZED,
+            "a request signed for {other_node} must not be accepted by {ADDR}"
+        );
+    }
+
+    /// Signed for one path, sent to another.
+    #[tokio::test]
+    async fn a_request_signed_for_a_different_path_is_refused() {
+        let keys = Keys::generate();
+        let auth = auth_header(
+            &keys,
+            &format!("https://{ADDR}/api/v1/harmless"),
+            "GET",
+            b"",
+        );
+        let code = status_of(state_for(&keys, ADDR), get("/api/v1/status", Some(&auth))).await;
+        assert_eq!(code, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn a_replayed_request_is_refused() {
+        let keys = Keys::generate();
+        let state = state_for(&keys, ADDR);
+        let auth = auth_header(&keys, &format!("https://{ADDR}/api/v1/status"), "GET", b"");
+
+        let first = status_of(state.clone(), get("/api/v1/status", Some(&auth))).await;
+        let second = status_of(state, get("/api/v1/status", Some(&auth))).await;
+
+        assert_eq!(first, StatusCode::OK);
+        assert_eq!(
+            second,
+            StatusCode::UNAUTHORIZED,
+            "the same signed request must not run twice"
+        );
+    }
+
+    /// The single most valuable test here: authentication is layered over the
+    /// router, not attached per route, so a route added tomorrow is covered
+    /// without anyone remembering to cover it. An unknown path returning 401
+    /// rather than 404 is what demonstrates that.
+    #[tokio::test]
+    async fn authentication_covers_paths_that_do_not_exist_yet() {
+        let keys = Keys::generate();
+        let code = status_of(state_for(&keys, ADDR), get("/api/v1/vm/1/destroy", None)).await;
+        assert_eq!(
+            code,
+            StatusCode::UNAUTHORIZED,
+            "an unauthenticated request reached routing; a future route would be exposed"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_status_report_names_the_daemon_version() {
+        let keys = Keys::generate();
+        let url = format!("https://{ADDR}/api/v1/status");
+        let auth = auth_header(&keys, &url, "GET", b"");
+
+        let response = router(state_for(&keys, ADDR))
+            .oneshot(get("/api/v1/status", Some(&auth)))
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), MAX_BODY_BYTES)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+        assert!(json["inventory"]["memory"]["total_bytes"].as_u64().unwrap() > 0);
+        assert!(
+            !json["inventory"]["cpu"]["arch"]
+                .as_str()
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// A rejection must say why, or a node that stops accepting commands is
+    /// debugged by guesswork.
+    #[tokio::test]
+    async fn a_rejection_explains_itself() {
+        let keys = Keys::generate();
+        let response = router(state_for(&keys, ADDR))
+            .oneshot(get("/api/v1/status", None))
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), MAX_BODY_BYTES)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            json["error"].as_str().unwrap().contains("Nostr scheme"),
+            "unhelpful rejection: {json}"
+        );
+    }
+
+    /// The base URL is the node's own address, which is what makes the cross
+    /// node replay test above meaningful.
+    #[test]
+    fn state_takes_its_base_url_from_its_own_address() {
+        let keys = Keys::generate();
+        assert_eq!(state_for(&keys, ADDR).base_url, format!("https://{ADDR}"));
+    }
+
+    /// The replay cache must outlive the window in which a request is still
+    /// considered fresh, or a request could age out of the cache and be
+    /// accepted a second time.
+    #[test]
+    fn the_replay_window_outlives_the_clock_window() {
+        assert!(
+            REPLAY_WINDOW > control_auth::MAX_CLOCK_SKEW,
+            "a request could leave the replay cache while still inside the clock window"
+        );
+    }
+}

--- a/lnvps_node/src/lib.rs
+++ b/lnvps_node/src/lib.rs
@@ -8,12 +8,14 @@
 //!   operator's own consumer account.
 //! - [`control_auth`] — how the node verifies *inbound* commands really came
 //!   from LNVPS, against a public key compiled into the binary.
+//! - [`control`] — the inbound HTTPS control API, authenticated on every request.
 //! - [`tls`] — the node's TLS identity, whose fingerprint LNVPS pins at
 //!   registration, so the node's *replies* are authenticated too.
 //! - [`inventory`] — what the node reports about the machine.
 //! - [`config`] — configuration, including where the control API may listen.
 
 pub mod config;
+pub mod control;
 pub mod control_auth;
 pub mod credential;
 pub mod inventory;

--- a/lnvps_node/src/main.rs
+++ b/lnvps_node/src/main.rs
@@ -1,12 +1,16 @@
 //! `lnvps-node` — the LNVPS marketplace node daemon.
 
-use std::path::PathBuf;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use lnvps_node::config::NodeConfig;
+use lnvps_node::control::ControlState;
 use lnvps_node::credential::Credential;
 use lnvps_node::inventory::Inventory;
+use lnvps_node::{config, control, control_auth, tls};
 
 #[derive(Parser)]
 #[command(name = "lnvps-node", version, about = "LNVPS marketplace node daemon")]
@@ -21,6 +25,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Run the daemon: serve the control API over the tunnel.
+    Run,
     /// Print what this node would report about its hardware.
     Inventory,
     /// Check the configuration and credential without contacting LNVPS.
@@ -33,11 +39,13 @@ enum Command {
     },
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     env_logger::init();
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Run => run(&cli.config).await?,
         // Deliberately usable before there is any config: an operator
         // evaluating whether their hardware qualifies should not have to
         // configure a daemon first.
@@ -66,7 +74,7 @@ fn main() -> Result<()> {
                 Some(dir) => dir,
                 None => NodeConfig::load(&cli.config)?.state_dir,
             };
-            let tls = lnvps_node::tls::load_or_generate(&state_dir, None)?;
+            let tls = tls::load_or_generate(&state_dir, None)?;
             println!("{}", tls.fingerprint);
             if tls.generated {
                 eprintln!(
@@ -77,4 +85,40 @@ fn main() -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Start the control API.
+///
+/// The order here is deliberate: everything that can be known to be wrong is
+/// checked before a socket is opened, so a misconfigured node fails at startup
+/// with a specific message instead of serving something it should not.
+async fn run(config_path: &Path) -> Result<()> {
+    let config = NodeConfig::load(config_path)?;
+
+    let control = config.control.as_ref().context(
+        "No control section in the configuration: this node is not paired yet, so there is \
+         nothing for LNVPS to command. Register the node first.",
+    )?;
+
+    // Refuses immediately if the binary was built without a control key, rather
+    // than starting a listener that can never authorise anything (decision 12).
+    let control_pubkey = control_auth::control_pubkey()?;
+
+    // Decision 13: the address must belong to the tunnel interface, checked
+    // against the interface itself.
+    let addrs = config::interface_addresses(&control.tunnel_interface)?;
+    config::validate_listen_address(control.listen, &addrs)?;
+
+    let tls = tls::load_or_generate(&config.state_dir, Some(control.listen))?;
+    if tls.generated {
+        log::warn!(
+            "Generated a new TLS certificate (fingerprint {}). LNVPS pins this value at \
+             registration, so until the new fingerprint is registered, control requests will \
+             not reach this node.",
+            tls.fingerprint
+        );
+    }
+
+    let addr = SocketAddr::new(control.listen, control.port);
+    control::serve(Arc::new(ControlState::new(control_pubkey, addr)), addr, tls).await
 }

--- a/lnvps_node/tests/control_https.rs
+++ b/lnvps_node/tests/control_https.rs
@@ -1,0 +1,241 @@
+//! End-to-end checks of the control API over a real socket.
+//!
+//! The unit tests in `control` drive the router directly, which proves the
+//! authentication logic but says nothing about whether the daemon actually
+//! serves HTTPS, or whether the certificate it presents is the one whose
+//! fingerprint LNVPS pinned. Both of those are the sort of thing that can be
+//! wrong while every unit test passes.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use lnvps_node::control::{ControlState, serve};
+use lnvps_node::control_auth::sha256_hex;
+use lnvps_node::tls;
+use nostr::{EventBuilder, Keys, Kind, Tag, TagKind};
+
+/// Start a control API on a free loopback port, returning its address, the
+/// certificate it serves and its fingerprint.
+async fn start_node(keys: &Keys, state_dir: &std::path::Path) -> (SocketAddr, Vec<u8>, String) {
+    // Ask the OS for a free port, then release it: axum_server binds by
+    // address, and a hardcoded port makes the suite fail when something else
+    // happens to hold it.
+    let port = {
+        let sock = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        sock.local_addr().unwrap().port()
+    };
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+    let node_tls = tls::load_or_generate(state_dir, Some(addr.ip())).unwrap();
+    let (cert, fingerprint) = (node_tls.cert_pem.clone(), node_tls.fingerprint.clone());
+
+    let state = Arc::new(ControlState::new(keys.public_key(), addr));
+    tokio::spawn(async move { serve(state, addr, node_tls).await });
+
+    // Wait for the listener rather than sleeping a fixed time.
+    for _ in 0..100 {
+        if std::net::TcpStream::connect(addr).is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    (addr, cert, fingerprint)
+}
+
+fn auth_header(keys: &Keys, url: &str, method: &str, body: &[u8]) -> String {
+    let mut tags = vec![
+        Tag::custom(TagKind::custom("u"), [url.to_string()]),
+        Tag::custom(TagKind::custom("method"), [method.to_string()]),
+    ];
+    if !body.is_empty() {
+        tags.push(Tag::custom(TagKind::custom("payload"), [sha256_hex(body)]));
+    }
+    let event = EventBuilder::new(Kind::HttpAuth, "")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .unwrap();
+    format!(
+        "Nostr {}",
+        BASE64.encode(serde_json::to_vec(&event).unwrap())
+    )
+}
+
+/// A client that trusts exactly one certificate — the same shape of trust
+/// LNVPS uses once it has pinned this node.
+fn pinned_client(cert_pem: &[u8]) -> reqwest::Client {
+    reqwest::Client::builder()
+        .add_root_certificate(reqwest::Certificate::from_pem(cert_pem).unwrap())
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn the_daemon_serves_https_and_authorises_lnvps() {
+    let keys = Keys::generate();
+    let dir = tempfile::tempdir().unwrap();
+    let (addr, cert, _) = start_node(&keys, dir.path()).await;
+
+    let url = format!("https://{addr}/api/v1/status");
+    let response = pinned_client(&cert)
+        .get(&url)
+        .header("Authorization", auth_header(&keys, &url, "GET", b""))
+        .send()
+        .await
+        .expect("control API did not answer over HTTPS");
+
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+    assert!(body["inventory"]["memory"]["total_bytes"].as_u64().unwrap() > 0);
+}
+
+/// Plain HTTP must not be served: the pin only means something if the
+/// connection is TLS in the first place.
+#[tokio::test]
+async fn the_control_api_is_not_reachable_over_plain_http() {
+    let keys = Keys::generate();
+    let dir = tempfile::tempdir().unwrap();
+    let (addr, _, _) = start_node(&keys, dir.path()).await;
+
+    let result = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap()
+        .get(format!("http://{addr}/api/v1/status"))
+        .send()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "the control API answered an unencrypted request: {result:?}"
+    );
+}
+
+/// The certificate presented on the wire must be the one whose fingerprint was
+/// registered. If these can differ, the pin protects nothing.
+#[tokio::test]
+async fn the_served_certificate_is_the_one_that_was_pinned() {
+    let keys = Keys::generate();
+    let dir = tempfile::tempdir().unwrap();
+    let (addr, cert_pem, fingerprint) = start_node(&keys, dir.path()).await;
+
+    // Take the certificate from the live TLS session, not from disk.
+    let presented = fetch_peer_certificate(addr).await;
+    assert_eq!(
+        tls::fingerprint_sha256(&presented),
+        fingerprint,
+        "the certificate served differs from the one whose fingerprint is registered"
+    );
+    assert_eq!(presented, tls::pem_to_der(&cert_pem).unwrap());
+}
+
+/// A client trusting some other certificate must fail the handshake — the
+/// negative half of the pinning claim.
+#[tokio::test]
+async fn a_client_pinned_to_a_different_certificate_is_rejected() {
+    let keys = Keys::generate();
+    let dir = tempfile::tempdir().unwrap();
+    let (addr, _, _) = start_node(&keys, dir.path()).await;
+
+    let someone_else = tls::generate(Some(addr.ip())).unwrap().cert_pem;
+    let url = format!("https://{addr}/api/v1/status");
+    let result = pinned_client(&someone_else)
+        .get(&url)
+        .header("Authorization", auth_header(&keys, &url, "GET", b""))
+        .send()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a client pinned to a different certificate completed the handshake"
+    );
+}
+
+/// Reaching the node over TLS is not authorisation. A guest that can route to
+/// the tunnel address gets exactly this far (decision 13).
+#[tokio::test]
+async fn tls_alone_does_not_authorise_a_request() {
+    let keys = Keys::generate();
+    let dir = tempfile::tempdir().unwrap();
+    let (addr, cert, _) = start_node(&keys, dir.path()).await;
+
+    let response = pinned_client(&cert)
+        .get(format!("https://{addr}/api/v1/status"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 401);
+}
+
+/// Read the peer certificate from a real handshake, accepting whatever is
+/// presented, so the test observes the server rather than trusting it.
+async fn fetch_peer_certificate(addr: SocketAddr) -> Vec<u8> {
+    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+    use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
+    use std::sync::Mutex;
+    use tokio_rustls::TlsConnector;
+
+    /// Records the certificate and accepts it. Test-only: the point is to
+    /// observe what the server actually sends.
+    #[derive(Debug)]
+    struct Capture(Arc<Mutex<Option<Vec<u8>>>>);
+
+    impl ServerCertVerifier for Capture {
+        fn verify_server_cert(
+            &self,
+            end_entity: &CertificateDer<'_>,
+            _: &[CertificateDer<'_>],
+            _: &ServerName<'_>,
+            _: &[u8],
+            _: UnixTime,
+        ) -> Result<ServerCertVerified, rustls::Error> {
+            *self.0.lock().unwrap() = Some(end_entity.to_vec());
+            Ok(ServerCertVerified::assertion())
+        }
+        fn verify_tls12_signature(
+            &self,
+            _: &[u8],
+            _: &CertificateDer<'_>,
+            _: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+        fn verify_tls13_signature(
+            &self,
+            _: &[u8],
+            _: &CertificateDer<'_>,
+            _: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::ED25519,
+                SignatureScheme::RSA_PSS_SHA256,
+            ]
+        }
+    }
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let seen = Arc::new(Mutex::new(None));
+    let config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(Capture(seen.clone())))
+        .with_no_client_auth();
+
+    let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let _ = TlsConnector::from(Arc::new(config))
+        .connect(ServerName::IpAddress(addr.ip().into()), stream)
+        .await
+        .unwrap();
+
+    let captured = seen.lock().unwrap().clone();
+    captured.expect("no certificate was presented")
+}

--- a/work/marketplace.md
+++ b/work/marketplace.md
@@ -473,7 +473,10 @@ v1.
    Consequences: the identity is **persisted**, because a certificate minted on each restart
    would break the pin and make the node unreachable; a corrupt certificate is a hard failure
    rather than a silent regeneration, for the same reason; and registration (increment 3)
-   must carry the fingerprint, with a re-registration path for rotation.
+   must carry the fingerprint, with a re-registration path for rotation. Note the node does
+   not currently verify that a persisted certificate still covers its tunnel address as a SAN:
+   under a fingerprint-pinning verifier that does not matter, but it is a loose end for the
+   rotation path to close.
 13. **The tunnel is not by itself a trust boundary.** Guests run on the node, so a guest that
    can route to the node's tunnel address could otherwise stop its neighbours. Two independent
    defences, both required: the listener binds **only** the tunnel interface address (enforced
@@ -549,9 +552,24 @@ Two guards worth remembering:
   flags were fixed in passing: `--no-default-features` did not compile, which is exactly the
   configuration the daemon needs (a node has neither libva nor NVML installed).
 
-**2b — control listener + heartbeat (next, with increments 3 and 4):**
-- Axum listener bound to the tunnel address, NIP-98 middleware, start/stop/status handlers
-  over the existing `VmBackend`.
+**2b — control listener (done):**
+- Axum listener over HTTPS bound to the tunnel address, with `GET /api/v1/status`.
+- NIP-98 authentication layered over the *whole* router rather than per route, so a route
+  added later cannot forget it — proven by an unauthenticated request to a path that does not
+  exist returning 401 rather than 404.
+- The `u` tag is checked against the node's **own** address, never the `Host` header;
+  otherwise a request captured from one node could be replayed against another by setting
+  `Host` to the first node's address.
+- Startup refuses, with a specific message, when: the binary has no `LNVPS_CONTROL_PUBKEY`,
+  the tunnel interface has no addresses, the listen address is a wildcard, or the listen
+  address belongs to some other interface. All four verified against a real machine.
+- Integration tests speak real TLS to a real socket: the certificate presented on the wire is
+  the one whose fingerprint is registered, a client pinned to a different certificate fails
+  the handshake, plain HTTP is refused, and reaching the node over TLS still authorises
+  nothing.
+
+**2c — VM lifecycle + heartbeat (next, with increments 3 and 4):**
+- start/stop/status handlers over the existing `VmBackend`.
 - Outbound registration and heartbeat frames (telemetry: cpu/mem/disk/net, libvirt version,
   firmware version).
 - `.deb` packaging + GitHub release workflow + self-upgrade, copied from `lnvps_fw`


### PR DESCRIPTION
Increment 2b of the marketplace plan. The node daemon now serves `GET /api/v1/status` over the tunnel.

## Authentication cannot be forgotten by a future route

It is layered over the whole router, not attached per route. The test that demonstrates this hits a path that **does not exist** and expects 401, not 404 — proving the layer sits in front of routing, so any route added later is covered without anyone remembering.

## The `u` tag is checked against the node's own address, not `Host`

Deriving the URL from the `Host` header would mean a request captured from node A could be sent to node B with `Host: <node A>` — node B would reconstruct node A's URL, match the signature, and execute the command. `a_request_for_another_node_is_refused_here` covers precisely that, and fails if the header is trusted.

## Startup refuses four specific misconfigurations

Verified by running the daemon on a real machine, not by reading the code:

| Condition | Message |
|---|---|
| No `LNVPS_CONTROL_PUBKEY` in the build | `built without LNVPS_CONTROL_PUBKEY, so it cannot verify control requests` |
| Tunnel interface has no addresses | `Tunnel interface wg-nonexistent has no addresses (is it up?)` |
| Wildcard bind | `0.0.0.0 binds every interface; it must be the node's tunnel address` |
| Address of a different interface | `10.100.2.34 is not an address of the tunnel interface (127.0.0.1, ::1)` |

Interface addresses are read from the machine, so the check is against reality rather than the config file restating itself.

## Real TLS, real socket

Unit tests drive the router directly, which proves the auth logic and nothing about whether the daemon actually serves HTTPS with the pinned certificate. The integration tests connect over TLS:

- the certificate presented **on the wire** is the one whose fingerprint is registered (read from a live handshake, not from disk)
- a client pinned to a different certificate fails the handshake
- plain HTTP is refused
- reaching the node over TLS authorises nothing on its own

On this host, three independent observers agreed on the fingerprint — `openssl s_client` on the wire, the `fingerprint` subcommand, and the daemon's own log line.

## Mutation testing

| Guard disabled | Result |
|---|---|
| Serve a certificate other than the pinned one | 3 tests fail |
| Downgrade to plain HTTP | 4 tests fail |
| Drop the authentication layer | TLS-is-not-authorisation fails |
| Trust the `Host` header for the URL | cross-node replay fails |

## Notes

- `config.example.yaml` added. Keys are kebab-case with unknown keys rejected; I got that wrong myself while testing, which is the argument for shipping an example.
- The node does not verify that a persisted certificate still covers its tunnel address as a SAN. Under a fingerprint-pinning verifier that does not matter, but it is recorded in the plan as a loose end for the rotation path.

Next (2c): start/stop/status over `VmBackend`, outbound registration and heartbeat, `.deb` packaging.