### PR TITLE
Keep the support chat connected, and stop its conversation growing forever

### DIFF
--- a/lnvps_agent/src/agent/mod.rs
+++ b/lnvps_agent/src/agent/mod.rs
@@ -36,8 +36,62 @@ fn truncate_chars(s: &str, max: usize) -> String {
     s.chars().take(max).collect()
 }
 
+/// Render the text handed to the model for summarisation.
+///
+/// Pulled out of [`SupportAgent::compact`] so the deterministic fallback
+/// summarises exactly what the model was asked to, and so both can be tested
+/// without a provider.
+fn compaction_transcript(summary: Option<&str>, messages: &[ChatMessage]) -> String {
+    let mut transcript = String::new();
+    if let Some(existing) = summary {
+        transcript.push_str("Existing summary (incorporate into your updated summary):\n");
+        transcript.push_str(existing);
+        transcript.push_str("\n\nNew exchanges to fold in:\n");
+    }
+    for message in messages {
+        transcript.push_str(&message.transcript_line());
+        transcript.push('\n');
+    }
+    transcript
+}
+
+/// Summarise a transcript without the model: keep the head, mark the cut.
+///
+/// Used when the provider cannot produce a summary. The head is kept rather
+/// than the tail because the recent messages are retained verbatim in the
+/// replay window (see [`FALLBACK_TAIL`]) and would otherwise be duplicated;
+/// what this preserves is the older context that is about to leave the window
+/// for good.
+///
+/// The marker is not decoration: without it the model reads a transcript that
+/// stops mid-sentence as a complete account of the conversation, and answers
+/// confidently from a history it cannot see the end of.
+fn fallback_summary(transcript: &str) -> String {
+    let kept = truncate_chars(transcript, FALLBACK_SUMMARY_CHARS);
+    if kept.chars().count() < transcript.chars().count() {
+        format!(
+            "[Automatic summary unavailable; earlier conversation truncated.]\n{kept}\n[… earlier detail omitted …]"
+        )
+    } else {
+        format!("[Automatic summary unavailable; raw transcript follows.]\n{kept}")
+    }
+}
+
 /// Number of stored chat messages that triggers a compaction pass.
 const COMPACTION_THRESHOLD: usize = 30;
+
+/// Messages kept in the replay window when compaction falls back to the
+/// deterministic path.
+///
+/// Small enough that the next turn is cheap, large enough that the immediate
+/// back-and-forth ("do it" / "which one?") is not cut mid-exchange.
+const FALLBACK_TAIL: usize = 6;
+
+/// Characters of transcript retained by the deterministic fallback summary.
+///
+/// A bounded, dumb summary. The point is that the replay window stops growing,
+/// not that the text is good.
+const FALLBACK_SUMMARY_CHARS: usize = 2000;
 
 /// Maximum tool-calling iterations for a general (public) request.
 const PUBLIC_MAX_ITERATIONS: usize = 5;
@@ -657,8 +711,20 @@ impl SupportAgent {
                 sender_id,
                 conv.messages.len()
             );
+            // Not swallowed: `compact` only returns `Err` once the deterministic
+            // fallback has *also* failed, which means the store itself is
+            // refusing writes. Nothing here can recover from that, but the log
+            // must say that the replay window is now growing without bound —
+            // the previous message ("Failed to compact") read as a transient
+            // per-turn blip and hid exactly that.
             if let Err(e) = self.compact(sender_id).await {
-                log::error!("Failed to compact conversation for {}: {}", sender_id, e);
+                log::error!(
+                    "Conversation for {} could not be compacted or truncated ({}); \
+                     the replay window is unbounded and every turn will now be \
+                     slower and more expensive than the last",
+                    sender_id,
+                    e
+                );
             }
         }
     }
@@ -677,17 +743,68 @@ impl SupportAgent {
             return Ok(());
         }
 
-        let mut transcript = String::new();
-        if let Some(ref existing) = conv.summary {
-            transcript.push_str("Existing summary (incorporate into your updated summary):\n");
-            transcript.push_str(existing);
-            transcript.push_str("\n\nNew exchanges to fold in:\n");
-        }
-        for message in &conv.messages {
-            transcript.push_str(&message.transcript_line());
-            transcript.push('\n');
-        }
+        let transcript = compaction_transcript(conv.summary.as_deref(), &conv.messages);
+        let message_count = conv.messages.len();
 
