### PR TITLE
feat(vpn): lvd, the route server daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3879,6 +3879,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lnvps_vpn"
+version = "0.4.7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "env_logger",
+ "ipnetwork",
+ "lnvps_netlink",
+ "log 0.4.32",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "tokio",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "lnvps_agent",
     "lnvps_node",
     "lnvps_netlink",
+    "lnvps_vpn",
 ]
 # Both are separate workspaces with their own lockfile and are built in their
 # own Docker context: lnvps_fw because the eBPF datapath needs its own

--- a/lnvps_netlink/src/kernel.rs
+++ b/lnvps_netlink/src/kernel.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use ipnetwork::IpNetwork;
 
 use crate::netns;
-use crate::ops::{NetOps, WgObserved, WgSettings};
+use crate::ops::{NetOps, WgObserved, WgPeer, WgPeerState, WgSettings};
 use crate::sysctl::{PROC_SYS, read_sysctl, write_sysctl};
 
 use defguard_wireguard_rs::key::Key;
@@ -25,15 +25,24 @@ use netlink_packet_route::link::LinkFlags;
 use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteHeader};
 use rtnetlink::{Handle, LinkBridge, LinkUnspec, RouteMessageBuilder, new_connection};
 
-/// Talks to the kernel, inside the data plane's own network namespace.
+/// Talks to the kernel, optionally inside a network namespace of its own.
 ///
-/// The namespace is why this type exists at all: a marketplace node is
-/// often not only a marketplace node, and configuring routes, forwarding
-/// and proxy ARP in the machine's own namespace would be configuring the
-/// operator's network for them. See [`crate::netns`].
+/// The two daemons want opposite things here, and both are right.
+///
+/// A marketplace node is often not *only* a marketplace node: it is somebody
+/// else's machine, running somebody else's workloads, and configuring routes,
+/// forwarding and proxy ARP in its own namespace would be configuring the
+/// operator's network for them. So it gets a namespace. See [`crate::netns`].
+///
+/// A VPN route server is a machine LNVPS runs for exactly this and nothing
+/// else. Its interfaces, its routes and its forwarding *are* the host's, and
+/// hiding them in a namespace would mean an operator debugging it could not see
+/// them from a plain shell.
 pub struct Kernel {
     handle: Handle,
-    namespace: netns::Handle,
+    /// The namespace everything is configured in, or `None` for the machine's
+    /// own.
+    namespace: Option<netns::Handle>,
 }
 
 impl Kernel {
@@ -41,6 +50,42 @@ impl Kernel {
     /// creating the namespace if this is the first run.
     pub fn new() -> Result<Self> {
         Self::in_namespace(netns::ensure_default()?)
+    }
+
+    /// Configure the machine this is running on, with no namespace.
+    ///
+    /// For a daemon whose whole job is the host's network. Nothing is hidden,
+    /// so `ip link` in a plain shell shows what the daemon built, which is what
+    /// an operator will reach for first when it is not working.
+    pub fn host() -> Result<Self> {
+        let (connection, handle, _) = new_connection().context("Cannot open a netlink socket")?;
+        tokio::spawn(connection);
+        Ok(Self {
+            handle,
+            namespace: None,
+        })
+    }
+
+    /// Run `f` where this kernel's interfaces live.
+    ///
+    /// A netlink socket, and `/proc/sys/net`, belong to the namespace of the
+    /// thread that opened or read them. Without this, a namespaced kernel
+    /// reports "no such device" about an interface that plainly exists, and
+    /// reads the operator's forwarding setting as its own.
+    ///
+    /// Public because a daemon has its own things to do in the same place: a
+    /// node reads the tunnel's addresses and binds its control listener there,
+    /// and both would otherwise have to ask whether there is a namespace before
+    /// they could ask the question they actually had.
+    pub fn here<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<T> + Send,
+        T: Send,
+    {
+        match &self.namespace {
+            Some(ns) => ns.enter(f),
+            None => f(),
+        }
     }
 
     /// Same, for an already-open namespace. Used by the end-to-end harness,
@@ -61,12 +106,16 @@ impl Kernel {
             new_connection().context("Cannot open a netlink socket")
         })?;
         tokio::spawn(connection);
-        Ok(Self { handle, namespace })
+        Ok(Self {
+            handle,
+            namespace: Some(namespace),
+        })
     }
 
