### PR TITLE
feat(marketplace): one-off node listing fee, and stop one-offs expiring

### DIFF
--- a/lnvps_api/src/api/legal.rs
+++ b/lnvps_api/src/api/legal.rs
@@ -262,6 +262,9 @@ async fn v1_generate_lir_agreement_from_subscription(
             lnvps_db::SubscriptionType::DnsHosting => ("DNS Hosting".to_string(), "—".to_string()),
             lnvps_db::SubscriptionType::Vps => ("VPS".to_string(), "—".to_string()),
             lnvps_db::SubscriptionType::App => ("App".to_string(), "—".to_string()),
+            lnvps_db::SubscriptionType::MarketplaceNodeFee => {
+                ("Marketplace Node Listing Fee".to_string(), "—".to_string())
+            }
         };
 
         resources.push(ResourceRequest {

--- a/lnvps_api/src/api/marketplace.rs
+++ b/lnvps_api/src/api/marketplace.rs
@@ -16,11 +16,15 @@ use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
+use chrono::Utc;
 use lnvps_api_common::{
     ApiData, ApiError, ApiResult, NODE_TOKEN_TTL_SECS, Nip98Auth, NodeAuth, issue_node_token,
     session_auth_enabled,
 };
-use lnvps_db::{MarketplaceNode, MarketplaceNodeStatus, MarketplaceOperator, MarketplaceTrustTier};
+use lnvps_db::{
+    IntervalType, MarketplaceNode, MarketplaceNodeStatus, MarketplaceOperator,
+    MarketplaceTrustTier, Subscription, SubscriptionLineItem, SubscriptionType,
+};
 
 use crate::api::RouterState;
 
@@ -34,6 +38,10 @@ pub fn router() -> Router<RouterState> {
         .route(
             "/api/v1/marketplace/nodes/{id}/token",
             post(v1_rotate_node_token),
+        )
+        .route(
+            "/api/v1/marketplace/nodes/{id}/fee",
+            post(v1_start_node_fee),
         )
         .route("/api/v1/marketplace/operator", get(v1_get_operator))
         // Node-facing: authenticated by the node's own token, not a user.
@@ -351,6 +359,132 @@ pub(crate) async fn owned_node(
     Ok(node)
 }
 
+/// Start paying a node's one-off listing fee.
+#[derive(Deserialize)]
+pub struct StartNodeFeeRequest {
+    /// The region the operator wants this node listed in.
+    ///
+    /// The fee's company and currency come from the region, exactly as an IP
+    /// range's come from its IP space — a node belongs to no region when it is
+    /// registered, so there is nothing else to derive them from. It also tells
+    /// the admin where the operator intends the hardware to live; approval can
+    /// still place it elsewhere.
+    pub region_id: u64,
+}
+
+/// The fee subscription for a node.
+#[derive(Serialize, Debug)]
+pub struct ApiNodeFee {
+    /// Subscription to pay. Pay it through the normal subscription renewal
+    /// endpoint — there is no separate payment rail for fees.
+    pub subscription_id: u64,
+    /// Amount due, in `currency`.
+    pub amount: u64,
+    pub currency: String,
+    /// Whether the fee has already been paid.
+    pub is_paid: bool,
+}
+
+/// Create (or return) the subscription covering a node's listing fee.
+///
+/// Idempotent on purpose: an operator who calls this twice must not end up with
+/// two fee subscriptions for one node, one of which they never pay and which
+/// then sits unpaid forever. The second call returns the first.
+async fn v1_start_node_fee(
+    auth: Nip98Auth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+    Json(req): Json<StartNodeFeeRequest>,
+) -> ApiResult<ApiNodeFee> {
+    ApiData::ok(start_node_fee(&this.db, &auth.pubkey(), id, &req).await?)
+}
+
+/// The body of [`v1_start_node_fee`], without the extractors, so it can be
+/// tested against a database rather than a live HTTP stack.
+pub(crate) async fn start_node_fee(
+    db: &std::sync::Arc<dyn lnvps_db::LNVpsDb>,
+    caller: &[u8; 32],
+    id: u64,
+    req: &StartNodeFeeRequest,
+) -> Result<ApiNodeFee, ApiError> {
+    let mut node = owned_node(db, caller, id).await?;
+
+    // Already started: hand back the existing subscription rather than making
+    // a second one.
+    if let Some(line_item_id) = node.subscription_line_item_id {
+        let line_item = db.get_subscription_line_item(line_item_id).await?;
+        let sub = db.get_subscription(line_item.subscription_id).await?;
+        return Ok(ApiNodeFee {
+            subscription_id: sub.id,
+            amount: line_item.setup_amount,
+            currency: sub.currency,
+            // `is_setup` is what payment sets, and a one-off fee never gets an
+            // expiry to check instead.
+            is_paid: sub.is_setup,
+        });
+    }
+
+    let region = db.get_host_region(req.region_id).await?;
+    let company = db.get_company(region.company_id).await?;
+    if company.marketplace_node_fee == 0 {
+        return Err(ApiError::new(
+            "No listing fee is required for nodes in this region",
+        ));
+    }
+
+    let subscription = Subscription {
+        id: 0,
+        user_id: db.upsert_user(caller).await?,
+        company_id: region.company_id,
+        name: format!("Marketplace node listing fee: {}", node.name),
+        description: Some(format!(
+            "One-off fee to list node '{}' in {}",
+            node.name, region.name
+        )),
+        created: Utc::now(),
+        expires: None,
+        is_active: false,
+        is_setup: false,
+        currency: company.base_currency.clone(),
+        interval_amount: 1,
+        interval_type: IntervalType::Month,
+        setup_fee: company.marketplace_node_fee,
+        // Nothing recurring to renew.
+        auto_renewal_enabled: false,
+        external_id: None,
+    };
+
+    // amount = 0 with a setup_amount is what marks this a one-off: it is the
+    // shape `subscription_payment_paid` recognises to leave `expires` NULL.
+    let line_item = SubscriptionLineItem {
+        id: 0,
+        subscription_id: 0,
+        subscription_type: SubscriptionType::MarketplaceNodeFee,
+        name: format!("Node listing fee: {}", node.name),
+        description: None,
+        amount: 0,
+        setup_amount: company.marketplace_node_fee,
+        configuration: None,
+    };
+
+    let (subscription_id, line_item_ids) = db
+        .insert_subscription_with_line_items(&subscription, vec![line_item])
+        .await?;
+    let line_item_id = *line_item_ids
+        .first()
+        .ok_or_else(|| ApiError::new("Failed to create fee line item"))?;
+
+    node.subscription_line_item_id = Some(line_item_id);
+    db.update_marketplace_node(&node).await?;
+
+    Ok(ApiNodeFee {
+        subscription_id,
+        amount: company.marketplace_node_fee,
+        currency: company.base_currency,
+        is_paid: false,
+    })
+}
+
 /// List the caller's own nodes.
 async fn v1_list_nodes(
     auth: Nip98Auth,
@@ -407,11 +541,147 @@ mod tests {
         Arc::new(MockDb::default())
     }
 
+    /// A database whose company charges `fee` to list a node, plus the id of a
+    /// region to derive that company from.
+    async fn db_with_fee(fee: u64) -> (Arc<dyn lnvps_db::LNVpsDb>, u64) {
+        init_session_secret(b"test-secret-for-marketplace".to_vec());
+        let mock = MockDb::default();
+        mock.set_marketplace_node_fee(1, fee).await;
+        let db: Arc<dyn lnvps_db::LNVpsDb> = Arc::new(mock);
+        let region_id = db.get_host_region(1).await.expect("mock region 1").id;
+        (db, region_id)
+    }
+
     fn request(name: &str, fingerprint: &str) -> RegisterNodeRequest {
         RegisterNodeRequest {
             name: name.to_string(),
             tls_fingerprint: fingerprint.to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn paying_a_fee_creates_a_one_off_subscription_for_that_node() {
+        let (db, region_id) = db_with_fee(5000).await;
+        let (node, _) = register_node(&db, &OPERATOR, &request("rack 1", FINGERPRINT_1))
+            .await
+            .unwrap();
+
+        let fee = start_node_fee(&db, &OPERATOR, node.id, &StartNodeFeeRequest { region_id })
+            .await
+            .unwrap();
+        assert_eq!(fee.amount, 5000);
+        assert_eq!(fee.currency, "EUR");
+        assert!(!fee.is_paid);
+
+        // The shape matters: amount 0 with a setup fee is what makes
+        // `subscription_payment_paid` treat this as a one-off and leave
+        // `expires` NULL. A recurring line item here would start dunning the
+        // operator for a fee they paid once.
+        let items = db
+            .list_subscription_line_items(fee.subscription_id)
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].amount, 0, "listing fee must not bill recurring");
+        assert_eq!(items[0].setup_amount, 5000);
+        assert_eq!(
+            items[0].subscription_type,
+            SubscriptionType::MarketplaceNodeFee
+        );
+
+        let sub = db.get_subscription(fee.subscription_id).await.unwrap();
+        assert_eq!(sub.expires, None);
+        assert!(
+            !sub.auto_renewal_enabled,
+            "a one-off fee must not auto-renew"
+        );
+
+        // The node now points at the line item that bills it.
+        let reloaded = db.get_marketplace_node(node.id).await.unwrap();
+        assert_eq!(reloaded.subscription_line_item_id, Some(items[0].id));
+        assert_eq!(
+            db.get_marketplace_node_by_line_item(items[0].id)
+                .await
+                .unwrap()
+                .id,
+            node.id
+        );
+    }
+
+    /// An operator who retries must not end up with two fee subscriptions, one
+    /// of which they never pay and which then sits unpaid forever.
+    #[tokio::test]
+    async fn starting_a_fee_twice_returns_the_same_subscription() {
+        let (db, region_id) = db_with_fee(5000).await;
+        let (node, _) = register_node(&db, &OPERATOR, &request("rack 1", FINGERPRINT_1))
+            .await
+            .unwrap();
+
+        let first = start_node_fee(&db, &OPERATOR, node.id, &StartNodeFeeRequest { region_id })
+            .await
+            .unwrap();
+        let second = start_node_fee(&db, &OPERATOR, node.id, &StartNodeFeeRequest { region_id })
+            .await
+            .unwrap();
+        assert_eq!(first.subscription_id, second.subscription_id);
+    }
+
+    /// Each node is charged separately — paying once must not license a fleet.
+    #[tokio::test]
+    async fn each_node_needs_its_own_fee() {
+        let (db, region_id) = db_with_fee(5000).await;
+        let (a, _) = register_node(&db, &OPERATOR, &request("a", FINGERPRINT_1))
+            .await
+            .unwrap();
+        let (b, _) = register_node(&db, &OPERATOR, &request("b", FINGERPRINT_2))
+            .await
+            .unwrap();
+
+        let fee_a = start_node_fee(&db, &OPERATOR, a.id, &StartNodeFeeRequest { region_id })
+            .await
+            .unwrap();
+        let fee_b = start_node_fee(&db, &OPERATOR, b.id, &StartNodeFeeRequest { region_id })
+            .await
+            .unwrap();
+        assert_ne!(
+            fee_a.subscription_id, fee_b.subscription_id,
+            "two nodes shared one listing fee"
+        );
+    }
+
+    /// Node ids must not be probeable through the fee endpoint either.
+    #[tokio::test]
+    async fn another_operators_node_cannot_be_paid_for() {
+        let (db, region_id) = db_with_fee(5000).await;
+        let (node, _) = register_node(&db, &OPERATOR, &request("rack 1", FINGERPRINT_1))
+            .await
+            .unwrap();
+
+        let err = start_node_fee(
+            &db,
+            &SOMEONE_ELSE,
+            node.id,
+            &StartNodeFeeRequest { region_id },
+        )
+        .await
+        .expect_err("paid for another operator's node");
+        assert!(format!("{err:?}").contains("not found"), "got: {err:?}");
+    }
+
+    /// A company that charges nothing must not create a zero-amount invoice
+    /// that can never be paid and would block approval forever.
+    #[tokio::test]
+    async fn no_fee_configured_means_nothing_to_pay() {
+        let (db, region_id) = db_with_fee(0).await;
+        let (node, _) = register_node(&db, &OPERATOR, &request("rack 1", FINGERPRINT_1))
+            .await
+            .unwrap();
+
+        assert!(
+            start_node_fee(&db, &OPERATOR, node.id, &StartNodeFeeRequest { region_id })
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/lnvps_api/src/subscription/marketplace_node_fee.rs
+++ b/lnvps_api/src/subscription/marketplace_node_fee.rs
@@ -1,0 +1,68 @@
+//! The one-off fee that lets a marketplace node be approved.
+//!
+//! Unlike every other line item handler this provisions nothing. The fee buys
+//! review and a listing, not a resource: paying it makes the node *eligible* for
+//! approval, and an admin still has to approve it. That is the whole point of
+//! charging at approval rather than at registration — hardware is vetted before
+//! money changes hands, and hardware that fails review costs its operator
+//! nothing.
+//!
+//! The expiry callbacks are unreachable rather than unimplemented. A fee
+//! subscription bills nothing recurring, and `subscription_payment_paid` leaves
+//! such a subscription's `expires` as NULL, which every expiry query filters on
+//! (`WHERE ... expires IS NOT NULL`). Reaching them means that invariant broke,
+//! so they say so loudly instead of quietly deactivating a node whose operator
+//! paid in full.
+
+use crate::subscription::SubscriptionLineItemHandler;
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use lnvps_db::{Subscription, SubscriptionLineItem, SubscriptionPayment};
+use log::info;
+
+pub struct MarketplaceNodeFeeLineItemHandler {
+    /// The line item this handler fulfils.
+    line_item_id: u64,
+}
+
+impl MarketplaceNodeFeeLineItemHandler {
+    pub fn new(line_item_id: u64) -> Self {
+        Self { line_item_id }
+    }
+}
+
+#[async_trait]
+impl SubscriptionLineItemHandler for MarketplaceNodeFeeLineItemHandler {
+    async fn on_payment(&self, _payment: &SubscriptionPayment) -> Result<()> {
+        // Nothing to provision. The node becomes approvable because the gate
+        // reads the payment state directly, so there is no flag to flip here
+        // that could disagree with what was actually paid.
+        info!(
+            "Marketplace node listing fee paid for line item {}",
+            self.line_item_id
+        );
+        Ok(())
+    }
+
+    async fn on_expired(&self, sub: &Subscription, line_item: &SubscriptionLineItem) -> Result<()> {
+        bail!(
+            "Marketplace node fee subscription {} (line item {}) expired, but a one-off fee must \
+             never acquire an expiry — check the one-off branch in subscription_payment_paid",
+            sub.id,
+            line_item.id
+        )
+    }
+
+    async fn on_grace_period_exceeded(
+        &self,
+        sub: &Subscription,
+        line_item: &SubscriptionLineItem,
+    ) -> Result<()> {
+        bail!(
+            "Marketplace node fee subscription {} (line item {}) exceeded a grace period it should \
+             never have had — check the one-off branch in subscription_payment_paid",
+            sub.id,
+            line_item.id
+        )
+    }
+}

--- a/lnvps_api/src/subscription/mod.rs
+++ b/lnvps_api/src/subscription/mod.rs
@@ -36,6 +36,7 @@ use std::time::{Duration, Instant};
 
 mod app;
 mod ip_range;
+mod marketplace_node_fee;
 mod vm;
 
 use crate::provisioner::{IpRangeProvisioner, VmProvisioner};
@@ -232,6 +233,9 @@ impl SubscriptionHandler {
                 self.ip_range_provisioner.clone(),
                 li.id,
             ))),
+            SubscriptionType::MarketplaceNodeFee => Ok(Box::new(
+                marketplace_node_fee::MarketplaceNodeFeeLineItemHandler::new(li.id),
+            )),
             SubscriptionType::App => Ok(Box::new(AppLineItemHandler::new(
                 self.db.clone(),
                 li.id,

--- a/lnvps_api_admin/src/admin/companies.rs
+++ b/lnvps_api_admin/src/admin/companies.rs
@@ -159,9 +159,11 @@ async fn admin_create_company(
         referral_rate: req.referral_rate.unwrap_or(0.0).max(0.0),
         max_prepay_days: req.max_prepay_days.unwrap_or(0),
         // Marketplace revenue share is not settable through the admin API yet
-        // (no marketplace exists to pay out); the column defaults to 0, which
-        // means "no revenue share", and is left untouched by company updates.
+        // (no payouts exist to run); it defaults to 0, meaning "no revenue
+        // share". Company updates read the row first and write it back
+        // unchanged, so a value set directly in the DB survives them.
         marketplace_rate: 0.0,
+        marketplace_node_fee: req.marketplace_node_fee.unwrap_or(0),
     };
 
     let company_id = this.db.admin_create_company(&company).await?;
@@ -277,6 +279,9 @@ async fn admin_update_company(
             return ApiData::err("referral_rate cannot be negative");
         }
         company.referral_rate = rate;
+    }
+    if let Some(fee) = req.marketplace_node_fee {
+        company.marketplace_node_fee = fee;
     }
     if let Some(days) = req.max_prepay_days {
         company.max_prepay_days = days;

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -1925,6 +1925,9 @@ pub struct AdminCompanyInfo {
     /// Maximum number of days a subscription may be prepaid/renewed in advance
     /// (0 = inherit the global default).
     pub max_prepay_days: u16,
+    /// One-off fee charged per marketplace node before an admin can approve it,
+    /// in this company's `base_currency`. `0` requires no fee.
+    pub marketplace_node_fee: u64,
     pub region_count: u64, // Number of regions assigned to this company
 }
 
@@ -1945,6 +1948,8 @@ pub struct CreateCompanyRequest {
     pub referral_rate: Option<f32>,
     /// Maximum prepay/renewal window in days (0 = inherit the global default).
     pub max_prepay_days: Option<u16>,
+    /// One-off marketplace node listing fee, in the company's base currency.
+    pub marketplace_node_fee: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -1964,6 +1969,8 @@ pub struct UpdateCompanyRequest {
     pub referral_rate: Option<f32>,
     /// Maximum prepay/renewal window in days (0 = inherit the global default).
     pub max_prepay_days: Option<u16>,
+    /// One-off marketplace node listing fee, in the company's base currency.
+    pub marketplace_node_fee: Option<u64>,
 }
 
 impl From<lnvps_db::Company> for AdminCompanyInfo {
@@ -1984,6 +1991,7 @@ impl From<lnvps_db::Company> for AdminCompanyInfo {
             base_currency: company.base_currency,
             referral_rate: company.referral_rate,
             max_prepay_days: company.max_prepay_days,
+            marketplace_node_fee: company.marketplace_node_fee,
             region_count: 0, // Will be filled by handler
         }
     }

--- a/lnvps_api_admin/src/bin/generate_demo_data.rs
+++ b/lnvps_api_admin/src/bin/generate_demo_data.rs
@@ -160,6 +160,7 @@ async fn create_companies(db: &LNVpsDbMysql) -> Result<Vec<Company>> {
             referral_rate: 0.0,
             max_prepay_days: 0,
             marketplace_rate: 0.0,
+            marketplace_node_fee: 0,
             address_2: None,
         },
         Company {
@@ -178,6 +179,7 @@ async fn create_companies(db: &LNVpsDbMysql) -> Result<Vec<Company>> {
             referral_rate: 0.0,
             max_prepay_days: 0,
             marketplace_rate: 0.0,
+            marketplace_node_fee: 0,
             address_2: None,
         },
         Company {
@@ -196,6 +198,7 @@ async fn create_companies(db: &LNVpsDbMysql) -> Result<Vec<Company>> {
             referral_rate: 0.0,
             max_prepay_days: 0,
             marketplace_rate: 0.0,
+            marketplace_node_fee: 0,
             address_2: None,
         },
     ];

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -368,6 +368,7 @@ impl Default for MockDb {
                         referral_rate: 0.0,
                         max_prepay_days: 0,
                         marketplace_rate: 0.0,
+                        marketplace_node_fee: 0,
                     },
                 );
                 companies
@@ -2723,31 +2724,52 @@ impl LNVpsDbBase for MockDb {
         }
         drop(payments);
 
+        // Same one-off rule as the real schema: a subscription that bills nothing
+        // recurring never acquires an expiry, or a paid-once listing fee would
+        // start being dunned for renewal. Mirrored here on purpose — a mock that
+        // expires what MariaDB leaves alone makes every test about it fiction.
+        let one_off = {
+            let items = self.subscription_line_items.lock().await;
+            let mine: Vec<_> = items
+                .values()
+                .filter(|li| li.subscription_id == payment.subscription_id)
+                .collect();
+            !mine.is_empty()
+                && mine.iter().all(|li| li.amount == 0)
+                && mine.iter().any(|li| li.setup_amount > 0)
+        };
+
         let mut subscriptions = self.subscriptions.lock().await;
         if let Some(subscription) = subscriptions.get_mut(&payment.subscription_id) {
-            let base = subscription
-                .expires
-                .unwrap_or_else(Utc::now)
-                .max(Utc::now());
-
-            let new_expires = if let Some(time_value) = payment.time_value {
-                // VM path: extend by explicit time_value seconds
-                base.add(TimeDelta::seconds(time_value as i64))
+            if one_off {
+                // Activated, but never given an expiry.
+                subscription.is_active = true;
+                subscription.is_setup = true;
             } else {
-                // Regular subscription path: use interval from subscription
-                match subscription.interval_type {
-                    IntervalType::Day => base.add(Days::new(subscription.interval_amount)),
-                    IntervalType::Month => {
-                        base.add(Months::new(subscription.interval_amount as u32))
+                let base = subscription
+                    .expires
+                    .unwrap_or_else(Utc::now)
+                    .max(Utc::now());
+
+                let new_expires = if let Some(time_value) = payment.time_value {
+                    // VM path: extend by explicit time_value seconds
+                    base.add(TimeDelta::seconds(time_value as i64))
+                } else {
+                    // Regular subscription path: use interval from subscription
+                    match subscription.interval_type {
+                        IntervalType::Day => base.add(Days::new(subscription.interval_amount)),
+                        IntervalType::Month => {
+                            base.add(Months::new(subscription.interval_amount as u32))
+                        }
+                        IntervalType::Year => {
+                            base.add(Months::new((12 * subscription.interval_amount) as u32))
+                        }
                     }
-                    IntervalType::Year => {
-                        base.add(Months::new((12 * subscription.interval_amount) as u32))
-                    }
-                }
-            };
-            subscription.expires = Some(new_expires);
-            subscription.is_active = true;
-            subscription.is_setup = true;
+                };
+                subscription.expires = Some(new_expires);
+                subscription.is_active = true;
+                subscription.is_setup = true;
+            }
         }
         drop(subscriptions);
 
@@ -3532,6 +3554,18 @@ impl LNVpsDbBase for MockDb {
             .ok_or_else(|| DbError::Other(anyhow!("Marketplace node not found")))
     }
 
+    async fn get_marketplace_node_by_line_item(
+        &self,
+        line_item_id: u64,
+    ) -> DbResult<MarketplaceNode> {
+        let nodes = self.marketplace_nodes.lock().await;
+        nodes
+            .values()
+            .find(|n| n.subscription_line_item_id == Some(line_item_id))
+            .cloned()
+            .ok_or_else(|| DbError::Other(anyhow!("Marketplace node not found")))
+    }
+
     async fn list_marketplace_nodes(&self, operator_id: u64) -> DbResult<Vec<MarketplaceNode>> {
         let nodes = self.marketplace_nodes.lock().await;
         let mut out: Vec<_> = nodes
@@ -3596,6 +3630,19 @@ impl LNVpsDbBase for MockDb {
         {
             return Err(anyhow!("Tunnel {} already backs another node", tunnel_id).into());
         }
+        // fk/uk_marketplace_node_line_item: one paid fee covers exactly one
+        // node, or the per-node gate silently degrades into a per-operator one.
+        if let Some(li) = node.subscription_line_item_id {
+            if !self.subscription_line_items.lock().await.contains_key(&li) {
+                return Err(anyhow!("Subscription line item {} not found", li).into());
+            }
+            if nodes
+                .values()
+                .any(|n| n.subscription_line_item_id == Some(li))
+            {
+                return Err(anyhow!("Line item {} already bills another node", li).into());
+            }
+        }
         let new_id = nodes.keys().max().copied().unwrap_or(0) + 1;
         nodes.insert(
             new_id,
@@ -3638,6 +3685,17 @@ impl LNVpsDbBase for MockDb {
         {
             return Err(anyhow!("A node with that TLS fingerprint already exists").into());
         }
+        if let Some(li) = node.subscription_line_item_id {
+            if !self.subscription_line_items.lock().await.contains_key(&li) {
+                return Err(anyhow!("Subscription line item {} not found", li).into());
+            }
+            if nodes
+                .values()
+                .any(|n| n.id != node.id && n.subscription_line_item_id == Some(li))
+            {
+                return Err(anyhow!("Line item {} already bills another node", li).into());
+            }
+        }
         let existing = nodes
             .get_mut(&node.id)
             .ok_or_else(|| DbError::Other(anyhow!("Marketplace node {} not found", node.id)))?;
@@ -3650,6 +3708,7 @@ impl LNVpsDbBase for MockDb {
         existing.status = node.status;
         existing.trust_tier = node.trust_tier;
         existing.tunnel_id = node.tunnel_id;
+        existing.subscription_line_item_id = node.subscription_line_item_id;
         Ok(())
     }
 
@@ -8290,7 +8349,10 @@ impl crate::dns::DnsServer for MockDnsServer {
 #[cfg(test)]
 mod marketplace_tests {
     use super::*;
-    use lnvps_db::{LNVpsDbBase, MarketplaceTrustTier, PayoutMode, RouterTunnelKind};
+    use lnvps_db::{
+        LNVpsDbBase, MarketplaceTrustTier, PayoutMode, RouterTunnelKind, Subscription,
+        SubscriptionLineItem, SubscriptionPayment, SubscriptionPaymentType, SubscriptionType,
+    };
 
     /// Create a user, returning its id. The marketplace tables carry real FKs
     /// to `users`, so tests cannot invent owners.
@@ -8315,6 +8377,174 @@ mod marketplace_tests {
             name: name.to_string(),
             ..Default::default()
         }
+    }
+
+    /// Build a subscription with the given line item amounts, plus an unpaid
+    /// payment against it. `(amount, setup_amount)` per line item.
+    async fn subscription_with(db: &MockDb, uid: u64, items: &[(u64, u64)]) -> (u64, Vec<u8>) {
+        let sub = Subscription {
+            id: 0,
+            user_id: uid,
+            company_id: 1,
+            name: "sub".to_string(),
+            description: None,
+            created: Utc::now(),
+            expires: None,
+            is_active: false,
+            is_setup: false,
+            currency: "EUR".to_string(),
+            interval_amount: 1,
+            interval_type: IntervalType::Month,
+            setup_fee: 0,
+            auto_renewal_enabled: false,
+            external_id: None,
+        };
+        let line_items = items
+            .iter()
+            .map(|(amount, setup_amount)| SubscriptionLineItem {
+                id: 0,
+                subscription_id: 0,
+                subscription_type: SubscriptionType::MarketplaceNodeFee,
+                name: "item".to_string(),
+                description: None,
+                amount: *amount,
+                setup_amount: *setup_amount,
+                configuration: None,
+            })
+            .collect();
+        let (sub_id, _) = db
+            .insert_subscription_with_line_items(&sub, line_items)
+            .await
+            .unwrap();
+
+        let payment = SubscriptionPayment {
+            id: vec![sub_id as u8; 32],
+            subscription_id: sub_id,
+            user_id: uid,
+            created: Utc::now(),
+            expires: Utc::now() + TimeDelta::hours(1),
+            amount: 1000,
+            currency: "EUR".to_string(),
+            rate: 1.0,
+            time_value: Some(2_592_000),
+            payment_method: PaymentMethod::Lightning,
+            payment_type: SubscriptionPaymentType::Purchase,
+            external_data: Default::default(),
+            external_id: None,
+            is_paid: false,
+            metadata: None,
+            tax: 0,
+            processing_fee: 0,
+            paid_at: None,
+            tax_rate: None,
+            tax_country_code: None,
+            tax_treatment: None,
+            tax_evidence: None,
+            tax_breakdown: None,
+            refunded_payment_id: None,
+        };
+        db.insert_subscription_payment(&payment).await.unwrap();
+        (sub_id, payment.id.clone())
+    }
+
+    /// A one-off purchase must never acquire an expiry, or `check_subscriptions`
+    /// mails the customer "your subscription will expire soon" about something
+    /// they bought outright.
+    #[tokio::test]
+    async fn a_one_off_fee_never_gets_an_expiry() {
+        let db = MockDb::default();
+        let uid = user(&db, 1).await;
+        let (sub_id, pid) = subscription_with(&db, uid, &[(0, 5000)]).await;
+
+        let payment = db.get_subscription_payment(&pid).await.unwrap();
+        db.subscription_payment_paid(&payment).await.unwrap();
+
+        let sub = db.get_subscription(sub_id).await.unwrap();
+        assert_eq!(sub.expires, None, "a one-off fee was given an expiry");
+        // ...but it is still activated: the expiry UPDATE is also what sets
+        // these, so skipping it wholesale would leave a paid fee looking unpaid.
+        assert!(sub.is_active, "paid fee left inactive");
+        assert!(sub.is_setup, "paid fee left un-set-up");
+    }
+
+    /// The narrow half of the rule. A recurring subscription must keep expiring
+    /// exactly as before — this branch sits in the shared payment path.
+    #[tokio::test]
+    async fn a_recurring_subscription_still_expires() {
+        let db = MockDb::default();
+        let uid = user(&db, 1).await;
+        let (sub_id, pid) = subscription_with(&db, uid, &[(1000, 500)]).await;
+
+        let payment = db.get_subscription_payment(&pid).await.unwrap();
+        db.subscription_payment_paid(&payment).await.unwrap();
+
+        let sub = db.get_subscription(sub_id).await.unwrap();
+        assert!(
+            sub.expires.is_some(),
+            "a recurring subscription stopped expiring — renewals would never be billed"
+        );
+    }
+
+    /// The case that makes the rule "no recurring amount AND a setup fee"
+    /// rather than just "no recurring amount": a free or fully-discounted
+    /// subscription has neither, and must still lapse on schedule.
+    #[tokio::test]
+    async fn a_free_subscription_still_expires() {
+        let db = MockDb::default();
+        let uid = user(&db, 1).await;
+        let (sub_id, pid) = subscription_with(&db, uid, &[(0, 0)]).await;
+
+        let payment = db.get_subscription_payment(&pid).await.unwrap();
+        db.subscription_payment_paid(&payment).await.unwrap();
+
+        let sub = db.get_subscription(sub_id).await.unwrap();
+        assert!(
+            sub.expires.is_some(),
+            "a zero-amount subscription stopped expiring — it would never be cleaned up"
+        );
+    }
+
+    /// Mirrors `uk_marketplace_node_line_item`. Without it two nodes could
+    /// point at one paid fee, turning the per-node gate into a per-operator one.
+    #[tokio::test]
+    async fn one_paid_fee_covers_one_node() {
+        let db = MockDb::default();
+        let uid = user(&db, 1).await;
+        let op = db
+            .insert_marketplace_operator(&operator(uid))
+            .await
+            .unwrap();
+        let (_, _) = subscription_with(&db, uid, &[(0, 5000)]).await;
+        let li = db.list_subscription_line_items(1).await.unwrap()[0].id;
+
+        db.insert_marketplace_node(&MarketplaceNode {
+            subscription_line_item_id: Some(li),
+            ..node(op, "first")
+        })
+        .await
+        .unwrap();
+
+        let err = db
+            .insert_marketplace_node(&MarketplaceNode {
+                subscription_line_item_id: Some(li),
+                ..node(op, "second")
+            })
+            .await
+            .expect_err("two nodes shared one listing fee");
+        assert!(format!("{err}").contains("already bills"), "got: {err}");
+
+        // ...and the same must hold on update, not just insert.
+        let other = db
+            .insert_marketplace_node(&node(op, "third"))
+            .await
+            .unwrap();
+        let mut steal = db.get_marketplace_node(other).await.unwrap();
+        steal.subscription_line_item_id = Some(li);
+        assert!(db.update_marketplace_node(&steal).await.is_err());
+
+        // The fee resolves back to the node it paid for.
+        let found = db.get_marketplace_node_by_line_item(li).await.unwrap();
+        assert_eq!(found.name, "first");
     }
 
     /// Mirrors `uk_marketplace_node_tls_fingerprint`: two nodes serving the

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -114,6 +114,18 @@ pub struct MockDb {
 }
 
 impl MockDb {
+    /// Set a company's one-off marketplace node listing fee.
+    ///
+    /// Test support: the fee is normally set through the admin API, which is
+    /// behind a feature the consumer API crate does not enable, so its tests
+    /// cannot reach `admin_update_company`.
+    pub async fn set_marketplace_node_fee(&self, company_id: u64, fee: u64) {
+        let mut companies = self.companies.lock().await;
+        if let Some(company) = companies.get_mut(&company_id) {
+            company.marketplace_node_fee = fee;
+        }
+    }
+
     /// The `uk_tunnel_*` unique keys: a peer key or an inner address may belong
     /// to at most one tunnel. Two tunnels sharing an inner address is a routing
     /// collision that delivers one tenant's traffic to another, so the mock

--- a/lnvps_api_common/src/model.rs
+++ b/lnvps_api_common/src/model.rs
@@ -965,6 +965,9 @@ pub enum ApiSubscriptionLineItemResource {
     /// A managed app deployment.
     #[serde(rename = "app")]
     App { app_deployment_id: u64 },
+    /// A marketplace node's one-off listing fee.
+    #[serde(rename = "marketplace_node")]
+    MarketplaceNode { marketplace_node_id: u64 },
 }
 
 impl ApiSubscriptionLineItemResource {
@@ -1004,6 +1007,13 @@ impl ApiSubscriptionLineItemResource {
                 .ok()
                 .map(|d| Self::App {
                     app_deployment_id: d.id,
+                }),
+            SubscriptionType::MarketplaceNodeFee => db
+                .get_marketplace_node_by_line_item(line_item.id)
+                .await
+                .ok()
+                .map(|n| Self::MarketplaceNode {
+                    marketplace_node_id: n.id,
                 }),
             SubscriptionType::DnsHosting => None,
         }

--- a/lnvps_db/migrations/20260807120000_marketplace_node_fee.sql
+++ b/lnvps_db/migrations/20260807120000_marketplace_node_fee.sql
@@ -1,0 +1,37 @@
+-- Marketplace node listing fee.
+--
+-- A node is registered for free and reviewed for free, but an admin cannot
+-- approve it until its fee is paid. The fee is per node, so paying once does
+-- not let an operator list an unlimited number of machines, and it is
+-- non-refundable: it buys the review and the listing, not a deposit LNVPS has
+-- to custody and return.
+--
+-- The fee reuses the subscription machinery rather than adding a second
+-- invoice-backed payments table. That is not a shortcut: `subscription_payment`
+-- is the only table the Lightning settlement listener resolves against, and its
+-- resume cursor is `last_paid_subscription_invoice`. A separate table would
+-- have to extend both, and a paid fee that missed either would settle into a
+-- "not found" log line and be lost.
+
+-- The default fee for nodes listed under this company, in the company's
+-- `base_currency` (same convention as `marketplace_rate`). 0 means no fee is
+-- required, which makes the approval gate a no-op — the intended state for a
+-- company that does not run a marketplace.
+ALTER TABLE company
+    ADD COLUMN marketplace_node_fee BIGINT UNSIGNED NOT NULL DEFAULT 0;
+
+-- The line item whose payment covers this node's listing fee.
+--
+-- Follows the established back-reference direction (`vm.subscription_line_item_id`,
+-- `ip_range_subscription.subscription_line_item_id`): the product row points at
+-- its line item, never the other way round, so `subscription_line_item` stays
+-- free of per-product columns.
+--
+-- Unique: one line item bills for exactly one node. Without this, two nodes
+-- could point at the same paid fee and the per-node gate would silently become
+-- a per-operator one — precisely the model that was rejected.
+ALTER TABLE marketplace_node
+    ADD COLUMN subscription_line_item_id INTEGER UNSIGNED NULL DEFAULT NULL,
+    ADD UNIQUE KEY uk_marketplace_node_line_item (subscription_line_item_id),
+    ADD CONSTRAINT fk_marketplace_node_line_item
+        FOREIGN KEY (subscription_line_item_id) REFERENCES subscription_line_item (id);

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -1118,6 +1118,15 @@ pub trait LNVpsDbBase: Send + Sync {
         fingerprint: &[u8],
     ) -> DbResult<MarketplaceNode>;
 
+    /// Get the marketplace node whose listing fee is billed by `line_item_id`.
+    ///
+    /// The back-reference direction matches `vm.subscription_line_item_id`: the
+    /// node points at its line item, so this is a lookup, not a join table.
+    async fn get_marketplace_node_by_line_item(
+        &self,
+        line_item_id: u64,
+    ) -> DbResult<MarketplaceNode>;
+
     /// List the nodes belonging to one operator
     async fn list_marketplace_nodes(&self, operator_id: u64) -> DbResult<Vec<MarketplaceNode>>;
 

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -1877,6 +1877,10 @@ pub struct MarketplaceNode {
     pub tunnel_id: Option<u64>,
     /// Last control-channel contact. `None` until the node first connects.
     pub last_seen: Option<DateTime<Utc>>,
+    /// The line item whose payment covers this node's one-off listing fee.
+    /// `None` until the operator starts the purchase. A node cannot be approved
+    /// until the subscription behind this line item is paid.
+    pub subscription_line_item_id: Option<u64>,
     /// When this node was registered
     pub created: DateTime<Utc>,
 }
@@ -2029,6 +2033,11 @@ pub struct Company {
     /// share for this company.
     #[sqlx(default)]
     pub marketplace_rate: f32,
+    /// One-off fee charged per marketplace node before it can be approved, in
+    /// this company's `base_currency`. `0` requires no fee, which makes the
+    /// approval gate a no-op.
+    #[sqlx(default)]
+    pub marketplace_node_fee: u64,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -2547,6 +2556,13 @@ pub enum SubscriptionType {
     DnsHosting = 2,    // DNS hosting services
     Vps = 3,           // VM (links to vm table via vm.subscription_line_item_id)
     App = 4, // Managed app deployment (links via app_deployment.subscription_line_item_id)
+    /// One-off marketplace node listing fee (links via
+    /// `marketplace_node.subscription_line_item_id`).
+    ///
+    /// Unlike every other variant this bills nothing recurring: the line item
+    /// carries a `setup_amount` and an `amount` of zero, so the subscription
+    /// never renews and never expires. See `subscription_payment_paid`.
+    MarketplaceNodeFee = 5,
 }
 
 impl Display for SubscriptionType {
@@ -2557,6 +2573,7 @@ impl Display for SubscriptionType {
             SubscriptionType::DnsHosting => write!(f, "DNS Hosting"),
             SubscriptionType::Vps => write!(f, "VPS"),
             SubscriptionType::App => write!(f, "App"),
+            SubscriptionType::MarketplaceNodeFee => write!(f, "Marketplace Node Fee"),
         }
     }
 }

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -2981,14 +2981,20 @@ impl LNVpsDbBase for LNVpsDbMysql {
         // amount, so it describes a one-off purchase and nothing else. A free or
         // fully-discounted recurring subscription has neither, and keeps today's
         // behaviour of expiring on schedule — a zero-amount VM must still lapse.
-        let recurring: Option<(i64, i64)> = sqlx::query_as(
-            "SELECT COALESCE(SUM(amount), 0), COALESCE(SUM(setup_amount), 0) \
-             FROM subscription_line_item WHERE subscription_id = ?",
+        // EXISTS rather than SUM: MySQL types SUM() as DECIMAL, which sqlx will
+        // not decode into an integer, and the error would surface here — in the
+        // statement that marks money as received — as every payment silently
+        // failing to settle.
+        let (has_recurring, has_setup): (i64, i64) = sqlx::query_as(
+            "SELECT \
+               EXISTS(SELECT 1 FROM subscription_line_item WHERE subscription_id = ? AND amount > 0), \
+               EXISTS(SELECT 1 FROM subscription_line_item WHERE subscription_id = ? AND setup_amount > 0)",
         )
         .bind(payment.subscription_id)
-        .fetch_optional(tx.as_mut())
+        .bind(payment.subscription_id)
+        .fetch_one(tx.as_mut())
         .await?;
-        let one_off = matches!(recurring, Some((0, setup)) if setup > 0);
+        let one_off = has_recurring == 0 && has_setup == 1;
 
         if one_off {
             // Still activate it: the expiry UPDATE below is also what sets

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -2970,7 +2970,35 @@ impl LNVpsDbBase for LNVpsDbMysql {
         .execute(tx.as_mut())
         .await?;
 
-        if let Some(time_value) = payment.time_value {
+        // A subscription that bills nothing recurring has nothing to renew, so
+        // it must never acquire an expiry. Without this branch a one-off
+        // purchase (a marketplace node listing fee) would be given an expiry by
+        // the code below, and `check_subscriptions` would then mail the customer
+        // "your subscription will expire soon" for something they bought
+        // outright.
+        //
+        // Deliberately narrow: it requires a setup fee *and* no recurring
+        // amount, so it describes a one-off purchase and nothing else. A free or
+        // fully-discounted recurring subscription has neither, and keeps today's
+        // behaviour of expiring on schedule — a zero-amount VM must still lapse.
+        let recurring: Option<(i64, i64)> = sqlx::query_as(
+            "SELECT COALESCE(SUM(amount), 0), COALESCE(SUM(setup_amount), 0) \
+             FROM subscription_line_item WHERE subscription_id = ?",
+        )
+        .bind(payment.subscription_id)
+        .fetch_optional(tx.as_mut())
+        .await?;
+        let one_off = matches!(recurring, Some((0, setup)) if setup > 0);
+
+        if one_off {
+            // Still activate it: the expiry UPDATE below is also what sets
+            // `is_active` and `is_setup`, so skipping it wholesale would leave a
+            // paid fee looking unpaid.
+            sqlx::query("UPDATE subscription SET is_active = 1, is_setup = 1 WHERE id = ?")
+                .bind(payment.subscription_id)
+                .execute(tx.as_mut())
+                .await?;
+        } else if let Some(time_value) = payment.time_value {
             // Extend subscription.expires by explicit time_value seconds
             sqlx::query(
                 "UPDATE subscription SET expires = DATE_ADD(GREATEST(COALESCE(expires, NOW()), NOW()), INTERVAL ? SECOND), is_active = 1, is_setup = 1 WHERE id = ?",
@@ -4065,10 +4093,22 @@ impl LNVpsDbBase for LNVpsDbMysql {
         })
     }
 
+    async fn get_marketplace_node_by_line_item(
+        &self,
+        line_item_id: u64,
+    ) -> DbResult<MarketplaceNode> {
+        Ok(
+            sqlx::query_as("SELECT * FROM marketplace_node WHERE subscription_line_item_id = ?")
+                .bind(line_item_id)
+                .fetch_one(&self.db)
+                .await?,
+        )
+    }
+
     async fn insert_marketplace_node(&self, node: &MarketplaceNode) -> DbResult<u64> {
         let res = sqlx::query(
-            "INSERT INTO marketplace_node (operator_id, name, tls_fingerprint, token_version, status, trust_tier, tunnel_id, last_seen) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?) returning id",
+            "INSERT INTO marketplace_node (operator_id, name, tls_fingerprint, token_version, status, trust_tier, tunnel_id, last_seen, subscription_line_item_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) returning id",
         )
         .bind(node.operator_id)
         .bind(&node.name)
@@ -4078,6 +4118,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         .bind(node.trust_tier)
         .bind(node.tunnel_id)
         .bind(node.last_seen)
+        .bind(node.subscription_line_item_id)
         .fetch_one(&self.db)
         .await?;
         Ok(res.try_get(0)?)
@@ -4086,7 +4127,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
     async fn update_marketplace_node(&self, node: &MarketplaceNode) -> DbResult<()> {
         sqlx::query(
             "UPDATE marketplace_node \
-             SET name = ?, tls_fingerprint = ?, token_version = ?, status = ?, trust_tier = ?, tunnel_id = ? \
+             SET name = ?, tls_fingerprint = ?, token_version = ?, status = ?, trust_tier = ?, tunnel_id = ?, subscription_line_item_id = ? \
              WHERE id = ?",
         )
         .bind(&node.name)
@@ -4095,6 +4136,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         .bind(node.status)
         .bind(node.trust_tier)
         .bind(node.tunnel_id)
+        .bind(node.subscription_line_item_id)
         .bind(node.id)
         .execute(&self.db)
         .await?;
@@ -6227,8 +6269,8 @@ impl AdminDb for LNVpsDbMysql {
 
     async fn admin_create_company(&self, company: &Company) -> DbResult<u64> {
         let result = sqlx::query(
-            r#"INSERT INTO company (name, address_1, address_2, city, state, country_code, tax_id, postcode, phone, email, created, base_currency, referral_rate, max_prepay_days)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, ?, ?)"#,
+            r#"INSERT INTO company (name, address_1, address_2, city, state, country_code, tax_id, postcode, phone, email, created, base_currency, referral_rate, max_prepay_days, marketplace_rate, marketplace_node_fee)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, ?, ?, ?, ?)"#,
         )
         .bind(&company.name)
         .bind(&company.address_1)
@@ -6243,6 +6285,8 @@ impl AdminDb for LNVpsDbMysql {
             .bind(&company.base_currency)
         .bind(company.referral_rate)
         .bind(company.max_prepay_days)
+        .bind(company.marketplace_rate)
+        .bind(company.marketplace_node_fee)
         .execute(&self.db)
         .await?;
 
@@ -6253,7 +6297,8 @@ impl AdminDb for LNVpsDbMysql {
         sqlx::query(
             r#"UPDATE company SET 
                name = ?, address_1 = ?, address_2 = ?, city = ?, state = ?, 
-               country_code = ?, tax_id = ?, postcode = ?, phone = ?, email = ?, base_currency = ?, referral_rate = ?, max_prepay_days = ?
+               country_code = ?, tax_id = ?, postcode = ?, phone = ?, email = ?, base_currency = ?, referral_rate = ?, max_prepay_days = ?,
+               marketplace_rate = ?, marketplace_node_fee = ?
                WHERE id = ?"#,
         )
         .bind(&company.name)
@@ -6269,6 +6314,8 @@ impl AdminDb for LNVpsDbMysql {
         .bind(&company.base_currency)
         .bind(company.referral_rate)
         .bind(company.max_prepay_days)
+        .bind(company.marketplace_rate)
+        .bind(company.marketplace_node_fee)
         .bind(company.id)
         .execute(&self.db)
         .await?;

--- a/work/marketplace.md
+++ b/work/marketplace.md
@@ -607,8 +607,37 @@ than as a unique-index violation. Another operator's node answers "not found" ra
 "forbidden", so ids cannot be probed. `GET /api/v1/node/self` is the node-authenticated
 endpoint that proves the token works end to end.
 
+16. **Listing a node costs a one-off, non-refundable, per-node fee, and the gate sits at
+   approval.** An operator registers and is reviewed for free, then pays before an admin can
+   approve — so hardware is vetted before money changes hands and rejected hardware costs its
+   operator nothing. Per node, because one payment unlocking an unlimited fleet prices spam
+   only once. Non-refundable, so LNVPS never custodies operator money and needs no return or
+   slashing procedure. Consequences that had to be built:
+   - **The fee is a `SubscriptionType::MarketplaceNodeFee`, not a new payments table.**
+     `subscription_payment` is the only table the Lightning settlement listener resolves
+     against, and its resume cursor is `last_paid_subscription_invoice`. A parallel table
+     would have to extend both, and a paid fee that missed either would settle into a
+     "not found" log line and be lost.
+   - **A one-off must never acquire an expiry.** No path through `subscription_payment_paid`
+     left `expires` NULL, so a paid fee would have been dunned by `check_subscriptions`.
+     One-offs are now recognised from the data — no recurring amount *and* a setup fee — and
+     keep `expires` NULL, which every expiry query already filters on. The rule is narrow on
+     purpose: a free or fully-discounted subscription has neither, and must keep lapsing.
+   - **The same UPDATE sets `is_active`/`is_setup`**, so the one-off branch sets them
+     explicitly rather than leaving a paid fee looking unpaid.
+   - **The company comes from a region the operator names when paying**, since a fresh node
+     belongs to no region and every other product derives its company from what is bought.
+
 **3b — admin approval (next):** approve/reject/suspend/drain, trust tier, capacity caps, the
-per-operator rate override, and creating the backing `VmHost` row on approval.
+per-operator rate override, and creating the backing `VmHost` row on approval. Approval is
+gated on a paid listing fee (decision 16) and on a pinned certificate — a node that never
+registered one cannot be reached. Reject deletes the registration (no `Rejected` state), so an
+operator may re-register the same hardware. Approval takes a `region_id` and creates the host
+`enabled = false` with an empty `ip`, filled in by increment 4 when the tunnel is allocated;
+a blank ip must be a hard error wherever a host is dialled, never a silent failure.
+`AdminResource::MarketplaceNode` (28) covers placement state and `MarketplaceOperator` (29)
+covers payout and revenue share, so suspending a node and changing what someone is paid are
+separately grantable.
 
 **Original scope:**
 - `POST /api/v1/node/register` under standard consumer auth → node bound to the calling user,


### PR DESCRIPTION
Operators register hardware for free and have it reviewed for free, but an admin cannot approve a node until its listing fee is paid. Per node, so paying once does not license a fleet. Non-refundable, so LNVPS never custodies operator money and needs no return or slashing procedure.

## Why the fee is a subscription, not a new payments table

`subscription_payment` is the **only** table the Lightning settlement listener resolves against (`invoice.rs` → `get_subscription_payment`), and its resume cursor is `last_paid_subscription_invoice`. A parallel `marketplace_bond` table would have had to extend both — and a paid fee that missed either would settle into a `not found` log line and be lost.

## The problem that modelling it as a subscription created

There is **no path through `subscription_payment_paid` that leaves `expires` NULL** — both branches set it. So a paid one-off would acquire an expiry, and `check_subscriptions` would start mailing the operator *"your subscription will expire soon"* about something they bought outright.

One-offs are now recognised from the data rather than a flag: a subscription that bills nothing recurring but carries a setup fee has nothing to renew, so `expires` stays NULL — which every expiry query already filters on with `expires IS NOT NULL`.

**The narrowness is the point.** The rule requires a setup fee *and* no recurring amount. Checking only "no recurring amount" would have swept in free and fully-discounted subscriptions, which have neither — and a zero-amount VM that stopped expiring would never be cleaned up.

Verified against MariaDB across all three shapes:

| Subscription | SUM(amount) | SUM(setup_amount) | one-off? |
|---|---|---|---|
| Node listing fee | 0 | 5000 | **yes** |
| Paid VPS | 1000 | 0 | no |
| Free VPS | 0 | 0 | no — must still lapse |

There was a second trap in the same statement: the expiry UPDATE is also what sets `is_active` and `is_setup`. Skipping it wholesale would have left a paid fee looking unpaid, so the one-off branch sets them explicitly.

## Schema

`uk_marketplace_node_line_item` makes one paid fee cover exactly one node — without it two nodes could point at the same payment and the per-node gate would silently degrade into the per-operator model that was rejected. Confirmed against MariaDB: sharing a fee gives `1062`, a dangling line item gives `1452`.

The mock enforces the unique key and the FK, so tests about them are not fiction.

## Endpoint

`POST /api/v1/marketplace/nodes/{id}/fee { region_id }`, paid through the normal subscription renewal endpoint.

The region is a parameter because a subscription needs a `company_id`, and every other product derives one from the thing being bought (IP range → IP space, VM → host region). A node that has just registered belongs to no region, so there is nothing to derive it from. Naming the target region supplies the company and currency, and tells the reviewing admin where the hardware is meant to live.

## Mutation testing

Every run included a control on unmutated code:

| Guard disabled | Result |
|---|---|
| Give one-off fees an expiry (the dunning regression) | caught |
| Treat free subscriptions as one-off | caught |
| Leave a paid one-off inactive | caught |
| Share one fee between two nodes (insert) | caught |
| Share one fee between two nodes (update) | caught |
| Create a second fee subscription per node | caught |
| Invoice a zero fee that can never be paid | caught |
| Bill the fee as recurring | caught |
| Never link the fee to the node it paid for | caught |

The fee handler provisions nothing — paying makes a node *approvable*, an admin still approves it — and its expiry callbacks `bail!` rather than no-op, because reaching them means the one-off invariant broke, and quietly deactivating a node whose operator paid in full is the worst available outcome.

No new clippy warnings (281 before and after).

Next (3b): admin approve/reject/suspend/drain, with approval gated on this fee and on a pinned certificate.