+        // A summary the model wrote is better than one we cut with scissors, so
+        // that is tried first — but it must not be the only option. When it
+        // fails the conversation still has to stop growing, because every
+        // uncompacted message is replayed on every subsequent turn: the cost of
+        // a turn rises, its latency rises with it, and the transcript this very
+        // function has to summarise gets larger, so the next attempt is *more*
+        // likely to fail than this one was. That is a doom loop, and it is what
+        // ran in production — 31, 33, 35, 39 messages within minutes, every
+        // attempt failing, until turns were slow enough to be cut off by the
+        // proxy in front of the API.
+        //
+        // The trade-off is deliberate and one-directional: a worse summary is
+        // better than an unbounded one. The fallback keeps the tail verbatim
+        // and truncates the rest, which loses detail from the middle of a long
+        // conversation but bounds what is replayed forever after.
+        let (summary, cursor) = match self.llm_summary(&transcript).await {
+            Ok(summary) => {
+                log::info!(
+                    "Compacted conversation for {}: {} messages -> {} chars summary",
+                    sender_id,
+                    message_count,
+                    summary.len()
+                );
+                // Pass back the cursor from the snapshot we actually
+                // summarised, so a message that arrived mid-summarisation stays
+                // in the replay window.
+                (summary, conv.cursor)
+            }
+            Err(e) => {
+                let tail = FALLBACK_TAIL.min(message_count);
+                let kept = message_count - tail;
+                log::warn!(
+                    "LLM compaction failed for {} ({}); falling back to truncation: \
+                     {} messages summarised verbatim, {} most recent kept",
+                    sender_id,
+                    e,
+                    kept,
+                    tail
+                );
+                (
+                    fallback_summary(&transcript),
+                    // Only advance past what the fallback actually folded in.
+                    // Keeping a tail means the customer's most recent exchange
+                    // survives compaction verbatim rather than being reduced to
+                    // a truncated line.
+                    conv.cursor.saturating_sub(tail as u64),
+                )
+            }
+        };
+
+        self.store.compact(sender_id, summary, cursor).await
+    }
+
+    /// Ask the model for a summary of `transcript`.
+    ///
+    /// Separated from [`Self::compact`] so that a provider that cannot produce
+    /// one is an ordinary `Err` the caller can fall back from, rather than the
+    /// end of compaction.
+    async fn llm_summary(&self, transcript: &str) -> Result<String> {
         let client = self.openai_client();
         let messages: Vec<ChatCompletionRequestMessage> = vec![
             ChatCompletionRequestSystemMessageArgs::default()
@@ -704,30 +821,48 @@ impl SupportAgent {
 
         let request = CreateChatCompletionRequestArgs::default()
             .model(&self.openai.model)
-            .max_completion_tokens(1024u32)
+            // Was hardcoded to 1024, which is what broke this in production.
+            // The configured model is a reasoning model whose thinking tokens
+            // are charged against this budget and are *not* returned in
+            // `content`, so a long transcript consumed the entire allowance
+            // before a single character of summary was emitted: the response
+            // came back `finish_reason: "length"` with `content: null`. Using
+            // the operator's own budget (`max-tokens`, 16384 in production)
+            // makes the ceiling one an operator can raise for their model
+            // instead of one compiled in for a non-reasoning one.
+            .max_completion_tokens(self.max_tokens())
             .messages(messages)
             .build()?;
 
         let response = client.chat().create(request).await?;
-        let summary = response
+        let choice = response
             .choices
             .first()
-            .ok_or_else(|| anyhow!("LLM returned no choices"))?
-            .message
-            .content
-            .clone()
-            .ok_or_else(|| anyhow!("LLM returned empty summary"))?;
+            .ok_or_else(|| anyhow!("LLM returned no choices"))?;
 
-        log::info!(
-            "Compacted conversation for {}: {} messages -> {} chars summary",
-            sender_id,
-            conv.messages.len(),
-            summary.len()
-        );
+        // `refusal` is a separate field, so a model that declines to summarise
+        // reports it here while `content` stays `None`. Naming it turns "empty
+        // summary" into the actual reason.
+        if let Some(refusal) = choice.message.refusal.as_deref().map(str::trim)
+            && !refusal.is_empty()
+        {
+            return Err(anyhow!("LLM refused to summarise: {refusal}"));
+        }
 
-        // Pass back the cursor from the snapshot we actually summarised, so a
-        // message that arrived mid-summarisation stays in the replay window.
-        self.store.compact(sender_id, summary, conv.cursor).await
+        // Treat whitespace-only content as absent: it is no more usable as a
+        // summary than `None`, and the two arrive interchangeably depending on
+        // the provider.
+        match choice.message.content.as_deref().map(str::trim) {
+            Some(summary) if !summary.is_empty() => Ok(summary.to_string()),
+            _ => Err(anyhow!(
+                "LLM returned no summary text (finish_reason: {}); \
+                 a reasoning model can exhaust max-tokens before emitting content",
+                choice
+                    .finish_reason
+                    .map(|r| format!("{r:?}"))
+                    .unwrap_or_else(|| "none".to_string()),
+            )),
+        }
     }
 
     pub async fn process_request(
@@ -1044,5 +1179,61 @@ mod tests {
                 .iter()
                 .all(|s| matches!(s.r#type, ChatCompletionToolType::Function))
         );
+    }
+
+    /// The transcript must carry the previous summary as well as the new
+    /// messages: dropping it would make each compaction forget everything the
+    /// one before it had already condensed.
+    #[test]
+    fn compaction_transcript_folds_in_the_existing_summary() {
+        let messages = vec![ChatMessage::user("vm 7 is down")];
+
+        let without = compaction_transcript(None, &messages);
+        assert!(without.contains("User: vm 7 is down"));
+        assert!(!without.contains("Existing summary"));
+
+        let with = compaction_transcript(Some("customer owns vm 7"), &messages);
+        assert!(with.contains("customer owns vm 7"));
+        assert!(with.contains("User: vm 7 is down"));
+    }
+
+    /// The fallback exists to bound the replay window, so its output must be
+    /// bounded no matter how large the conversation got.
+    #[test]
+    fn fallback_summary_is_bounded_and_says_it_was_truncated() {
+        let huge = "User: please help with my vm\n".repeat(5_000);
+        let summary = fallback_summary(&huge);
+
+        assert!(summary.chars().count() < huge.chars().count());
+        assert!(
+            summary.chars().count() < FALLBACK_SUMMARY_CHARS + 200,
+            "summary was {} chars",
+            summary.chars().count()
+        );
+        // Without the marker the model reads a transcript that stops
+        // mid-sentence as the whole story.
+        assert!(summary.contains("truncated"));
+        assert!(summary.contains("omitted"));
+    }
+
+    /// A transcript already under the cap is kept whole, and is not labelled as
+    /// truncated when nothing was cut.
+    #[test]
+    fn fallback_summary_keeps_a_short_transcript_whole() {
+        let short = "User: hello\nAgent: hi\n";
+        let summary = fallback_summary(short);
+
+        assert!(summary.contains("User: hello"));
+        assert!(summary.contains("Agent: hi"));
+        assert!(!summary.contains("omitted"));
+    }
+
+    /// Multi-byte input must not panic the fallback (the cut is by character,
+    /// not by byte).
+    #[test]
+    fn fallback_summary_handles_multibyte() {
+        let emoji = "🚀".repeat(FALLBACK_SUMMARY_CHARS * 2);
+        let summary = fallback_summary(&emoji);
+        assert!(summary.contains("omitted"));
     }
 }

--- a/lnvps_agent/tests/compaction.rs
+++ b/lnvps_agent/tests/compaction.rs
@@ -1,0 +1,279 @@
+//! Tests for conversation compaction.
+//!
+//! These drive [`SupportAgent::compact`] against a mock OpenAI-compatible
+//! server, because the bug being guarded against is not in how a summary is
+//! rendered but in what happens when the provider does not return one: the
+//! replay window has to stop growing either way.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use lnvps_agent::agent::SupportAgent;
+use lnvps_agent::api_client::ApiClient;
+use lnvps_agent::conversation::{ChatMessage, ConversationStore, MemoryStore};
+use lnvps_agent::identity::SupportChannelKind;
+use lnvps_agent::settings::{OpenAiConfig, Settings};
+
+/// A throwaway nsec so `ApiClient` can be constructed; no request reaches the
+/// LNVPS API in these tests.
+const TEST_NSEC: &str = "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5";
+
+fn settings(base_url: String) -> Settings {
+    Settings {
+        listen: None,
+        admin_api_url: "http://127.0.0.1:1".to_string(),
+        user_api_url: "http://127.0.0.1:1".to_string(),
+        nsec: TEST_NSEC.to_string(),
+        openai: OpenAiConfig {
+            base_url,
+            api_key: Some("test".to_string()),
+            model: "test-model".to_string(),
+            max_tokens: Some(256),
+        },
+        system_prompt: None,
+        email: None,
+        kind1: None,
+        conversation_history_path: None,
+    }
+}
+
+fn agent_for(server: &MockServer, store: Arc<dyn ConversationStore>) -> SupportAgent {
+    let settings = settings(format!("{}/v1", server.uri()));
+    let api = Arc::new(ApiClient::new(&settings).expect("api client"));
+    SupportAgent::new(api, settings, store)
+}
+
+/// A non-streaming chat completion response body.
+fn completion(message: serde_json::Value, finish_reason: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "test-model",
+        "choices": [{ "index": 0, "message": message, "finish_reason": finish_reason }],
+    }))
+}
+
+/// Seed `store` with `count` messages so there is something to compact.
+async fn seed(store: &Arc<MemoryStore>, count: usize) -> Result<()> {
+    let messages: Vec<ChatMessage> = (0..count)
+        .map(|i| ChatMessage::user(format!("message number {i} about vm 1753")))
+        .collect();
+    store
+        .append("user:1", SupportChannelKind::WebChat, messages)
+        .await
+}
+
+/// The happy path: a provider that returns a summary gets it stored, and the
+/// whole replay window is cleared.
+#[tokio::test]
+async fn a_summary_from_the_model_is_stored() -> Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(completion(
+            serde_json::json!({ "role": "assistant", "content": "The customer asked about VM 1753." }),
+            "stop",
+        ))
+        .mount(&server)
+        .await;
+
+    let store = Arc::new(MemoryStore::new());
+    seed(&store, 10).await?;
+
+    agent_for(&server, store.clone()).compact("user:1").await?;
+
+    let conv = store.load("user:1").await;
+    assert_eq!(
+        conv.summary.as_deref(),
+        Some("The customer asked about VM 1753.")
+    );
+    assert!(
+        conv.messages.is_empty(),
+        "a real summary compacts the whole window"
+    );
+    Ok(())
+}
+
+/// Regression for the production outage: the configured model is a reasoning
+/// model whose thinking tokens are charged against `max_completion_tokens` and
+/// are not returned in `content`, so a long transcript came back
+/// `finish_reason: "length"` with `content: null`.
+///
+/// Before the fix this returned `Err("LLM returned empty summary")`, the caller
+/// logged and swallowed it, and the conversation never compacted — it grew 31,
+/// 33, 35, 39 messages within minutes, each turn replaying the whole history.
+/// Compaction must now still bound the window.
+#[tokio::test]
+async fn a_reasoning_model_that_returns_no_content_still_compacts() -> Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        // Exactly what https://yalr.v0l.io/v1 returned in production.
+        .respond_with(completion(
+            serde_json::json!({ "role": "assistant", "content": null }),
+            "length",
+        ))
+        .mount(&server)
+        .await;
+
+    let store = Arc::new(MemoryStore::new());
+    seed(&store, 40).await?;
+
+    // The call itself must succeed: a provider that cannot summarise is not a
+    // reason to leave the conversation unbounded.
+    agent_for(&server, store.clone()).compact("user:1").await?;
+
+    let conv = store.load("user:1").await;
+    assert!(
+        conv.summary.is_some(),
+        "the fallback must leave some memory behind"
+    );
+    assert!(
+        conv.messages.len() < 40,
+        "the replay window must shrink, got {} of 40",
+        conv.messages.len()
+    );
+    // The most recent exchange survives verbatim rather than being flattened
+    // into a truncated line.
+    assert!(
+        !conv.messages.is_empty(),
+        "a tail of recent messages is kept"
+    );
+    Ok(())
+}
+
+/// Compaction has to be able to run repeatedly against a broken provider
+/// without the window creeping upward — this is the property whose absence
+/// caused the incident.
+#[tokio::test]
+async fn repeated_failures_keep_the_window_bounded() -> Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(completion(
+            serde_json::json!({ "role": "assistant", "content": null }),
+            "length",
+        ))
+        .mount(&server)
+        .await;
+
+    let store = Arc::new(MemoryStore::new());
+    let agent = agent_for(&server, store.clone());
+
+    let mut sizes = Vec::new();
+    for _ in 0..5 {
+        // Each round adds a burst of traffic, as a busy conversation would.
+        seed(&store, 20).await?;
+        agent.compact("user:1").await?;
+        sizes.push(store.load("user:1").await.messages.len());
+    }
+
+    // Without the fallback every round would leave all 20 new messages behind
+    // and this would climb 20, 40, 60, 80, 100.
+    for size in &sizes {
+        assert!(
+            *size <= 20,
+            "replay window grew unbounded across rounds: {sizes:?}"
+        );
+    }
+    Ok(())
+}
+
+/// A model that declines names its reason in `refusal` while `content` stays
+/// `None`; the old code reported that as "empty summary".
+#[tokio::test]
+async fn a_refusal_is_reported_and_still_compacts() -> Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(completion(
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "refusal": "I cannot summarise this content."
+            }),
+            "stop",
+        ))
+        .mount(&server)
+        .await;
+
+    let store = Arc::new(MemoryStore::new());
+    seed(&store, 40).await?;
+
+    agent_for(&server, store.clone()).compact("user:1").await?;
+
+    let conv = store.load("user:1").await;
+    assert!(conv.summary.is_some());
+    assert!(conv.messages.len() < 40);
+    Ok(())
+}
+
+/// Whitespace-only content is no more usable than `None`, and providers return
+/// the two interchangeably.
+#[tokio::test]
+async fn whitespace_only_content_is_treated_as_no_summary() -> Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(completion(
+            serde_json::json!({ "role": "assistant", "content": "   \n  " }),
+            "stop",
+        ))
+        .mount(&server)
+        .await;
+
+    let store = Arc::new(MemoryStore::new());
+    seed(&store, 40).await?;
+
+    agent_for(&server, store.clone()).compact("user:1").await?;
+
+    let conv = store.load("user:1").await;
+    let summary = conv.summary.expect("fallback summary");
+    assert!(
+        !summary.trim().is_empty(),
+        "a blank summary is not a summary"
+    );
+    assert!(conv.messages.len() < 40);
+    Ok(())
+}
+
+/// A provider that is unreachable must fall back the same way — the window
+/// cannot depend on the provider being up.
+///
+/// Unreachable rather than 5xx on purpose: async-openai retries server errors
+/// with backoff, so a mocked 500 makes this test take ~15 minutes to assert
+/// something a refused connection proves in milliseconds.
+#[tokio::test]
+async fn a_provider_error_still_compacts() -> Result<()> {
+    let settings = settings("http://127.0.0.1:1/v1".to_string());
+    let api = Arc::new(ApiClient::new(&settings).expect("api client"));
+    let store = Arc::new(MemoryStore::new());
+    seed(&store, 40).await?;
+
+    SupportAgent::new(api, settings, store.clone())
+        .compact("user:1")
+        .await?;
+
+    let conv = store.load("user:1").await;
+    assert!(conv.summary.is_some());
+    assert!(conv.messages.len() < 40);
+    Ok(())
+}
+
+/// Nothing to compact is not a failure, and must not invent a summary.
+#[tokio::test]
+async fn an_empty_conversation_is_left_alone() -> Result<()> {
+    let server = MockServer::start().await;
+    let store = Arc::new(MemoryStore::new());
+
+    agent_for(&server, store.clone()).compact("user:1").await?;
+
+    let conv = store.load("user:1").await;
+    assert!(conv.summary.is_none());
+    assert!(conv.messages.is_empty());
+    Ok(())
+}

