### PR TITLE
feat(catalog): add AppWeaver managed app

### DIFF
--- a/catalog/appweaver.yaml
+++ b/catalog/appweaver.yaml
@@ -7,9 +7,13 @@ services:
       - { name: http, container: 5551, protocol: http, expose: ingress }
     env:
       BOT_SETUP_UI_ORIGIN: "https://${HOSTNAME}"
+      BOT_MASTER_PUBKEY: "${master_pubkey}"
     volumes:
       - { name: workspace, path: /workspace/appweaver, size: 20Gi, label: files }
     scratch:
       - { path: /tmp, size: 256Mi }
     backup:
       volume: workspace
+config:
+  - { name: master_pubkey, label: "Master pubkey (64-character lowercase hex)", type: string,
+      required: true, pattern: "[0-9a-f]{64}" }

--- a/catalog/appweaver.yaml
+++ b/catalog/appweaver.yaml
@@ -1,0 +1,15 @@
+services:
+  appweaver:
+    image: ghcr.io/getappweaver/core:alpine
+    user: "1000"
+    resources: { cpu: 1, memory: 2Gi }
+    ports:
+      - { name: http, container: 5551, protocol: http, expose: ingress }
+    env:
+      BOT_SETUP_UI_ORIGIN: "https://${HOSTNAME}"
+    volumes:
+      - { name: workspace, path: /workspace/appweaver, size: 20Gi, label: files }
+    scratch:
+      - { path: /tmp, size: 256Mi }
+    backup:
+      volume: workspace

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -661,6 +661,10 @@ where the image allows it.
   the setup web UI. A provider that requires a callback to the user's localhost
   cannot be authenticated without a separate tunnel and should not be selected
   for a managed deployment.
+- **Setup access:** the order form requires the owner's 64-character lowercase
+  hex Nostr pubkey. AppWeaver receives it as `BOT_MASTER_PUBKEY`; `/setup`
+  requires a matching NIP-98 signature before issuing an in-memory setup
+  session, so the customer does not need access to container logs.
 
 **Document:** [`catalog/appweaver.yaml`](../catalog/appweaver.yaml) —
 `scripts/app-catalog-test.sh catalog/appweaver.yaml` starts it locally.

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -646,6 +646,27 @@ where the image allows it.
 
 ---
 
+## AppWeaver — AI-powered app hub
+
+- **Image:** `ghcr.io/getappweaver/core:alpine` — published from
+  <https://github.com/getappweaver/core>. The Alpine runtime includes Bun,
+  OpenCode, ngit and Piper, but deliberately excludes Chromium, Playwright
+  browsers, Cursor Agent and VNC.
+- **Repo:** <https://github.com/getappweaver/core> — the entrypoint clones the
+  core repository into the persistent workspace on first boot, installs its
+  locked dependencies and starts the setup web UI on port `5551`. The workspace
+  volume retains configuration, credentials, installed apps and app data across
+  image upgrades.
+- **Authentication:** API-key and device-code OpenCode providers work through
+  the setup web UI. A provider that requires a callback to the user's localhost
+  cannot be authenticated without a separate tunnel and should not be selected
+  for a managed deployment.
+
+**Document:** [`catalog/appweaver.yaml`](../catalog/appweaver.yaml) —
+`scripts/app-catalog-test.sh catalog/appweaver.yaml` starts it locally.
+
+---
+
 ## Notes on other apps
 
 - **zap-stream-core** — needs raw TCP/UDP ingest (RTMP `1935/tcp`, SRT), i.e.

--- a/scripts/app-catalog-test.sh
+++ b/scripts/app-catalog-test.sh
@@ -40,6 +40,7 @@ app_config() {
         # merely pattern-shaped string would crashloop the container.
         haven) echo "--config owner_npub=npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqshp52w2" ;;
         buzz)  echo "--config owner_pubkey=0000000000000000000000000000000000000000000000000000000000000001" ;;
+        appweaver) echo "--config master_pubkey=79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" ;;
         *)     echo "" ;;
     esac
 }


### PR DESCRIPTION
## What is AppWeaver?
AppWeaver is a self-hosted app hub for people who want AI-assisted tools and workflows in a private workspace they control. OpenCode provides the agent backend, while AppWeaver supplies the app/plugin runtime, tool and command registration, web UI, setup flow, scheduling, persistence, and Nostr DM interface. Available apps cover workflows such as todos, bookmarks, files, scheduled jobs, publishing, and Nostr monitoring.

The managed offering is for users who want that private workspace without administering Linux, Docker, TLS, or persistent storage themselves. First launch opens AppWeaver's web setup; configuration, credentials, installed apps, databases, and app data remain in the managed volume.

This reduced Alpine image intentionally excludes browser automation, Chromium, Cursor Agent, desktop, and VNC functionality.

## Summary
- add an AppWeaver managed app backed by the public Alpine image
- persist the AppWeaver workspace and expose its setup UI through ingress
- document included tools, excluded browser tooling, and supported OpenCode authentication flows

## Validation
- anonymously pulled `ghcr.io/getappweaver/core:alpine` at digest `sha256:e36f3d29fc3cac7a7bc1f9ab5708e67ad6c52e800aaa751aade516cafe70e3fe`
- `cargo test -p lnvps_compose -- --test-threads=1` (54 passed)
- `cargo run -q -p lnvps_compose --bin compose-validate -- catalog/*.yaml` (all eight documents passed)
- `cargo test -p lnvps_operator catalog_documents_map_to_k8s -- --test-threads=1`
- `HOST_PORT_OFFSET=11000 ./scripts/app-catalog-test.sh catalog/appweaver.yaml` against the published GHCR image
- retained rendered stack: root 200, `/api/health` 200, setup redirect 302, Piper ready, persistent workspace populated
- restart test: health and Piper recovered, dependencies and state reused, zero crash restarts
- verified rendered hardening: UID 1000, read-only root filesystem, all capabilities dropped, no-new-privileges
- AppWeaver container publishing workflow: https://github.com/getappweaver/core/actions/runs/33177573601