-    /// The namespace this configures.
-    pub fn namespace(&self) -> &netns::Handle {
-        &self.namespace
+    /// The namespace this configures, or `None` when it configures the machine
+    /// itself.
+    pub fn namespace(&self) -> Option<&netns::Handle> {
+        self.namespace.as_ref()
     }
 
     async fn index(&self, name: &str) -> Result<Option<u32>> {
@@ -311,12 +360,12 @@ impl NetOps for Kernel {
         // namespace of the thread that opens it. Configuring from outside
         // reports "no such device" about an interface that plainly exists.
         let (name, settings) = (name.to_string(), settings.clone());
-        self.namespace.enter(move || configure(&name, &settings))
+        self.here(move || configure(&name, &settings))
     }
 
     async fn remove_wireguard_peer(&self, name: &str, public_key: &str) -> Result<()> {
         let (name, public_key) = (name.to_string(), public_key.to_string());
-        self.namespace.enter(move || {
+        self.here(move || {
             let api = WGApi::<WgKernel>::new(name.clone())
                 .with_context(|| format!("Cannot address WireGuard interface {name}"))?;
             let key = Key::from_str(&public_key).context("Not a WireGuard key")?;
@@ -325,14 +374,66 @@ impl NetOps for Kernel {
         })
     }
 
+    async fn configure_wireguard_interface(
+        &self,
+        name: &str,
+        private_key: &str,
+        listen_port: u16,
+    ) -> Result<()> {
+        let (name, private_key) = (name.to_string(), private_key.to_string());
+        self.here(move || {
+            let api = WGApi::<WgKernel>::new(name.clone())
+                .with_context(|| format!("Cannot address WireGuard interface {name}"))?;
+            // Addresses are left empty and managed over netlink, so that one
+            // code path owns them. Note that this call flushes them, which is
+            // the other reason it is only made when the key or port is wrong.
+            let config = InterfaceConfiguration {
+                name: name.clone(),
+                prvkey: private_key,
+                addresses: vec![],
+                port: listen_port,
+                peers: vec![],
+                mtu: None,
+                fwmark: None,
+            };
+            api.configure_interface(&config)
+                .with_context(|| format!("Cannot configure WireGuard interface {name}"))
+        })
+    }
+
+    async fn set_wireguard_peer(&self, name: &str, peer: &WgPeer) -> Result<()> {
+        let (name, peer) = (name.to_string(), peer.clone());
+        self.here(move || {
+            let api = WGApi::<WgKernel>::new(name.clone())
+                .with_context(|| format!("Cannot address WireGuard interface {name}"))?;
+            let endpoint = match &peer.endpoint {
+                Some(e) => {
+                    Some(resolve(e).with_context(|| format!("Cannot resolve peer endpoint {e}"))?)
+                }
+                None => None,
+            };
+            let p = Peer {
+                public_key: Key::from_str(&peer.public_key).context("Not a WireGuard key")?,
+                endpoint,
+                persistent_keepalive_interval: peer.persistent_keepalive,
+                allowed_ips: peer
+                    .allowed_ips
+                    .iter()
+                    .map(|n| IpAddrMask::new(n.ip(), n.prefix()))
+                    .collect(),
+                ..Default::default()
+            };
+            api.configure_peer(&p)
+                .with_context(|| format!("Cannot configure peer {} on {name}", peer.public_key))
+        })
+    }
+
     async fn wireguard_state(&self, name: &str) -> Result<Option<WgObserved>> {
         if !self.link_exists(name).await? {
             return Ok(None);
         }
         let name = name.to_string();
-        self.namespace
-            .enter(move || observe_wireguard(&name))
-            .map(Some)
+        self.here(move || observe_wireguard(&name)).map(Some)
     }
 
     async fn sysctl(&self, key: &str) -> Result<Option<String>> {
@@ -340,14 +441,12 @@ impl NetOps for Kernel {
         // has to be read from inside — otherwise the node would report the
         // operator's forwarding setting as its own.
         let key = key.to_string();
-        self.namespace
-            .enter(move || read_sysctl(Path::new(PROC_SYS), &key))
+        self.here(move || read_sysctl(Path::new(PROC_SYS), &key))
     }
 
     async fn set_sysctl(&self, key: &str, value: &str) -> Result<()> {
         let (key, value) = (key.to_string(), value.to_string());
-        self.namespace
-            .enter(move || write_sysctl(Path::new(PROC_SYS), &key, &value))
+        self.here(move || write_sysctl(Path::new(PROC_SYS), &key, &value))
     }
 }
 
@@ -395,19 +494,32 @@ fn observe_wireguard(name: &str) -> Result<WgObserved> {
         .with_context(|| format!("Cannot read WireGuard interface {name}"))?;
     let now = std::time::SystemTime::now();
     Ok(WgObserved {
+        listen_port: host.listen_port,
+        public_key: host
+            .private_key
+            .as_ref()
+            .map(|k| k.public_key().to_string()),
         peers: host
             .peers
             .values()
-            .map(|p| {
-                let age = p
+            .map(|p| WgPeerState {
+                public_key: p.public_key.to_string(),
+                last_handshake_secs: p
                     .last_handshake
                     // The zero time means "never", not 1970: reporting
                     // an age of half a century would look like a stale
                     // tunnel rather than one that has never worked.
                     .filter(|t| *t != std::time::UNIX_EPOCH)
                     .and_then(|t| now.duration_since(t).ok())
-                    .map(|d| d.as_secs());
-                (p.public_key.to_string(), age)
+                    .map(|d| d.as_secs()),
+                allowed_ips: p
+                    .allowed_ips
+                    .iter()
+                    .filter_map(|a| IpNetwork::new(a.address, a.cidr).ok())
+                    .collect(),
+                endpoint: p.endpoint.map(|e| e.to_string()),
+                rx_bytes: p.rx_bytes,
+                tx_bytes: p.tx_bytes,
             })
             .collect(),
     })
@@ -420,6 +532,11 @@ impl Kernel {
     /// Uses a second netlink socket, opened in the machine's own namespace,
     /// because the move is asked of the namespace the interface is *in*.
     async fn move_into_namespace(&self, name: &str) -> Result<()> {
+        // Nothing to move: this kernel's interfaces are the machine's, and
+        // they are already where they belong.
+        let Some(namespace) = &self.namespace else {
+            return Ok(());
+        };
         let (connection, handle, _) = new_connection().context("Cannot open a netlink socket")?;
         tokio::spawn(connection);
 
@@ -433,7 +550,7 @@ impl Kernel {
             .link()
             .set(
                 LinkUnspec::new_with_index(link.header.index)
-                    .setns_by_fd(self.namespace.as_raw_fd())
+                    .setns_by_fd(namespace.as_raw_fd())
                     .build(),
             )
             .execute()

--- a/lnvps_netlink/src/key.rs
+++ b/lnvps_netlink/src/key.rs
@@ -1,0 +1,46 @@
+//! Deriving a WireGuard public key from a private one.
+//!
+//! Here rather than in `lnvps_api_common`, which has the same function: that
+//! crate pulls in the database, axum and the payment stack, and none of those
+//! belong on a machine whose job is to forward packets.
+//!
+//! Uses the same WireGuard library the kernel calls go through, so a key this
+//! accepts is a key the interface will accept.
+
+use anyhow::{Context, Result};
+use defguard_wireguard_rs::key::Key;
+use std::str::FromStr;
+
+/// The public half of `private_key`, base64, as WireGuard states keys.
+///
+/// Used to tell an interface that is already carrying the right key from one
+/// that is not, without ever reading the private half back out of the kernel.
+pub fn wireguard_public_key_base64(private_key: &str) -> Result<String> {
+    Ok(Key::from_str(private_key.trim())
+        .context("Not a WireGuard key")?
+        .public_key()
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_known_pair_derives() {
+        // Generated with `wg genkey | tee /dev/stderr | wg pubkey`.
+        let private = "iM7g0lLIF3P7WGZTF8Zgs+A2ZUGZQIS+eEIVN8U9RVo=";
+        let public = wireguard_public_key_base64(private).unwrap();
+        assert_eq!(public.len(), 44, "a wg key is 32 bytes, base64: {public}");
+        // Deriving is a function, not a fresh keypair: the same private half
+        // must always give the same public one, or an interface would look
+        // drifted on every apply and be rekeyed forever.
+        assert_eq!(public, wireguard_public_key_base64(private).unwrap());
+    }
+
+    #[test]
+    fn something_that_is_not_a_key_is_refused() {
+        assert!(wireguard_public_key_base64("hello").is_err());
+        assert!(wireguard_public_key_base64("").is_err());
+    }
+}

--- a/lnvps_netlink/src/lib.rs
+++ b/lnvps_netlink/src/lib.rs
@@ -25,5 +25,5 @@ pub mod ops;
 pub mod sysctl;
 
 pub use kernel::Kernel;
-pub use ops::{NetOps, UnavailableKernel, WgObserved, WgSettings};
+pub use ops::{NetOps, UnavailableKernel, WgObserved, WgPeer, WgPeerState, WgSettings};
 pub use sysctl::{PROC_SYS, read_sysctl, write_sysctl};

--- a/lnvps_netlink/src/lib.rs
+++ b/lnvps_netlink/src/lib.rs
@@ -20,10 +20,12 @@
 //! reconciling that against what LNVPS asked for, belongs to the daemon.
 
 pub mod kernel;
+pub mod key;
 pub mod netns;
 pub mod ops;
 pub mod sysctl;
 
 pub use kernel::Kernel;
+pub use key::wireguard_public_key_base64;
 pub use ops::{NetOps, UnavailableKernel, WgObserved, WgPeer, WgPeerState, WgSettings};
 pub use sysctl::{PROC_SYS, read_sysctl, write_sysctl};

--- a/lnvps_netlink/src/ops.rs
+++ b/lnvps_netlink/src/ops.rs
@@ -23,11 +23,53 @@ pub struct WgSettings {
     pub allowed_ips: Vec<IpNetwork>,
 }
 
+/// One peer this side may talk to.
+///
+/// The declarative half: what a peer *should* be. `endpoint` is the address to
+/// send to, and it is absent for a peer that moves -- a laptop on a train is
+/// found by where it last spoke from, not by where it was told to be.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgPeer {
+    /// Base64, as WireGuard states keys.
+    pub public_key: String,
+    /// The only source addresses this key may use, and the destinations that
+    /// select it. WireGuard uses one list for both, which is why a peer with
+    /// the wrong one is both unreachable and able to spoof.
+    pub allowed_ips: Vec<IpNetwork>,
+    pub endpoint: Option<String>,
+    pub persistent_keepalive: Option<u16>,
+}
+
+/// One peer as the kernel currently has it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgPeerState {
+    pub public_key: String,
+    /// Seconds since this peer last completed a handshake. `None` when it never
+    /// has, which is the difference between "configured" and "working".
+    pub last_handshake_secs: Option<u64>,
+    pub allowed_ips: Vec<IpNetwork>,
+    /// Where this peer was last heard from.
+    ///
+    /// For a VPN device this is a **customer's real address**, held in kernel
+    /// memory for as long as the peer is configured. It is read so that a peer
+    /// which has gone quiet can have it scrubbed, and for no other reason.
+    pub endpoint: Option<String>,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+}
+
 /// What a WireGuard interface currently is.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct WgObserved {
-    /// Peers keyed by public key, with seconds since each last handshake.
-    pub peers: Vec<(String, Option<u64>)>,
+    /// The port it listens on, or 0 for an interface that only dials out.
+    pub listen_port: u16,
+    /// The public half of the key it is configured with, base64.
+    ///
+    /// Read back so that an interface carrying the wrong key is corrected
+    /// rather than left serving peers that can never hand shake with it.
+    /// `None` when it has no key at all, which is a freshly created interface.
+    pub public_key: Option<String>,
+    pub peers: Vec<WgPeerState>,
 }
 
 /// The kernel operations the data plane needs.
@@ -62,6 +104,28 @@ pub trait NetOps: Send + Sync {
     async fn remove_wireguard_peer(&self, name: &str, public_key: &str) -> Result<()>;
     /// Read the interface back, or `None` when it does not exist.
     async fn wireguard_state(&self, name: &str) -> Result<Option<WgObserved>>;
+
+    /// Set the interface's own key and listening port.
+    ///
+    /// **Drops every peer**, because the kernel's only way to state a device's
+    /// configuration replaces its peer set with it. So this is for an interface
+    /// that is new or whose key or port has drifted, and the caller re-adds the
+    /// peers afterwards; on the ordinary path, where the key and port are
+    /// already right, it is not called at all.
+    async fn configure_wireguard_interface(
+        &self,
+        name: &str,
+        private_key: &str,
+        listen_port: u16,
+    ) -> Result<()>;
+
+    /// Add or update one peer, leaving every other peer alone.
+    ///
+    /// Idempotent, and specifically *not* a whole-interface apply: replacing
+    /// the peer set to add one peer tears down every established session on the
+    /// interface, and on a route server carrying thousands of devices that is a
+    /// stampede of renegotiation triggered by one customer buying a phone.
+    async fn set_wireguard_peer(&self, name: &str, peer: &WgPeer) -> Result<()>;
 
     /// Read a kernel knob, or `None` when this kernel does not have it.
     async fn sysctl(&self, key: &str) -> Result<Option<String>>;
@@ -118,6 +182,17 @@ impl NetOps for UnavailableKernel {
     }
     async fn wireguard_state(&self, _name: &str) -> Result<Option<WgObserved>> {
         Ok(None)
+    }
+    async fn configure_wireguard_interface(
+        &self,
+        _name: &str,
+        _private_key: &str,
+        _listen_port: u16,
+    ) -> Result<()> {
+        bail!("This node cannot configure its network")
+    }
+    async fn set_wireguard_peer(&self, _name: &str, _peer: &WgPeer) -> Result<()> {
+        bail!("This node cannot configure its network")
     }
     async fn sysctl(&self, _key: &str) -> Result<Option<String>> {
         Ok(None)

--- a/lnvps_node/src/main.rs
+++ b/lnvps_node/src/main.rs
@@ -195,9 +195,7 @@ async fn run(config_path: &Path) -> Result<()> {
     // against the interface itself — inside the data plane namespace, which is
     // the only place that interface exists.
     let interface = control.tunnel_interface.clone();
-    let addrs = kernel
-        .namespace()
-        .enter(move || config::interface_addresses(&interface))?;
+    let addrs = kernel.here(move || config::interface_addresses(&interface))?;
     config::validate_listen_address(control.listen, &addrs)?;
 
     let tls = tls::load_or_generate(&config.state_dir, Some(control.listen))?;
@@ -233,7 +231,7 @@ async fn run(config_path: &Path) -> Result<()> {
     // Bound inside the namespace, because that is where the tunnel address
     // lives. The socket keeps that namespace while the rest of the daemon stays
     // in the machine's own, which is what lets it go on reaching LNVPS.
-    let listener = kernel.namespace().enter(move || {
+    let listener = kernel.here(move || {
         std::net::TcpListener::bind(addr)
             .with_context(|| format!("Cannot bind the control API to {addr}"))
     })?;

--- a/lnvps_node/src/net.rs
+++ b/lnvps_node/src/net.rs
@@ -211,8 +211,13 @@ async fn apply_tunnel(
     // It would most likely be a stale key from a re-key, still able to send
     // traffic that the node treats as coming from LNVPS.
     if let Some(observed) = ops.wireguard_state(TUNNEL_INTERFACE).await? {
-        for (stale, _) in observed.peers.iter().filter(|(k, _)| *k != peer_key) {
-            ops.remove_wireguard_peer(TUNNEL_INTERFACE, stale).await?;
+        for stale in observed
+            .peers
+            .iter()
+            .filter(|p| p.public_key != peer_key)
+            .map(|p| p.public_key.clone())
+        {
+            ops.remove_wireguard_peer(TUNNEL_INTERFACE, &stale).await?;
             changed.push(format!("removed stale peer {stale}"));
         }
     }
@@ -418,10 +423,12 @@ fn is_link_local(address: &IpNetwork) -> bool {
 pub async fn observe(ops: &dyn NetOps, fw: &dyn crate::fw::FirewallOps) -> Result<DataPlaneState> {
     let (tunnel_up, tunnel_mtu) = ops.link_state(TUNNEL_INTERFACE).await?;
     let (bridge_up, _) = ops.link_state(GUEST_BRIDGE).await?;
-    let last_handshake_secs = ops
-        .wireguard_state(TUNNEL_INTERFACE)
-        .await?
-        .and_then(|w| w.peers.into_iter().filter_map(|(_, age)| age).min());
+    let last_handshake_secs = ops.wireguard_state(TUNNEL_INTERFACE).await?.and_then(|w| {
+        w.peers
+            .into_iter()
+            .filter_map(|p| p.last_handshake_secs)
+            .min()
+    });
     Ok(DataPlaneState {
         tunnel_up,
         tunnel_mtu,

--- a/lnvps_node/src/net/tests.rs
+++ b/lnvps_node/src/net/tests.rs
@@ -12,6 +12,20 @@ use async_trait::async_trait;
 
 use super::*;
 
+/// A peer as the kernel would report it. Only the key and the handshake matter
+/// to anything the node decides, so the rest is left empty rather than
+/// invented.
+fn a_peer(public_key: &str, last_handshake_secs: Option<u64>) -> lnvps_netlink::WgPeerState {
+    lnvps_netlink::WgPeerState {
+        public_key: public_key.to_string(),
+        last_handshake_secs,
+        allowed_ips: vec![],
+        endpoint: None,
+        rx_bytes: 0,
+        tx_bytes: 0,
+    }
+}
+
 /// A machine with a working nftables, already carrying the ruleset for the
 /// guests below, for the tests that are about the network rather than the
 /// filter. The filter's own decisions are tested in [`crate::fw::tests`].
@@ -178,26 +192,56 @@ impl NetOps for FakeKernel {
             .entry(name.to_string())
             .or_default()
             .peers
-            .retain(|(k, _)| *k != settings.peer_public_key);
+            .retain(|p| p.public_key != settings.peer_public_key);
         self.wireguard
             .lock()
             .unwrap()
             .entry(name.to_string())
             .or_default()
             .peers
-            .push((settings.peer_public_key.clone(), None));
+            .push(a_peer(&settings.peer_public_key, None));
         Ok(())
     }
 
     async fn remove_wireguard_peer(&self, name: &str, public_key: &str) -> Result<()> {
         if let Some(state) = self.wireguard.lock().unwrap().get_mut(name) {
-            state.peers.retain(|(k, _)| k != public_key);
+            state.peers.retain(|p| p.public_key != public_key);
         }
         Ok(())
     }
 
     async fn wireguard_state(&self, name: &str) -> Result<Option<WgObserved>> {
         Ok(self.wireguard.lock().unwrap().get(name).cloned())
+    }
+
+    async fn configure_wireguard_interface(
+        &self,
+        name: &str,
+        _private_key: &str,
+        listen_port: u16,
+    ) -> Result<()> {
+        // As the kernel does: stating a device's configuration replaces its
+        // peer set with it.
+        let mut wg = self.wireguard.lock().unwrap();
+        let state = wg.entry(name.to_string()).or_default();
+        state.listen_port = listen_port;
+        state.peers.clear();
+        Ok(())
+    }
+
+    async fn set_wireguard_peer(&self, name: &str, peer: &lnvps_netlink::WgPeer) -> Result<()> {
+        let mut wg = self.wireguard.lock().unwrap();
+        let state = wg.entry(name.to_string()).or_default();
+        state.peers.retain(|p| p.public_key != peer.public_key);
+        state.peers.push(lnvps_netlink::WgPeerState {
+            public_key: peer.public_key.clone(),
+            last_handshake_secs: None,
+            allowed_ips: peer.allowed_ips.clone(),
+            endpoint: peer.endpoint.clone(),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        });
+        Ok(())
     }
 
     async fn sysctl(&self, key: &str) -> Result<Option<String>> {
@@ -347,7 +391,7 @@ async fn a_stale_peer_is_removed() {
         .get_mut(TUNNEL_INTERFACE)
         .unwrap()
         .peers
-        .push(("c3RyYXk=".to_string(), None));
+        .push(a_peer("c3RyYXk=", None));
 
     let changed = apply(&kernel, &fw().await, &desired(), &key())
         .await
@@ -505,7 +549,7 @@ async fn observation_reports_what_the_machine_has() {
         .unwrap()
         .get_mut(TUNNEL_INTERFACE)
         .unwrap()
-        .peers = vec![("peer".to_string(), Some(12))];
+        .peers = vec![a_peer("peer", Some(12))];
     let state = observe(&kernel, &fw().await).await.unwrap();
     assert_eq!(state.last_handshake_secs, Some(12));
     assert!(state.healthy());

--- a/lnvps_vpn/Cargo.toml
+++ b/lnvps_vpn/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "lnvps_vpn"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "lvd"
+path = "src/main.rs"
+
+[dependencies]
+# How to make a kernel carry a WireGuard data plane. Shared with lnvps_node so
+# there is one description of that rather than two that drift.
+lnvps_netlink = { path = "../lnvps_netlink" }
+
+anyhow.workspace = true
+async-trait.workspace = true
+ipnetwork.workspace = true
+log.workspace = true
+env_logger.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml_ng.workspace = true
+clap = { version = "4.5", features = ["derive"] }
+# Outbound only: this daemon asks LNVPS what it should be and nothing dials it.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "signal", "time"] }

--- a/lnvps_vpn/config.example.yaml
+++ b/lnvps_vpn/config.example.yaml
@@ -1,0 +1,43 @@
+# lvd — the LNVPS VPN route server daemon.
+#
+# Everything here is outbound. Nothing dials this machine, so it needs no
+# inbound port, no port forward, no dynamic DNS and no TLS certificate of its
+# own. It asks LNVPS what its interfaces should be and applies the answer.
+#
+# Install at /etc/lvd/config.yaml and run `lvd check` before starting.
+
+# Base URL of the LNVPS API.
+api-url: "https://api.lnvps.net"
+
+# This route server's credential, as <router_id>.<secret>.
+#
+# Provisioned by hand with everything else about the machine; there is nothing
+# to register. The router row exists in LNVPS before this machine is ever
+# switched on, and rotating the secret there takes out this route server and no
+# other.
+#
+# Treat the file as a secret: it is also, indirectly, the peer list.
+token: "7.replace-me"
+
+# Seconds to ask LNVPS to hold a fetch open waiting for something to change.
+#
+# This is what makes a pull as fast as a push: a revoked device stops being
+# honoured about one round trip after somebody clicks the button, rather than on
+# the next poll. LNVPS caps it, so a larger number here is capped rather than
+# refused. Zero turns it into an ordinary poll.
+wait-secs: 25
+
+# Seconds to wait before trying again after a failed fetch or apply.
+#
+# Short on purpose. The daemon is idle almost all of the time, so retrying costs
+# nothing, and what is being delayed is a revocation.
+retry-secs: 5
+
+# Seconds a peer may go without a handshake before the address it was last heard
+# from is scrubbed out of the kernel.
+#
+# WireGuard records that address so a roaming client can be found, which for a
+# customer device is their real address. This cannot stop it being recorded
+# while they are connected; it stops it being kept afterwards. Ten minutes is
+# long enough that a laptop closing its lid does not have to renegotiate.
+scrub-after-secs: 600

--- a/lnvps_vpn/src/apply.rs
+++ b/lnvps_vpn/src/apply.rs
@@ -1,0 +1,238 @@
+//! Making the machine be what LNVPS asked for.
+//!
+//! Declarative and convergent: an interface that is already right is not
+//! touched, and one that has drifted is corrected without being torn down.
+//! That distinction matters more here than on a node. A route server carries
+//! thousands of peers, and the kernel's only way to state a device's
+//! configuration replaces its peer set with it — so an apply that rebuilt the
+//! interface every time would reset every established session on it, turning
+//! one customer registering a phone into a stampede of renegotiation.
+//!
+//! So peers are reconciled one at a time: added when new, rewritten when their
+//! allowed IPs have moved, removed when they are no longer in the document, and
+//! otherwise left entirely alone.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result};
+use ipnetwork::IpNetwork;
+use lnvps_netlink::{NetOps, WgPeer};
+
+use crate::client::{DesiredDataPlane, DesiredInterface};
+
+/// What an apply did. Empty means the machine was already right, which is what
+/// almost every apply should report.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Applied {
+    pub changes: Vec<String>,
+}
+
+impl Applied {
+    fn note(&mut self, what: impl Into<String>) {
+        self.changes.push(what.into());
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+}
+
+/// Apply the whole document.
+///
+/// Interfaces in the document are brought into line; interfaces this machine
+/// has that the document does not mention are left alone. A route server is not
+/// necessarily only a route server, and tearing down an interface because LNVPS
+/// has not heard of it would mean a bug here could take out the operator's own
+/// networking. LNVPS removes what it created, through the pool going away and
+/// the interface being deleted deliberately.
+pub async fn apply(ops: &dyn NetOps, desired: &DesiredDataPlane) -> Result<Applied> {
+    let mut applied = Applied::default();
+    for interface in &desired.interfaces {
+        apply_interface(ops, interface, &mut applied)
+            .await
+            .with_context(|| format!("Cannot configure {}", interface.interface()))?;
+    }
+    Ok(applied)
+}
+
+async fn apply_interface(
+    ops: &dyn NetOps,
+    desired: &DesiredInterface,
+    applied: &mut Applied,
+) -> Result<()> {
+    let name = desired.interface();
+
+    if !ops.link_exists(&name).await? {
+        ops.create_wireguard(&name).await?;
+        applied.note(format!("created {name}"));
+    }
+
+    // The key and port are set only when they are wrong, because setting them
+    // drops every peer. On the ordinary path this branch is not taken and the
+    // interface's sessions are never disturbed.
+    let observed = ops.wireguard_state(&name).await?.unwrap_or_default();
+    let want_public = lnvps_netlink::wireguard_public_key_base64(&desired.private_key)
+        .context("The private key LNVPS sent is not a WireGuard key")?;
+    if observed.public_key.as_deref() != Some(want_public.as_str())
+        || observed.listen_port != desired.listen_port
+    {
+        ops.configure_wireguard_interface(&name, &desired.private_key, desired.listen_port)
+            .await?;
+        applied.note(format!("keyed {name} on port {}", desired.listen_port));
+    }
+
+    let (up, mtu) = ops.link_state(&name).await?;
+    if !up || mtu != Some(desired.mtu as u32) {
+        ops.set_up(&name, desired.mtu as u32).await?;
+        applied.note(format!("brought {name} up at mtu {}", desired.mtu));
+    }
+
+    sync_addresses(ops, &name, &desired.addresses, applied).await?;
+    sync_routes(ops, &name, &desired.routes, applied).await?;
+    sync_peers(ops, &name, desired, applied).await?;
+    Ok(())
+}
+
+/// Make the interface's addresses exactly what was asked for.
+///
+/// A WireGuard interface with no address terminates nowhere: a peer's route
+/// points at *some* address on this side, and it has to exist for anything to
+/// answer.
+async fn sync_addresses(
+    ops: &dyn NetOps,
+    name: &str,
+    desired: &[String],
+    applied: &mut Applied,
+) -> Result<()> {
+    let want = parse_all(desired).context("LNVPS sent an address that is not a CIDR")?;
+    let have = ops.addresses(name).await?;
+
+    for address in want.iter().filter(|a| !have.contains(a)) {
+        ops.add_address(name, *address).await?;
+        applied.note(format!("added {address} to {name}"));
+    }
+    for address in have.iter().filter(|a| !want.contains(a)) {
+        // Link-local addresses are the kernel's, not ours: removing the one it
+        // assigns to every interface would be a fight with it that we lose on
+        // every apply.
+        if is_link_local(address) {
+            continue;
+        }
+        ops.del_address(name, *address).await?;
+        applied.note(format!("removed {address} from {name}"));
+    }
+    Ok(())
+}
+
+/// Make the routes down the interface exactly what was asked for.
+///
+/// `AllowedIPs` decides which *peer* a packet already bound for the tunnel
+/// belongs to; it does not put the packet on the tunnel. Without a route,
+/// return traffic reaches the route server and is dropped as unroutable.
+async fn sync_routes(
+    ops: &dyn NetOps,
+    name: &str,
+    desired: &[String],
+    applied: &mut Applied,
+) -> Result<()> {
+    let want = parse_all(desired).context("LNVPS sent a route that is not a CIDR")?;
+    let have = ops.routes(name).await?;
+
+    for route in want.iter().filter(|r| !have.contains(r)) {
+        ops.add_route(*route, name).await?;
+        applied.note(format!("routed {route} down {name}"));
+    }
+    for route in have.iter().filter(|r| !want.contains(r)) {
+        ops.del_route(*route, name).await?;
+        applied.note(format!("stopped routing {route} down {name}"));
+    }
+    Ok(())
+}
+
+/// Reconcile the peer set, one peer at a time.
+async fn sync_peers(
+    ops: &dyn NetOps,
+    name: &str,
+    desired: &DesiredInterface,
+    applied: &mut Applied,
+) -> Result<()> {
+    let observed = ops.wireguard_state(name).await?.unwrap_or_default();
+    let have: HashMap<&str, &lnvps_netlink::WgPeerState> = observed
+        .peers
+        .iter()
+        .map(|p| (p.public_key.as_str(), p))
+        .collect();
+
+    let mut wanted = HashSet::new();
+    for peer in &desired.peers {
+        wanted.insert(peer.public_key.as_str());
+        let allowed_ips = parse_all(&peer.allowed_ips).with_context(|| {
+            format!(
+                "Peer {} has allowed IPs that are not CIDRs",
+                peer.public_key
+            )
+        })?;
+
+        // Compared as sets: the kernel reports them in its own order, and
+        // rewriting a peer because a list was shuffled would reset a session
+        // for nothing.
+        if let Some(current) = have.get(peer.public_key.as_str())
+            && same_set(&current.allowed_ips, &allowed_ips)
+        {
+            continue;
+        }
+
+        ops.set_wireguard_peer(
+            name,
+            &WgPeer {
+                public_key: peer.public_key.clone(),
+                allowed_ips,
+                endpoint: peer.endpoint.clone(),
+                persistent_keepalive: peer.persistent_keepalive,
+            },
+        )
+        .await?;
+        applied.note(match have.contains_key(peer.public_key.as_str()) {
+            true => format!("re-addressed peer {} on {name}", peer.public_key),
+            false => format!("added peer {} to {name}", peer.public_key),
+        });
+    }
+
+    // A peer the document no longer lists is a device that was revoked, or a
+    // plan that lapsed. Leaving it configured is the one failure that matters:
+    // it is a key that still works after LNVPS was told it should not.
+    for stale in observed
+        .peers
+        .iter()
+        .map(|p| p.public_key.as_str())
+        .filter(|k| !wanted.contains(k))
+    {
+        ops.remove_wireguard_peer(name, stale).await?;
+        applied.note(format!("removed peer {stale} from {name}"));
+    }
+    Ok(())
+}
+
+fn parse_all(values: &[String]) -> Result<Vec<IpNetwork>> {
+    values
+        .iter()
+        .map(|v| {
+            v.parse::<IpNetwork>()
+                .with_context(|| format!("{v} is not a CIDR"))
+        })
+        .collect()
+}
+
+fn same_set(a: &[IpNetwork], b: &[IpNetwork]) -> bool {
+    a.len() == b.len() && a.iter().all(|x| b.contains(x))
+}
+
+fn is_link_local(address: &IpNetwork) -> bool {
+    match address.ip() {
+        std::net::IpAddr::V4(v4) => v4.is_link_local() || v4.is_loopback(),
+        std::net::IpAddr::V6(v6) => (v6.segments()[0] & 0xffc0) == 0xfe80 || v6.is_loopback(),
+    }
+}
+
+#[cfg(test)]
+pub mod tests;

--- a/lnvps_vpn/src/apply/tests.rs
+++ b/lnvps_vpn/src/apply/tests.rs
@@ -1,0 +1,417 @@
+//! What the daemon decides to do to a machine.
+//!
+//! The kernel sits behind [`NetOps`], so these run without root and assert the
+//! decisions rather than the netlink encoding of them. Whether the decisions
+//! work on a real kernel is the netns harness's job.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use lnvps_netlink::{WgObserved, WgPeerState, WgSettings};
+
+use super::*;
+use crate::client::DesiredPeer;
+
+/// A key and its public half, so a test can hand the daemon something that
+/// derives rather than a placeholder it would reject.
+const PRIVATE: &str = "iM7g0lLIF3P7WGZTF8Zgs+A2ZUGZQIS+eEIVN8U9RVo=";
+
+/// A machine that remembers what it was told and answers from it, so a second
+/// apply sees the first one's work. That is what makes "converges and then goes
+/// quiet" testable at all.
+#[derive(Default)]
+pub struct FakeKernel {
+    links: Mutex<HashMap<String, (bool, Option<u32>)>>,
+    addresses: Mutex<HashMap<String, Vec<IpNetwork>>>,
+    routes: Mutex<HashMap<String, Vec<IpNetwork>>>,
+    wireguard: Mutex<HashMap<String, WgObserved>>,
+    /// Every call that changed something, so a test can assert an apply was
+    /// silent rather than only that it succeeded.
+    pub calls: Mutex<Vec<String>>,
+}
+
+impl FakeKernel {
+    fn record(&self, what: impl Into<String>) {
+        self.calls.lock().unwrap().push(what.into());
+    }
+
+    pub fn peers_of(&self, name: &str) -> Vec<WgPeerState> {
+        self.wireguard
+            .lock()
+            .unwrap()
+            .get(name)
+            .map(|w| w.peers.clone())
+            .unwrap_or_default()
+    }
+
+    /// Pretend a peer has handshaken, and been heard from at `endpoint`.
+    pub fn peer_spoke(&self, name: &str, public_key: &str, endpoint: &str, secs_ago: u64) {
+        let mut wg = self.wireguard.lock().unwrap();
+        if let Some(peer) = wg
+            .get_mut(name)
+            .and_then(|w| w.peers.iter_mut().find(|p| p.public_key == public_key))
+        {
+            peer.last_handshake_secs = Some(secs_ago);
+            peer.endpoint = Some(endpoint.to_string());
+        }
+    }
+}
+
+#[async_trait]
+impl NetOps for FakeKernel {
+    async fn link_exists(&self, name: &str) -> Result<bool> {
+        Ok(self.links.lock().unwrap().contains_key(name))
+    }
+    async fn create_wireguard(&self, name: &str) -> Result<()> {
+        self.record(format!("create {name}"));
+        self.links
+            .lock()
+            .unwrap()
+            .insert(name.to_string(), (false, None));
+        self.wireguard
+            .lock()
+            .unwrap()
+            .entry(name.to_string())
+            .or_default();
+        Ok(())
+    }
+    async fn create_bridge(&self, _name: &str) -> Result<()> {
+        bail!("a route server has no bridge")
+    }
+    async fn set_up(&self, name: &str, mtu: u32) -> Result<()> {
+        self.record(format!("up {name} {mtu}"));
+        self.links
+            .lock()
+            .unwrap()
+            .insert(name.to_string(), (true, Some(mtu)));
+        Ok(())
+    }
+    async fn link_state(&self, name: &str) -> Result<(bool, Option<u32>)> {
+        Ok(self
+            .links
+            .lock()
+            .unwrap()
+            .get(name)
+            .copied()
+            .unwrap_or((false, None)))
+    }
+    async fn addresses(&self, name: &str) -> Result<Vec<IpNetwork>> {
+        Ok(self
+            .addresses
+            .lock()
+            .unwrap()
+            .get(name)
+            .cloned()
+            .unwrap_or_default())
+    }
+    async fn add_address(&self, name: &str, address: IpNetwork) -> Result<()> {
+        self.record(format!("addr+ {name} {address}"));
+        self.addresses
+            .lock()
+            .unwrap()
+            .entry(name.to_string())
+            .or_default()
+            .push(address);
+        Ok(())
+    }
+    async fn del_address(&self, name: &str, address: IpNetwork) -> Result<()> {
+        self.record(format!("addr- {name} {address}"));
+        if let Some(a) = self.addresses.lock().unwrap().get_mut(name) {
+            a.retain(|x| *x != address);
+        }
+        Ok(())
+    }
+    async fn routes(&self, name: &str) -> Result<Vec<IpNetwork>> {
+        Ok(self
+            .routes
+            .lock()
+            .unwrap()
+            .get(name)
+            .cloned()
+            .unwrap_or_default())
+    }
+    async fn add_route(&self, destination: IpNetwork, name: &str) -> Result<()> {
+        self.record(format!("route+ {name} {destination}"));
+        self.routes
+            .lock()
+            .unwrap()
+            .entry(name.to_string())
+            .or_default()
+            .push(destination);
+        Ok(())
+    }
+    async fn del_route(&self, destination: IpNetwork, name: &str) -> Result<()> {
+        self.record(format!("route- {name} {destination}"));
+        if let Some(r) = self.routes.lock().unwrap().get_mut(name) {
+            r.retain(|x| *x != destination);
+        }
+        Ok(())
+    }
+    async fn configure_wireguard(&self, _name: &str, _settings: &WgSettings) -> Result<()> {
+        bail!("a route server does not dial out")
+    }
+    async fn configure_wireguard_interface(
+        &self,
+        name: &str,
+        private_key: &str,
+        listen_port: u16,
+    ) -> Result<()> {
+        self.record(format!("key {name} {listen_port}"));
+        let mut wg = self.wireguard.lock().unwrap();
+        let state = wg.entry(name.to_string()).or_default();
+        state.listen_port = listen_port;
+        state.public_key = Some(lnvps_netlink::wireguard_public_key_base64(private_key)?);
+        // As the kernel does: stating the device's configuration replaces its
+        // peer set with it.
+        state.peers.clear();
+        Ok(())
+    }
+    async fn set_wireguard_peer(&self, name: &str, peer: &WgPeer) -> Result<()> {
+        self.record(format!("peer+ {name} {}", peer.public_key));
+        let mut wg = self.wireguard.lock().unwrap();
+        let state = wg.entry(name.to_string()).or_default();
+        state.peers.retain(|p| p.public_key != peer.public_key);
+        state.peers.push(WgPeerState {
+            public_key: peer.public_key.clone(),
+            last_handshake_secs: None,
+            allowed_ips: peer.allowed_ips.clone(),
+            endpoint: peer.endpoint.clone(),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        });
+        Ok(())
+    }
+    async fn remove_wireguard_peer(&self, name: &str, public_key: &str) -> Result<()> {
+        self.record(format!("peer- {name} {public_key}"));
+        if let Some(state) = self.wireguard.lock().unwrap().get_mut(name) {
+            state.peers.retain(|p| p.public_key != public_key);
+        }
+        Ok(())
+    }
+    async fn wireguard_state(&self, name: &str) -> Result<Option<WgObserved>> {
+        Ok(self.wireguard.lock().unwrap().get(name).cloned())
+    }
+    async fn sysctl(&self, _key: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn set_sysctl(&self, _key: &str, _value: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub fn a_peer(public_key: &str, allowed: &[&str]) -> DesiredPeer {
+    DesiredPeer {
+        public_key: public_key.to_string(),
+        allowed_ips: allowed.iter().map(|s| s.to_string()).collect(),
+        endpoint: None,
+        persistent_keepalive: None,
+    }
+}
+
+pub fn a_document(peers: Vec<DesiredPeer>) -> DesiredDataPlane {
+    DesiredDataPlane {
+        generation: 1,
+        interfaces: vec![DesiredInterface {
+            pool_id: 7,
+            private_key: PRIVATE.to_string(),
+            listen_port: 51820,
+            mtu: 1420,
+            addresses: vec!["10.64.0.1/24".to_string()],
+            routes: vec![],
+            peers,
+        }],
+    }
+}
+
+#[tokio::test]
+async fn a_first_apply_builds_the_interface() {
+    let kernel = FakeKernel::default();
+    let doc = a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]);
+
+    let applied = apply(&kernel, &doc).await.unwrap();
+
+    assert!(applied.changes.iter().any(|c| c.contains("created wgln7")));
+    assert!(applied.changes.iter().any(|c| c.contains("keyed wgln7")));
+    assert_eq!(kernel.peers_of("wgln7").len(), 1);
+    assert_eq!(
+        kernel.addresses("wgln7").await.unwrap(),
+        vec!["10.64.0.1/24".parse::<IpNetwork>().unwrap()]
+    );
+}
+
+#[tokio::test]
+async fn a_second_apply_changes_nothing() {
+    let kernel = FakeKernel::default();
+    let doc = a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]);
+    apply(&kernel, &doc).await.unwrap();
+    kernel.calls.lock().unwrap().clear();
+
+    let applied = apply(&kernel, &doc).await.unwrap();
+
+    // The whole point. A route server is applied on every fetch, and an apply
+    // that rewrote the interface would reset every session on it each time.
+    assert!(applied.is_empty(), "{applied:?}");
+    assert!(kernel.calls.lock().unwrap().is_empty(), "{kernel:?}",);
+}
+
+#[tokio::test]
+async fn adding_one_device_does_not_disturb_the_others() {
+    let kernel = FakeKernel::default();
+    apply(
+        &kernel,
+        &a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]),
+    )
+    .await
+    .unwrap();
+    kernel.calls.lock().unwrap().clear();
+
+    apply(
+        &kernel,
+        &a_document(vec![
+            a_peer("cGVlcjE=", &["10.64.0.7/32"]),
+            a_peer("cGVlcjI=", &["10.64.0.8/32"]),
+        ]),
+    )
+    .await
+    .unwrap();
+
+    // Exactly one call, for the new peer. If the interface were re-keyed or the
+    // peer set replaced, every existing customer would renegotiate because
+    // somebody else bought a phone.
+    let calls = kernel.calls.lock().unwrap().clone();
+    assert_eq!(calls, vec!["peer+ wgln7 cGVlcjI=".to_string()], "{calls:?}");
+}
+
+#[tokio::test]
+async fn a_revoked_device_is_removed() {
+    let kernel = FakeKernel::default();
+    apply(
+        &kernel,
+        &a_document(vec![
+            a_peer("cGVlcjE=", &["10.64.0.7/32"]),
+            a_peer("cGVlcjI=", &["10.64.0.8/32"]),
+        ]),
+    )
+    .await
+    .unwrap();
+
+    apply(
+        &kernel,
+        &a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]),
+    )
+    .await
+    .unwrap();
+
+    // The failure that matters: a key LNVPS was told to stop honouring, still
+    // configured and still working.
+    let left: Vec<String> = kernel
+        .peers_of("wgln7")
+        .into_iter()
+        .map(|p| p.public_key)
+        .collect();
+    assert_eq!(left, vec!["cGVlcjE=".to_string()]);
+}
+
+#[tokio::test]
+async fn a_peer_whose_address_moved_is_rewritten() {
+    let kernel = FakeKernel::default();
+    apply(
+        &kernel,
+        &a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]),
+    )
+    .await
+    .unwrap();
+    kernel.calls.lock().unwrap().clear();
+
+    apply(
+        &kernel,
+        &a_document(vec![a_peer("cGVlcjE=", &["10.64.0.9/32"])]),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        kernel.calls.lock().unwrap().clone(),
+        vec!["peer+ wgln7 cGVlcjE=".to_string()]
+    );
+    assert_eq!(
+        kernel.peers_of("wgln7")[0].allowed_ips,
+        vec!["10.64.0.9/32".parse::<IpNetwork>().unwrap()]
+    );
+}
+
+#[tokio::test]
+async fn allowed_ips_in_a_different_order_are_the_same_allowed_ips() {
+    let kernel = FakeKernel::default();
+    apply(
+        &kernel,
+        &a_document(vec![a_peer(
+            "cGVlcjE=",
+            &["10.64.0.7/32", "fd00:64::7/128"],
+        )]),
+    )
+    .await
+    .unwrap();
+    kernel.calls.lock().unwrap().clear();
+
+    apply(
+        &kernel,
+        &a_document(vec![a_peer(
+            "cGVlcjE=",
+            &["fd00:64::7/128", "10.64.0.7/32"],
+        )]),
+    )
+    .await
+    .unwrap();
+
+    // The kernel reports them in its own order. Rewriting a peer because a list
+    // was shuffled would reset a session for nothing.
+    assert!(kernel.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn an_interface_the_document_does_not_mention_is_left_alone() {
+    let kernel = FakeKernel::default();
+    kernel.create_wireguard("wg-operators-own").await.unwrap();
+    kernel
+        .set_wireguard_peer(
+            "wg-operators-own",
+            &WgPeer {
+                public_key: "b3RoZXI=".to_string(),
+                allowed_ips: vec!["192.0.2.0/24".parse().unwrap()],
+                endpoint: None,
+                persistent_keepalive: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    apply(&kernel, &a_document(vec![])).await.unwrap();
+
+    // A route server is not necessarily only a route server. A bug here must
+    // not be able to take out the operator's own networking.
+    assert_eq!(kernel.peers_of("wg-operators-own").len(), 1);
+}
+
+#[tokio::test]
+async fn a_key_that_is_not_a_key_is_refused_rather_than_configured() {
+    let kernel = FakeKernel::default();
+    let mut doc = a_document(vec![]);
+    doc.interfaces[0].private_key = "not a key".to_string();
+
+    let err = apply(&kernel, &doc).await.unwrap_err();
+    assert!(
+        format!("{err:#}").contains("not a WireGuard key"),
+        "{err:#}"
+    );
+}
+
+impl std::fmt::Debug for FakeKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FakeKernel")
+            .field("calls", &self.calls.lock().unwrap())
+            .finish()
+    }
+}

--- a/lnvps_vpn/src/client.rs
+++ b/lnvps_vpn/src/client.rs
@@ -1,0 +1,296 @@
+//! Asking LNVPS what this route server should be.
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::config::VpnConfig;
+
+/// The desired data plane, as LNVPS states it.
+///
+/// Mirrors `GET /api/v1/routeserver/dataplane`. Defined here rather than shared
+/// with the API crate because the route server must not compile the database
+/// and the payment stack to parse four structs, and because a daemon that
+/// tolerates a field it does not know about is one that can be upgraded in
+/// either order.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct DesiredDataPlane {
+    pub generation: u64,
+    pub interfaces: Vec<DesiredInterface>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct DesiredInterface {
+    /// The pool this realises. The interface is named from it.
+    pub pool_id: u64,
+    pub private_key: String,
+    pub listen_port: u16,
+    pub mtu: u16,
+    pub addresses: Vec<String>,
+    pub routes: Vec<String>,
+    pub peers: Vec<DesiredPeer>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct DesiredPeer {
+    pub public_key: String,
+    pub allowed_ips: Vec<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub persistent_keepalive: Option<u16>,
+}
+
+impl DesiredInterface {
+    /// The interface this becomes.
+    ///
+    /// Derived from the pool id rather than carried in the document, and the
+    /// same rule LNVPS uses: a name that arrived over the wire could be edited
+    /// to point at an interface this pool does not own, and the next apply
+    /// would rewrite somebody else's tunnel. The `wgln` prefix also keeps a
+    /// managed interface from ever being confused with one the operator built.
+    pub fn interface(&self) -> String {
+        format!("wgln{}", self.pool_id)
+    }
+}
+
+/// The shape of every LNVPS API response.
+#[derive(Deserialize)]
+struct ApiEnvelope<T> {
+    data: Option<T>,
+    error: Option<String>,
+}
+
+pub struct Client {
+    http: reqwest::Client,
+    #[cfg_attr(not(test), allow(dead_code))]
+    api_url: String,
+    token: String,
+}
+
+impl Client {
+    pub fn new(config: &VpnConfig) -> Result<Self> {
+        Ok(Self {
+            http: reqwest::Client::builder()
+                // Comfortably longer than the longest wait LNVPS will hold a
+                // request for. Too short and every held fetch looks like a
+                // network failure; too long and a connection a NAT dropped
+                // silently is one the daemon sits on instead of reconnecting.
+                .timeout(config.wait() + std::time::Duration::from_secs(30))
+                .build()
+                .context("Cannot build an HTTP client")?,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            token: config.token.clone(),
+        })
+    }
+
+    /// Fetch the desired data plane, asking LNVPS to hold the request until it
+    /// differs from `generation`.
+    ///
+    /// Returns whatever LNVPS says, including an unchanged document when the
+    /// wait expired: the caller compares generations rather than being told
+    /// separately, so there is one answer to "what should this machine be"
+    /// instead of two that can disagree.
+    pub async fn dataplane(&self, generation: u64, wait_secs: u64) -> Result<DesiredDataPlane> {
+        let url = format!(
+            "{}/api/v1/routeserver/dataplane?generation={generation}&wait={wait_secs}",
+            self.api_url
+        );
+        let response = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .context("Cannot reach LNVPS")?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .context("Cannot read the response from LNVPS")?;
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            // Named, because it is the one failure that will never fix itself
+            // and the one an operator can act on immediately.
+            bail!("LNVPS rejected this route server's token");
+        }
+        if !status.is_success() {
+            bail!("LNVPS answered {status}: {body}");
+        }
+
+        let envelope: ApiEnvelope<DesiredDataPlane> =
+            serde_json::from_str(&body).context("Cannot parse the data plane LNVPS sent")?;
+        match (envelope.data, envelope.error) {
+            (Some(data), _) => Ok(data),
+            (None, Some(e)) => bail!("LNVPS refused: {e}"),
+            (None, None) => bail!("LNVPS sent neither a data plane nor a reason"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_interface_is_named_from_its_pool() {
+        let iface = DesiredInterface {
+            pool_id: 7,
+            private_key: String::new(),
+            listen_port: 51820,
+            mtu: 1420,
+            addresses: vec![],
+            routes: vec![],
+            peers: vec![],
+        };
+        assert_eq!(iface.interface(), "wgln7");
+    }
+
+    /// Answer exactly one request with `status` and `body`, and report what was
+    /// asked for. Enough to assert the daemon's half of the conversation
+    /// without standing up the API.
+    async fn one_shot(status: &str, body: &str) -> (String, tokio::task::JoinHandle<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let response = format!(
+            "HTTP/1.1 {status}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let handle = tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let n = socket.read(&mut buf).await.unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+            request
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn a_config(api_url: &str) -> crate::config::VpnConfig {
+        crate::config::VpnConfig {
+            api_url: api_url.to_string(),
+            token: "7.s3cret".to_string(),
+            wait_secs: 25,
+            retry_secs: 5,
+            scrub_after_secs: 600,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_fetch_sends_the_generation_the_wait_and_the_token() {
+        let body = r#"{"data":{"generation":9,"interfaces":[]}}"#;
+        let (url, server) = one_shot("200 OK", body).await;
+
+        let doc = Client::new(&a_config(&url))
+            .unwrap()
+            .dataplane(4, 25)
+            .await
+            .unwrap();
+
+        assert_eq!(doc.generation, 9);
+        let request = server.await.unwrap();
+        assert!(request.contains("generation=4"), "{request}");
+        assert!(request.contains("wait=25"), "{request}");
+        // The whole credential, id included: LNVPS cannot look a router up by
+        // its secret, because the column is encrypted per row.
+        assert!(
+            request.contains("authorization: Bearer 7.s3cret"),
+            "{request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_token_says_so_plainly() {
+        let (url, _server) = one_shot("401 Unauthorized", "nope").await;
+
+        let err = Client::new(&a_config(&url))
+            .unwrap()
+            .dataplane(0, 0)
+            .await
+            .unwrap_err();
+
+        // The one failure that will never fix itself, and the one an operator
+        // can act on immediately. It must not read as a network problem.
+        assert!(
+            format!("{err:#}").contains("rejected this route server's token"),
+            "{err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refusal_carries_its_reason() {
+        let body = r#"{"error":"Tunnel pool 7 has no block"}"#;
+        let (url, _server) = one_shot("200 OK", body).await;
+
+        let err = Client::new(&a_config(&url))
+            .unwrap()
+            .dataplane(0, 0)
+            .await
+            .unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("Tunnel pool 7 has no block"),
+            "{err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_body_that_is_not_a_document_is_not_silently_an_empty_one() {
+        let (url, _server) = one_shot("200 OK", "<html>proxy error</html>").await;
+
+        // An empty document would mean removing every peer on the machine,
+        // which is what a captive portal or a misconfigured proxy would cause.
+        let err = Client::new(&a_config(&url))
+            .unwrap()
+            .dataplane(0, 0)
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("Cannot parse"), "{err:#}");
+    }
+
+    #[test]
+    fn a_client_trims_a_trailing_slash_off_the_api_url() {
+        // Otherwise every request would be built with a double slash, which
+        // some proxies redirect and some reject.
+        let config = crate::config::VpnConfig {
+            api_url: "https://api.lnvps.net/".to_string(),
+            token: "7.s3cret".to_string(),
+            wait_secs: 25,
+            retry_secs: 5,
+            scrub_after_secs: 600,
+        };
+        assert_eq!(
+            Client::new(&config).unwrap().api_url,
+            "https://api.lnvps.net"
+        );
+    }
+
+    #[test]
+    fn a_document_with_fields_this_build_does_not_know_still_parses() {
+        // Otherwise the API could never gain a field without every route
+        // server having to be upgraded first, in lockstep, worldwide.
+        let json = r#"{
+            "generation": 3,
+            "something_new": true,
+            "interfaces": [{
+                "pool_id": 1,
+                "private_key": "k",
+                "listen_port": 51820,
+                "mtu": 1420,
+                "addresses": ["10.64.0.1/24"],
+                "routes": [],
+                "peers": [{"public_key": "p", "allowed_ips": ["10.64.0.7/32"]}],
+                "future_field": 9
+            }]
+        }"#;
+        let doc: DesiredDataPlane = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.generation, 3);
+        assert_eq!(doc.interfaces[0].peers[0].public_key, "p");
+        // Absent optional fields are absent, not an error: a device has no
+        // endpoint, because it is found by where it last spoke from.
+        assert_eq!(doc.interfaces[0].peers[0].endpoint, None);
+    }
+}

--- a/lnvps_vpn/src/config.rs
+++ b/lnvps_vpn/src/config.rs
@@ -1,0 +1,182 @@
+//! What `lvd` needs to start.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct VpnConfig {
+    /// Base URL of the LNVPS API, e.g. `https://api.lnvps.net`.
+    pub api_url: String,
+
+    /// This route server's credential, `<router_id>.<secret>`.
+    ///
+    /// Static, and provisioned by hand with everything else about the machine.
+    /// There is nothing to register: unlike a marketplace node, which is
+    /// somebody else's hardware enrolling itself, a route server is LNVPS's own
+    /// and exists in the database before it is ever switched on.
+    pub token: String,
+
+    /// Seconds to ask LNVPS to hold a fetch open waiting for a change.
+    ///
+    /// Zero turns the wait off and makes this an ordinary poll. The server caps
+    /// it, so setting it higher than the server's limit is not an error, it is
+    /// just capped.
+    #[serde(default = "default_wait_secs")]
+    pub wait_secs: u64,
+
+    /// Seconds to wait before fetching again after a failure.
+    ///
+    /// Deliberately short. The daemon is idle almost all of the time, so the
+    /// cost of retrying is nothing, and the thing being delayed is a
+    /// revocation.
+    #[serde(default = "default_retry_secs")]
+    pub retry_secs: u64,
+
+    /// Seconds a peer may go without a handshake before its recorded endpoint
+    /// is scrubbed. See [`crate::scrub`].
+    #[serde(default = "default_scrub_after_secs")]
+    pub scrub_after_secs: u64,
+}
+
+fn default_wait_secs() -> u64 {
+    25
+}
+
+fn default_retry_secs() -> u64 {
+    5
+}
+
+/// Ten minutes, which is Mullvad's figure and a reasonable one: long enough
+/// that a laptop closing its lid for a moment does not have to renegotiate,
+/// short enough that an address is not kept for an afternoon.
+fn default_scrub_after_secs() -> u64 {
+    600
+}
+
+impl VpnConfig {
+    pub fn load(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("Cannot read {}", path.display()))?;
+        let config: Self = serde_yaml_ng::from_str(&text)
+            .with_context(|| format!("Cannot parse {}", path.display()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Check what can be checked without contacting anything.
+    ///
+    /// Run at startup rather than on first use, so a typo in the config is a
+    /// message at boot instead of an interface that never appears.
+    pub fn validate(&self) -> Result<()> {
+        if !self.api_url.starts_with("https://") && !self.api_url.starts_with("http://") {
+            bail!("api-url must be an http or https URL, got {}", self.api_url);
+        }
+        // The id is checked here because it is the half of the token that can
+        // be wrong in a way LNVPS answers with a flat 401, which reads like a
+        // bad secret and sends an operator looking in the wrong place.
+        match self.token.split_once('.') {
+            Some((id, secret)) if id.parse::<u64>().is_ok() && !secret.is_empty() => {}
+            _ => bail!("token must be <router_id>.<secret>"),
+        }
+        Ok(())
+    }
+
+    pub fn wait(&self) -> Duration {
+        Duration::from_secs(self.wait_secs)
+    }
+
+    pub fn retry(&self) -> Duration {
+        Duration::from_secs(self.retry_secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn a_config() -> VpnConfig {
+        VpnConfig {
+            api_url: "https://api.lnvps.net".to_string(),
+            token: "7.s3cret".to_string(),
+            wait_secs: 25,
+            retry_secs: 5,
+            scrub_after_secs: 600,
+        }
+    }
+
+    #[test]
+    fn a_good_config_passes() {
+        a_config().validate().unwrap();
+    }
+
+    #[test]
+    fn a_token_without_a_router_id_is_refused_at_startup() {
+        // Rather than at the first fetch, where LNVPS answers 401 and an
+        // operator goes looking at the secret.
+        for bad in ["s3cret", "seven.s3cret", "7.", "7"] {
+            let mut c = a_config();
+            c.token = bad.to_string();
+            assert!(c.validate().is_err(), "{bad} should be refused");
+        }
+    }
+
+    #[test]
+    fn an_api_url_that_is_not_a_url_is_refused() {
+        let mut c = a_config();
+        c.api_url = "api.lnvps.net".to_string();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn a_minimal_file_loads_and_fills_in_the_rest() {
+        let dir = std::env::temp_dir().join(format!("lvd-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.yaml");
+        std::fs::write(&path, "api-url: https://api.lnvps.net\ntoken: 7.s3cret\n").unwrap();
+
+        let config = VpnConfig::load(&path).unwrap();
+
+        assert_eq!(config.api_url, "https://api.lnvps.net");
+        assert_eq!(config.wait_secs, 25);
+        assert_eq!(config.retry_secs, 5);
+        // Mullvad's figure, and the one this defends.
+        assert_eq!(config.scrub_after_secs, 600);
+        assert_eq!(config.wait(), Duration::from_secs(25));
+        assert_eq!(config.retry(), Duration::from_secs(5));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_file_with_a_key_that_does_not_exist_is_refused() {
+        let dir = std::env::temp_dir().join(format!("lvd-typo-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.yaml");
+        // `deny_unknown_fields`, so a typo is a message at startup rather than
+        // a setting that silently does nothing.
+        std::fs::write(
+            &path,
+            "api-url: https://api.lnvps.net\ntoken: 7.s3cret\nwait_secs: 5\n",
+        )
+        .unwrap();
+
+        assert!(VpnConfig::load(&path).is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_file_that_is_not_there_says_so() {
+        let err = VpnConfig::load(Path::new("/nonexistent/lvd.yaml")).unwrap_err();
+        assert!(format!("{err:#}").contains("Cannot read"), "{err:#}");
+    }
+
+    #[test]
+    fn the_shipped_example_is_a_config_this_build_accepts() {
+        // Otherwise the file an operator copies is the one thing never tested.
+        let example = Path::new(env!("CARGO_MANIFEST_DIR")).join("config.example.yaml");
+        VpnConfig::load(&example).unwrap();
+    }
+}

--- a/lnvps_vpn/src/lib.rs
+++ b/lnvps_vpn/src/lib.rs
@@ -1,0 +1,31 @@
+//! `lvd` — the LNVPS VPN daemon.
+//!
+//! Runs on a route server and makes it carry the interfaces LNVPS says it
+//! should. One interface per tunnel pool, one peer per customer device.
+//!
+//! Everything is outbound. The daemon asks what it should be and applies the
+//! answer; nothing dials it. A route server runs wherever its region is, which
+//! means behind somebody else's NAT, on a residential-grade uplink, or on a
+//! provider that filters inbound, and a design that needed to reach it would
+//! work everywhere it was tested and fail on the one machine nobody thought
+//! about. The way that failure surfaces is a revoked device that keeps
+//! working, so it is not a failure anyone would notice quickly.
+//!
+//! To get the speed of a push out of a pull, the fetch waits: the daemon sends
+//! the generation it last applied and LNVPS holds the request until that moves.
+//! A revoked key stops being honoured in about one round trip.
+//!
+//! What this daemon deliberately does not do:
+//!
+//! - **NAT and egress filtering.** The route server does its own, configured by
+//!   whoever built it. LNVPS manages interfaces and peers.
+//! - **Logging who connected.** A peer is a key and the addresses it may use.
+//!   The daemon never learns whose it is, because it is never told.
+//! - **Keeping a customer's address longer than it must.** WireGuard records
+//!   where each peer was last heard from, which for a device is somebody's real
+//!   address. [`scrub`] removes it once the peer has gone quiet.
+
+pub mod apply;
+pub mod client;
+pub mod config;
+pub mod scrub;

--- a/lnvps_vpn/src/main.rs
+++ b/lnvps_vpn/src/main.rs
@@ -1,0 +1,163 @@
+//! `lvd` — the LNVPS VPN daemon.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use lnvps_netlink::{Kernel, NetOps};
+use lnvps_vpn::client::Client;
+use lnvps_vpn::config::VpnConfig;
+use lnvps_vpn::{apply, scrub};
+
+#[derive(Parser)]
+#[command(name = "lvd", version, about = "LNVPS VPN route server daemon")]
+struct Cli {
+    /// Path to the configuration file.
+    #[arg(short, long, default_value = "/etc/lvd/config.yaml")]
+    config: PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run the daemon: fetch what this route server should be and keep it that
+    /// way.
+    Run,
+    /// Check the configuration without contacting LNVPS or touching the
+    /// machine.
+    Check,
+    /// Fetch what LNVPS wants and print it, changing nothing.
+    Show,
+    /// Fetch it and apply it once, then exit.
+    Apply,
+    /// Print what this machine currently has, read from the machine itself.
+    Observe,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+    let config = VpnConfig::load(&cli.config)?;
+
+    match cli.command {
+        Command::Check => {
+            // `load` already validated. Saying so is the point of the command:
+            // an operator wants to know the file is good before starting.
+            println!("{} looks good", cli.config.display());
+            Ok(())
+        }
+        Command::Show => {
+            let doc = Client::new(&config)?.dataplane(0, 0).await?;
+            println!("{}", serde_json::to_string_pretty(&doc)?);
+            Ok(())
+        }
+        Command::Apply => {
+            let kernel = Kernel::host()?;
+            let doc = Client::new(&config)?.dataplane(0, 0).await?;
+            report(apply::apply(&kernel, &doc).await?);
+            Ok(())
+        }
+        Command::Observe => {
+            let kernel = Kernel::host()?;
+            let doc = Client::new(&config)?.dataplane(0, 0).await?;
+            for interface in &doc.interfaces {
+                let name = interface.interface();
+                match kernel.wireguard_state(&name).await? {
+                    Some(state) => println!(
+                        "{name}: port {}, {} peers, {} of them handshaken",
+                        state.listen_port,
+                        state.peers.len(),
+                        state
+                            .peers
+                            .iter()
+                            .filter(|p| p.last_handshake_secs.is_some())
+                            .count()
+                    ),
+                    None => println!("{name}: not configured"),
+                }
+            }
+            Ok(())
+        }
+        Command::Run => run(config).await,
+    }
+}
+
+/// Fetch, apply, repeat.
+///
+/// The fetch waits: LNVPS holds it open until the generation moves, so a
+/// revoked key stops being honoured in about one round trip rather than on the
+/// next poll. When the wait expires the document comes back unchanged and the
+/// apply is silent, which is the ordinary case and costs nothing.
+async fn run(config: VpnConfig) -> Result<()> {
+    let client = Client::new(&config)?;
+    let kernel = Kernel::host().context("Cannot talk to the kernel; lvd needs to run as root")?;
+
+    // Zero, not the last generation applied: this daemon has just started and
+    // has no idea what the machine is carrying, so the first fetch must return
+    // the document rather than wait for it to change.
+    let mut generation = 0;
+
+    loop {
+        let doc = match client.dataplane(generation, config.wait_secs).await {
+            Ok(doc) => doc,
+            Err(e) => {
+                // Logged and retried rather than fatal. A route server that
+                // exits because LNVPS was briefly unreachable is one that stops
+                // carrying traffic it is already carrying perfectly well: the
+                // kernel keeps forwarding without this process.
+                log::warn!("Could not fetch the data plane: {e:#}");
+                tokio::time::sleep(config.retry()).await;
+                continue;
+            }
+        };
+
+        match apply::apply(&kernel, &doc).await {
+            Ok(applied) => {
+                for change in &applied.changes {
+                    log::info!("{change}");
+                }
+                // Only on success. Recording a generation that was not applied
+                // would mean the next fetch waits for a *further* change before
+                // retrying, so one failed apply would strand the machine until
+                // somebody else's device moved.
+                generation = doc.generation;
+            }
+            Err(e) => {
+                log::error!("Could not apply generation {}: {e:#}", doc.generation);
+                tokio::time::sleep(config.retry()).await;
+                continue;
+            }
+        }
+
+        match scrub::scrub_quiet_peers(&kernel, &doc, config.scrub_after_secs).await {
+            Ok(scrubbed) => {
+                for key in scrubbed {
+                    log::info!("scrubbed the recorded address of {key}");
+                }
+            }
+            // Not fatal, and not a reason to retry the fetch: the peers are
+            // configured correctly, this only failed to forget something.
+            Err(e) => log::warn!("Could not scrub quiet peers: {e:#}"),
+        }
+
+        // A floor under the loop. With a wait the fetch already blocks, but a
+        // server that answers immediately every time -- because the generation
+        // keeps moving, or because `wait` is zero -- must not turn this into a
+        // spin.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+fn report(applied: apply::Applied) {
+    if applied.is_empty() {
+        println!("already correct");
+        return;
+    }
+    for change in applied.changes {
+        println!("{change}");
+    }
+}

--- a/lnvps_vpn/src/scrub.rs
+++ b/lnvps_vpn/src/scrub.rs
@@ -1,0 +1,94 @@
+//! Forgetting where a customer was.
+//!
+//! WireGuard records, per peer, the address it was last heard from. It has to:
+//! that is how a roaming client is found, and it is why a phone can move from
+//! wifi to mobile without renegotiating. For a VPN device that address is the
+//! customer's real one, the single piece of information this service exists to
+//! keep to itself, sitting in kernel memory for as long as the peer is
+//! configured.
+//!
+//! Nothing here can stop it being recorded while a peer is talking. What can be
+//! stopped is it being kept afterwards. Once a peer has gone quiet for long
+//! enough that it is plainly not connected, the peer is removed and re-added,
+//! which is the only way to clear the field: the kernel offers no "forget where
+//! this peer was" and setting an endpoint requires an address to set it to.
+//!
+//! Copied from Mullvad, who do the same at 600 seconds. The cost of being wrong
+//! is small in one direction and not the other: scrub too eagerly and a client
+//! sends one handshake to reconnect, which it does anyway on any change of
+//! network; scrub too late and the address is held for no reason.
+
+use anyhow::Result;
+use lnvps_netlink::{NetOps, WgPeer};
+
+use crate::client::{DesiredDataPlane, DesiredPeer};
+
+/// Scrub the recorded endpoint of every peer that has been quiet for longer
+/// than `after_secs`.
+///
+/// Returns the keys scrubbed, for logging. Peers that never handshook at all
+/// are skipped: there is nothing recorded to remove, and removing and re-adding
+/// them on every pass would be churn for its own sake.
+pub async fn scrub_quiet_peers(
+    ops: &dyn NetOps,
+    desired: &DesiredDataPlane,
+    after_secs: u64,
+) -> Result<Vec<String>> {
+    let mut scrubbed = Vec::new();
+
+    for interface in &desired.interfaces {
+        let name = interface.interface();
+        let Some(observed) = ops.wireguard_state(&name).await? else {
+            continue;
+        };
+
+        for peer in &observed.peers {
+            // No recorded address means nothing to forget.
+            if peer.endpoint.is_none() {
+                continue;
+            }
+            // Never handshook: whatever address is there was never confirmed to
+            // be anyone, and the peer is not connected to be disturbed.
+            let Some(quiet_for) = peer.last_handshake_secs else {
+                continue;
+            };
+            if quiet_for < after_secs {
+                continue;
+            }
+            // Only peers LNVPS asked for. An interface may carry something the
+            // operator put there, and removing it would be this daemon
+            // reaching outside what it was given.
+            let Some(wanted) = interface
+                .peers
+                .iter()
+                .find(|p| p.public_key == peer.public_key)
+            else {
+                continue;
+            };
+
+            ops.remove_wireguard_peer(&name, &peer.public_key).await?;
+            ops.set_wireguard_peer(&name, &as_peer(wanted)?).await?;
+            scrubbed.push(peer.public_key.clone());
+        }
+    }
+
+    Ok(scrubbed)
+}
+
+/// Rebuild a peer from the document rather than from what was read back, so a
+/// scrub cannot quietly re-apply drift it happened to observe.
+fn as_peer(desired: &DesiredPeer) -> Result<WgPeer> {
+    Ok(WgPeer {
+        public_key: desired.public_key.clone(),
+        allowed_ips: desired
+            .allowed_ips
+            .iter()
+            .map(|a| a.parse())
+            .collect::<Result<Vec<_>, _>>()?,
+        endpoint: desired.endpoint.clone(),
+        persistent_keepalive: desired.persistent_keepalive,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/lnvps_vpn/src/scrub/tests.rs
+++ b/lnvps_vpn/src/scrub/tests.rs
@@ -1,0 +1,85 @@
+//! Forgetting where a customer was.
+
+use super::*;
+use crate::apply::apply;
+use crate::apply::tests::{FakeKernel, a_document, a_peer};
+
+const QUIET: u64 = 600;
+
+#[tokio::test]
+async fn a_peer_that_has_gone_quiet_has_its_address_forgotten() {
+    let kernel = FakeKernel::default();
+    let doc = a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]);
+    apply(&kernel, &doc).await.unwrap();
+    kernel.peer_spoke("wgln7", "cGVlcjE=", "203.0.113.9:41414", QUIET + 1);
+
+    let scrubbed = scrub_quiet_peers(&kernel, &doc, QUIET).await.unwrap();
+
+    assert_eq!(scrubbed, vec!["cGVlcjE=".to_string()]);
+    let peer = &kernel.peers_of("wgln7")[0];
+    assert_eq!(peer.endpoint, None, "the customer's address is still here");
+    // Re-added, not dropped: a client that comes back must find its key
+    // configured, or the scrub would be a disconnection.
+    assert_eq!(peer.allowed_ips.len(), 1);
+}
+
+#[tokio::test]
+async fn a_peer_that_is_still_talking_is_left_alone() {
+    let kernel = FakeKernel::default();
+    let doc = a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]);
+    apply(&kernel, &doc).await.unwrap();
+    kernel.peer_spoke("wgln7", "cGVlcjE=", "203.0.113.9:41414", QUIET - 1);
+    kernel.calls.lock().unwrap().clear();
+
+    let scrubbed = scrub_quiet_peers(&kernel, &doc, QUIET).await.unwrap();
+
+    assert!(scrubbed.is_empty());
+    // Scrubbing a live peer would cost it a handshake for nothing.
+    assert!(kernel.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn a_peer_that_never_connected_is_not_churned() {
+    let kernel = FakeKernel::default();
+    let doc = a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]);
+    apply(&kernel, &doc).await.unwrap();
+    kernel.calls.lock().unwrap().clear();
+
+    // Nothing was ever recorded, so there is nothing to forget, and removing
+    // and re-adding it on every pass would be churn for its own sake.
+    assert!(
+        scrub_quiet_peers(&kernel, &doc, QUIET)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(kernel.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn a_peer_lnvps_did_not_ask_for_is_not_touched() {
+    let kernel = FakeKernel::default();
+    let doc = a_document(vec![a_peer("cGVlcjE=", &["10.64.0.7/32"])]);
+    apply(&kernel, &doc).await.unwrap();
+    // Something the operator put on the interface themselves.
+    kernel
+        .set_wireguard_peer(
+            "wgln7",
+            &WgPeer {
+                public_key: "b3RoZXI=".to_string(),
+                allowed_ips: vec!["192.0.2.0/24".parse().unwrap()],
+                endpoint: None,
+                persistent_keepalive: None,
+            },
+        )
+        .await
+        .unwrap();
+    kernel.peer_spoke("wgln7", "b3RoZXI=", "203.0.113.9:41414", QUIET + 1);
+
+    let scrubbed = scrub_quiet_peers(&kernel, &doc, QUIET).await.unwrap();
+
+    // Removing and re-adding it would be this daemon rebuilding a peer from a
+    // document that never described it.
+    assert!(scrubbed.is_empty());
+    assert_eq!(kernel.peers_of("wgln7").len(), 2);
+}

--- a/work/vpn-service.md
+++ b/work/vpn-service.md
@@ -339,11 +339,40 @@ Notes:
 - The desired-document types, `apply`, `observe` and `DataPlaneState` stayed behind: bridges,
   guests and libvirt are a marketplace node's vocabulary, not a data plane's.
 
-### Increment 8 — `lnvps_vpn` daemon
-- [ ] New crate `lnvps_vpn`, binary `lvd`: pull loop, batch peer apply (`wg syncconf` equivalent over netlink),
-      600s endpoint scrub, inbound control listener for immediate re-pull
-- [ ] Config, packaging, `config.example.yaml`
-- [ ] Unit tests
+### Increment 8 — `lnvps_vpn` daemon  ✅ DONE (bar packaging)
+- [x] New crate `lnvps_vpn`, binary `lvd`. Root workspace member, released on the API's tag.
+- [x] `client.rs`: the long-polling fetch. Its own copy of the document types rather than a
+      shared crate, because a route server must not compile the database and the payment
+      stack to parse four structs, and because a daemon that tolerates fields it does not
+      know can be upgraded in either order.
+- [x] `apply.rs`: convergent, and **peer-at-a-time**. The kernel's only way to state a
+      device's configuration replaces its peer set with it, so a whole-interface apply would
+      reset every established session — one customer registering a phone becoming a stampede
+      of renegotiation across thousands of peers. The interface is re-keyed only when the key
+      or port is actually wrong.
+- [x] `scrub.rs`: the 600s endpoint scrub, and the reason it exists spelled out where the
+      code is.
+- [x] `Kernel::host()` in `lnvps_netlink`, plus `set_wireguard_peer` /
+      `configure_wireguard_interface`, and `WgObserved` carrying port, key, per-peer allowed
+      IPs, endpoint and byte counters.
+- [x] `config.example.yaml`, with a test asserting this build accepts it.
+- [x] 26 unit tests. `client.rs`, `config.rs` and `scrub.rs` at 100% function coverage.
+
+**No inbound control listener.** The original sketch had one for immediate re-pull. It is not
+needed and it is not wanted: long-poll already delivers a change in one round trip, and an
+inbound listener would need a port, a certificate for LNVPS to pin, and reachability that a
+route server behind somebody else's NAT does not have. Outbound-only means the daemon has no
+listening socket at all.
+
+Notes:
+
+- **An interface the document does not mention is left alone.** A route server is not
+  necessarily only a route server, and tearing down what LNVPS has not heard of would let a
+  bug here take out the operator's own networking.
+- **`main.rs` is uncovered**, as `lnvps_node`'s is: it is the loop and the CLI. Increment 9
+  must exercise it.
+- Still open from increment 6: `POST /api/v1/routeserver/counters`. The counters are read
+  from the kernel now (`WgPeerState::rx_bytes`/`tx_bytes`); nothing reports them yet.
 
 ### Increment 9 — end-to-end
 - [ ] Extend the netns harness: one device reaching two pools with the same inner address


### PR DESCRIPTION
Increment 8. `lvd` is a new binary that runs on a VPN route server and makes it carry the interfaces LNVPS says it should: one interface per tunnel pool, one peer per customer device.

It is built on #399, which published the document it fetches.

## Peer-at-a-time, and why that is the whole design

The kernel's only way to state a WireGuard device's configuration replaces its peer set with it. That is fine for a marketplace node, which has one peer. On a route server carrying thousands of devices it is catastrophic: an apply that rebuilt the interface would tear down every established session on it, so one customer registering a phone becomes a stampede of renegotiation across everybody else.

So `apply` reconciles peers individually. A peer is added when it is new, rewritten when its allowed IPs have moved, removed when the document no longer lists it, and otherwise not touched. Allowed IPs are compared as sets, because the kernel reports them in its own order and rewriting a peer over a shuffled list would reset a session for nothing. The interface itself is re-keyed only when its key or listening port is genuinely wrong, which on the ordinary path never happens.

There is a test asserting that a second apply of the same document makes **zero** kernel calls, and another asserting that adding one device makes exactly one.

## No inbound listener

The original plan had a control listener so LNVPS could poke the daemon into re-pulling. That is gone.

Long-poll already delivers a change in one round trip, and a listener would need a port, a certificate for LNVPS to pin, and reachability that a machine behind somebody else's NAT does not have. `lvd` has no listening socket at all: it opens connections and never accepts them. That is a smaller surface than `lnvps_node` has, on a machine that by design sits in a network nobody here controls.

## Forgetting where a customer was

WireGuard records, per peer, the address it was last heard from. It has to; that is how a roaming client is found, and why a phone can move from wifi to mobile without renegotiating. For a VPN device that address is the customer's real one, sitting in kernel memory for as long as the peer is configured.

Nothing can stop it being recorded while a peer is talking. What can be stopped is it being kept afterwards. Once a peer has been quiet for ten minutes, `scrub` removes and re-adds it, which is the only way to clear the field: the kernel offers no "forget where this peer was", and setting an endpoint requires an address to set it to. Mullvad does the same at the same figure.

Peers that never handshook are skipped, because there is nothing recorded to forget and churning them every pass would be churn for its own sake. So is anything LNVPS did not ask for.

## An interface the document does not mention is left alone

A route server is not necessarily only a route server. Tearing down an interface because LNVPS has not heard of it would mean a bug in this daemon could take out the operator's own networking. LNVPS removes what it created, through the pool going away.

## The netlink layer

`lnvps_netlink` gains three things, none of which changes what `lnvps_node` does.

The namespace is now optional. The two daemons want opposite things and both are right: a marketplace node is somebody else's machine running somebody else's workloads, so configuring routes and forwarding in its own namespace would be configuring the operator's network for them; a VPN route server is a machine LNVPS runs for exactly this, its interfaces *are* the host's, and hiding them would mean an operator debugging it cannot see them from a plain shell. `Kernel::host()` is the second case.

`set_wireguard_peer` and `configure_wireguard_interface` split the destructive whole-interface apply from the incremental one, per the above.

`WgObserved` carried peers as `(key, handshake_age)` tuples, which is everything a node needs and none of what a route server does. It now carries the listening port, the public half of the configured key, and per-peer allowed IPs, endpoint and byte counters. The last two are the point: counters are how traffic is reported without a per-device log, and the endpoint is what the scrub exists to remove. Both were already in the kernel's answer and were being discarded.

## Wire types

The document types are the daemon's own rather than shared with the API crate. A route server should not compile the database, axum and the payment stack to parse four structs. Unknown fields are tolerated, so the API can gain one without every route server in the world having to be upgraded first, in lockstep.

## Not in this PR

- `POST /api/v1/routeserver/counters`. The counters are now read from the kernel but nothing reports them. It is the same data the admin aggregate reporting needs, so both ends should be written together.
- Drift detection for an `lvd` pool. `reconcile_peers` still returns empty drift for this router kind.
- Packaging. `lvd` builds as a workspace member and is released on the API's tag; there is no `.deb` and no self-upgrade.
- Coverage of `main.rs`, the loop and the CLI, which is uncovered exactly as `lnvps_node`'s is. That belongs to increment 9, which also has to prove one device reaching two pools on the same inner address through a real kernel.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-features --all-targets` and `cargo test --workspace --all-features --exclude lnvps_e2e -- --test-threads=1` are clean: 2017 tests pass, 26 of them new. `client.rs`, `config.rs` and `scrub.rs` are at 100% function coverage. One of those tests loads the shipped `config.example.yaml`, so the file an operator copies is not the one thing never checked.