--- a/lnvps_api/Cargo.toml
+++ b/lnvps_api/Cargo.toml
@@ -135,6 +135,11 @@ uuid = { version = "1.16", features = ["v4", "serde"], optional = true }
 quick-xml = { version = "0.39", features = ["serde", "serialize"], optional = true }
 
 [dev-dependencies]
+# `test-util` gives the paused clock the support-chat keepalive tests drive, so
+# a 20s ping interval is asserted in microseconds instead of real time. A
+# dev-dependency on purpose: it must never reach the shipped binary, where it
+# would let time be paused at runtime.
+tokio = { workspace = true, features = ["test-util"] }
 # Loading back a probe key to prove the pair matches; the client itself lives
 # in lnvps_api_common.
 russh = "0.62"

--- a/lnvps_api/src/api/support.rs
+++ b/lnvps_api/src/api/support.rs
@@ -21,6 +21,7 @@
 //! Every message yields exactly one terminal frame (`final` or `error`).
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::ws::{Message, WebSocket};
 use futures::StreamExt;
@@ -58,6 +59,29 @@ async fn may_view_tool_activity(db: &Arc<dyn LNVpsDb>, user_id: u64) -> bool {
 /// Path the NIP-98 auth event must be signed against.
 pub(crate) const CHAT_PATH: &str = "/api/v1/support/chat";
 
+/// How often the server sends an unsolicited WebSocket ping.
+///
+/// A turn produces no frames while the model thinks and runs tools, which can
+/// run to minutes, so an otherwise healthy connection looks idle to anything in
+/// between. Reverse proxies close idle connections on a timer — nginx's
+/// `proxy_read_timeout` defaults to 60s, and that default is exactly what cut
+/// conversations mid-answer in production:
+///
+/// ```text
+/// WARN Support chat socket error for user 1:
+///      WebSocket protocol error: Connection reset without closing handshake
+/// ```
+///
+/// The server has to be the end that speaks, because a browser cannot send a
+/// ping frame from JavaScript — the WebSocket API exposes no such method — so
+/// the client physically cannot keep this connection alive by itself.
+///
+/// 20s gives three pings inside a 60s window, so a single dropped or delayed
+/// ping does not reach the timeout. Raising the proxy's timeout (as was done as
+/// an immediate mitigation) is not a substitute: this endpoint should not
+/// depend on every proxy in front of it being configured generously.
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+
 /// Serialize an event as a JSON text frame.
 fn frame(event: &ChatEvent) -> Message {
     // The enum is a plain tagged struct; serialization cannot realistically
@@ -72,6 +96,43 @@ fn frame(event: &ChatEvent) -> Message {
                     .into(),
             )
         }
+    }
+}
+
+/// The unsolicited ping the server sends to keep the connection alive.
+///
+/// Empty payload: a pong echoes the payload back, and nothing reads it. Built
+/// here rather than inline so the two call sites cannot drift.
+fn ping_frame() -> Message {
+    Message::Ping(Vec::new().into())
+}
+
+/// A keepalive clock for one connection.
+///
+/// Wraps [`tokio::time::interval`] only to make the two decisions that are easy
+/// to get wrong testable on their own: that the first tick does not fire
+/// immediately (which would ping a client that has not finished connecting),
+/// and that ticks are paced rather than burst after a long turn.
+struct Keepalive {
+    interval: tokio::time::Interval,
+}
+
+impl Keepalive {
+    /// Start a keepalive that first fires `period` from now.
+    fn new(period: Duration) -> Self {
+        let mut interval = tokio::time::interval(period);
+        // `interval` yields immediately on first poll; consume that so the
+        // first ping lands a full period in rather than at connect time.
+        interval.reset();
+        // A turn can outrun several periods. Missed ticks must not then fire
+        // back-to-back — the point is liveness, not making up lost pings.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        Self { interval }
+    }
+
+    /// Resolve when the next ping is due.
+    async fn tick(&mut self) {
+        self.interval.tick().await;
     }
 }
 
@@ -160,8 +221,30 @@ pub(crate) async fn v1_support_chat(
         if privileged { "visible" } else { "hidden" }
     );
 
+    // Ticks while waiting for a message *and* while a turn streams, because the
+    // streaming gap is the long one.
+    let mut ping = Keepalive::new(PING_INTERVAL);
+
     let mut turns = 0usize;
-    while let Some(incoming) = ws.recv().await {
+    loop {
+        let incoming = tokio::select! {
+            // Biased so a message already waiting is handled before a ping that
+            // came due in the same poll: pings are keepalive, not work.
+            biased;
+            incoming = ws.recv() => match incoming {
+                Some(incoming) => incoming,
+                None => break,
+            },
+            _ = ping.tick() => {
+                // A failed send means the peer is gone, exactly as it does on
+                // the streaming path.
+                if ws.send(ping_frame()).await.is_err() {
+                    break;
+                }
+                continue;
+            }
+        };
+
         let text = match incoming {
             Ok(Message::Text(text)) => text.to_string(),
             Ok(Message::Close(_)) => break,
@@ -205,12 +288,33 @@ pub(crate) async fn v1_support_chat(
 
         // Relay the turn. The stream always ends with a terminal event, so the
         // client can rely on one `final` or `error` per message it sends.
+        //
+        // Pings are interleaved here rather than only between turns because
+        // this is where the socket goes quiet for minutes. A ping is a control
+        // frame, so it does not appear in the client's message stream and the
+        // one-terminal-frame-per-message contract is untouched.
         let mut events = session.send(message);
         let mut client_gone = false;
-        while let Some(event) = events.next().await {
-            if ws.send(frame(&event)).await.is_err() {
-                client_gone = true;
-                break;
+        loop {
+            tokio::select! {
+                // Biased so a ready event is always sent before a due ping;
+                // reply latency is what the customer sees.
+                biased;
+                event = events.next() => match event {
+                    Some(event) => {
+                        if ws.send(frame(&event)).await.is_err() {
+                            client_gone = true;
+                            break;
+                        }
+                    }
+                    None => break,
+                },
+                _ = ping.tick() => {
+                    if ws.send(ping_frame()).await.is_err() {
+                        client_gone = true;
+                        break;
+                    }
+                }
             }
         }
         if client_gone {
@@ -268,5 +372,106 @@ mod tests {
     #[test]
     fn chat_path_matches_the_route() {
         assert_eq!(CHAT_PATH, "/api/v1/support/chat");
+    }
+
+    /// The keepalive is worthless if it does not fit inside the idle timeout of
+    /// whatever sits in front of the API. nginx's `proxy_read_timeout` default
+    /// is 60s, which is what closed these connections in production; leave room
+    /// for more than one ping inside that window so a single delayed ping is
+    /// not immediately fatal.
+    #[test]
+    fn ping_interval_fits_inside_a_default_proxy_timeout() {
+        let nginx_default = Duration::from_secs(60);
+        assert!(
+            PING_INTERVAL * 3 <= nginx_default,
+            "PING_INTERVAL {:?} leaves no margin under a {:?} idle timeout",
+            PING_INTERVAL,
+            nginx_default
+        );
+    }
+
+    /// A ping is a control frame, not a chat frame: it must never be something
+    /// the client would try to parse as a [`ChatEvent`], or the
+    /// one-terminal-frame-per-message contract would be broken by keepalive
+    /// traffic.
+    #[test]
+    fn a_ping_is_not_a_text_frame() {
+        assert!(matches!(ping_frame(), Message::Ping(_)));
+    }
+
+    /// The first ping must not go out at connect time — only after a full idle
+    /// period. `tokio::time::interval` fires immediately on first poll, so this
+    /// is the easy half of the bug to reintroduce.
+    #[tokio::test(start_paused = true)]
+    async fn the_first_ping_waits_a_full_interval() {
+        let mut keepalive = Keepalive::new(PING_INTERVAL);
+
+        // Nothing due yet, one tick short of the interval.
+        tokio::time::advance(PING_INTERVAL - Duration::from_millis(1)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(0), keepalive.tick())
+                .await
+                .is_err(),
+            "pinged before the first interval elapsed"
+        );
+
+        // Due now.
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(0), keepalive.tick())
+                .await
+                .is_ok(),
+            "no ping after a full interval"
+        );
+    }
+
+    /// A turn can run for minutes, outrunning several ping periods. The missed
+    /// ticks must not then fire back to back: that would put a burst of pings
+    /// on the wire the moment the turn ends, which is noise rather than
+    /// liveness.
+    #[tokio::test(start_paused = true)]
+    async fn missed_ticks_do_not_burst() {
+        let mut keepalive = Keepalive::new(PING_INTERVAL);
+
+        // Simulate a long turn during which nothing polled the keepalive.
+        tokio::time::advance(PING_INTERVAL * 5).await;
+
+        // The first tick is due immediately — that ping was owed.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(0), keepalive.tick())
+                .await
+                .is_ok()
+        );
+
+        // But the next one is a full period away, not owed four times over.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(0), keepalive.tick())
+                .await
+                .is_err(),
+            "missed ticks fired as a burst"
+        );
+        tokio::time::advance(PING_INTERVAL).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(0), keepalive.tick())
+                .await
+                .is_ok()
+        );
+    }
+
+    /// Pings keep coming for as long as the connection is idle; a keepalive
+    /// that fired once would not survive a long conversation.
+    #[tokio::test(start_paused = true)]
+    async fn pings_repeat_while_idle() {
+        let mut keepalive = Keepalive::new(PING_INTERVAL);
+
+        for i in 0..10 {
+            tokio::time::advance(PING_INTERVAL).await;
+            assert!(
+                tokio::time::timeout(Duration::from_millis(0), keepalive.tick())
+                    .await
+                    .is_ok(),
+                "keepalive stopped firing after {i} pings"
+            );
+        }
     }
 }


### PR DESCRIPTION
Two production bugs on the live-chat support agent, found in the logs on `api.lnvps.net` today. They compound: the second is what made the first fire as often as it did.

## The chat dropped mid-answer

An agent turn produces no frames while the model runs and calls tools, which takes minutes on a long conversation. Nothing else was on the wire either — the server never sent a ping, and axum answers client pings but originates none. A working connection was therefore indistinguishable from an abandoned one to anything sitting in between, and reverse proxies close idle connections on a timer.

In production that was the ingress default, `proxy_read_timeout: 60s`:

```
WARN Support chat socket error for user 1:
     WebSocket protocol error: Connection reset without closing handshake
```

The customer saw the reply stop and the connection drop for no stated reason, most often on exactly the questions worth asking — the ones the agent takes a while to answer.

**The server has to be the end that speaks.** A browser cannot originate a ping frame from JavaScript; the WebSocket API exposes no method for it. However the client is written, it cannot keep this connection open by itself.

The handler now pings every 20s from a `tokio::select!` over the receive future, the event stream and an interval — during a turn as well as between turns, since the streaming gap is the long one. A ping is a control frame, so it never enters the client's message stream and the one-terminal-frame-per-message contract is untouched; a failed ping send ends the connection exactly as a failed event send already did.

20s so that three pings fit inside a 60s window and one delayed ping is not fatal. The ingress timeout has already been raised as an immediate mitigation, but that is a property of one deployment's proxy — this endpoint should not need every proxy in front of it configured generously in order to work.

## Compaction failed every time, silently

```
INFO  Conversation for user:1 has 31 messages, triggering compaction
ERROR Failed to compact conversation for user:1: LLM returned empty summary
INFO  Conversation for user:1 has 33 messages, triggering compaction
ERROR Failed to compact conversation for user:1: LLM returned empty summary
```

31, 33, 35, 39 within minutes. Every uncompacted message is replayed on every later turn, so each turn got slower and more expensive than the last — which is what pushed turns past the proxy timeout above. Left alone it ends at the model's context limit, where the conversation stops working altogether.

**Cause:** a hardcoded `max_completion_tokens(1024)`. The configured model is a reasoning model, and its thinking tokens are charged against that budget while not being returned in `content`, so a long transcript consumed the entire allowance before a single character of summary was emitted.

Reproduced directly against the configured endpoint with a transcript the size of the one in the logs:

| `max_completion_tokens` | `finish_reason` | `content` | completion tokens |
|---|---|---|---|
| 1024 (was hardcoded) | `length` | `null` | 1024 |
| 4096 | `stop` | summary | 476 |

The budget was the binding constraint, not the length of the summary.

**Changes**, the last being the one that matters:

- The token budget now comes from the operator's own `max-tokens` (16384 in production) instead of a constant compiled in for a non-reasoning model.
- `refusal` is reported as itself. It is a separate field, so a model that declines left `content` as `None` and was reported as "empty summary" — the one case where the old message named the wrong cause. Whitespace-only content is treated as absent (providers return that and `None` interchangeably), and the error now names `finish_reason`.
- **Compaction no longer depends on the model succeeding.** When a summary cannot be obtained for any reason — refusal, no content, provider down — it falls back to a deterministic truncation: a bounded head of the transcript as the summary, the six most recent messages kept verbatim, cursor advanced past the rest.

The trade-off in that last point is deliberate: **a worse summary is better than an unbounded one.** Truncation loses detail from the middle of a long conversation, which is a real cost. The alternative is a window that grows until the conversation breaks, and it degrades in the worst possible way — a bigger transcript makes the *next* attempt more likely to fail than the one before it. That is the doom loop the logs show.

The call site no longer swallows the result. `compact` now only returns `Err` once the fallback has *also* failed, meaning the store itself is refusing writes; nothing can recover from that, but the log now says the window is unbounded and every turn will be slower than the last, rather than "Failed to compact" — which read as a transient per-turn blip and hid exactly that.

Not fixed by raising `COMPACTION_THRESHOLD`: that moves the number that triggers a broken path.

## Verified

- `cargo check -p lnvps_api -p lnvps_agent` — clean.
- `cargo test -p lnvps_agent` — 66 lib + 7 compaction + 9 streaming, all pass.
- `cargo test -p lnvps_api --lib` — 444 pass, run three times for flakes.
- `cargo clippy -p lnvps_api -p lnvps_agent --all-targets` — 246 warnings on this branch, 246 on `origin/master`; none in any file touched here.
- Both fixes were verified as genuine regression tests by reverting the fix and watching the new tests fail: 5 of the 7 compaction tests fail without the fallback, and each keepalive test fails if its corresponding line is removed.
- The compaction cause was confirmed empirically against the live configured endpoint, not inferred from the types (table above).

## Not verified

- **No live socket test.** The keepalive is tested through a `Keepalive` wrapper on a paused clock — first tick does not fire at connect time, missed ticks do not burst, pings repeat while idle — plus a static check that the interval fits inside a default proxy timeout. That the ping reaches a real browser through a real proxy is not covered by any test here; it needs a deployment.
- The fallback's *summary quality* is not asserted, only that it is bounded, marked as truncated, and keeps a verbatim tail. It is a worse summary by design.
- Whether the configured model can be made to emit content reliably at a larger budget for *any* transcript size is unknown — that is why the fallback exists rather than just the budget change.
