### PR TITLE
Schedule and record app deployment backups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +3698,8 @@ name = "lnvps_compose"
 version = "0.4.7"
 dependencies = [
  "anyhow",
+ "chrono",
+ "croner",
  "rand 0.9.4",
  "regex",
  "serde",
@@ -6927,6 +6940,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -4,16 +4,16 @@ use chrono::{DateTime, Days, Months, NaiveDate, TimeDelta, Utc};
 use lnvps_db::nostr::LNVPSNostrDb;
 use lnvps_db::{
     AccessPolicy, AgentConversation, AgentConversationFilter, AgentConversationOverview,
-    AgentMessage, App, AppCluster, AppDeployment, AppDeploymentDesiredState, AppDeploymentFilter,
-    AppDeploymentServiceUsage, AppDeploymentStatus, AppDeploymentVolumeUsage, AppTag,
-    AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, BulkMessageTarget, Company, CpuArch,
-    CpuMfg, DbError, DbResult, Discount, DiscountRedemption, DiskInterface, DiskType, DnsServer,
-    DnsServerKind, EncryptedString, IntervalType, IpRange, IpRangeAllocationMode,
-    IpRangeSubscription, IpSpacePricing, LNVpsDbBase, MarketplaceNode, MarketplaceNodeHealth,
-    MarketplaceNodeStatus, MarketplaceOperator, NewAgentMessage, NostrDomain, NostrDomainHandle,
-    OsDistribution, PaymentMethod, PaymentMethodConfig, Referral, ReferralCostUsage,
-    ReferralPayout, Region, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel,
-    RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
+    AgentMessage, App, AppBackupState, AppCluster, AppDeployment, AppDeploymentBackup,
+    AppDeploymentDesiredState, AppDeploymentFilter, AppDeploymentServiceUsage, AppDeploymentStatus,
+    AppDeploymentVolumeUsage, AppTag, AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace,
+    BulkMessageTarget, Company, CpuArch, CpuMfg, DbError, DbResult, Discount, DiscountRedemption,
+    DiskInterface, DiskType, DnsServer, DnsServerKind, EncryptedString, IntervalType, IpRange,
+    IpRangeAllocationMode, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, MarketplaceNode,
+    MarketplaceNodeHealth, MarketplaceNodeStatus, MarketplaceOperator, NewAgentMessage,
+    NostrDomain, NostrDomainHandle, OsDistribution, PaymentMethod, PaymentMethodConfig, Referral,
+    ReferralCostUsage, ReferralPayout, Region, Router, RouterBgpRoute, RouterBgpSession,
+    RouterTunnel, RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
     SubscriptionPaymentWithCompany, Tunnel, TunnelPool, TunnelRoute, User, UserPaymentMethod,
     UserSshKey, Vm, VmCostPlan, VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate,
     VmFirewallPolicy, VmFirewallRule, VmHistory, VmHost, VmHostDisk, VmHostKind, VmIpAssignment,
@@ -112,6 +112,7 @@ pub struct MockDb {
     pub app_tag_assignments: Arc<Mutex<Vec<(u64, u64)>>>,
     pub app_clusters: Arc<Mutex<HashMap<u64, AppCluster>>>,
     pub app_deployments: Arc<Mutex<HashMap<u64, AppDeployment>>>,
+    pub app_deployment_backups: Arc<Mutex<HashMap<u64, AppDeploymentBackup>>>,
     #[allow(clippy::type_complexity)]
     pub app_deployment_usage_breakdown: Arc<
         Mutex<
@@ -538,6 +539,7 @@ impl Default for MockDb {
             app_tag_assignments: Arc::new(Default::default()),
             app_clusters: Arc::new(Default::default()),
             app_deployments: Arc::new(Default::default()),
+            app_deployment_backups: Arc::new(Default::default()),
             app_deployment_usage_breakdown: Arc::new(Default::default()),
             failing_usage_writes: Arc::new(Default::default()),
             failing_usage_breakdown_writes: Arc::new(Default::default()),
@@ -5927,6 +5929,98 @@ impl LNVpsDbBase for MockDb {
         Ok((services, volumes))
     }
 
+    async fn list_app_deployment_backups(
+        &self,
+        deployment_id: u64,
+    ) -> DbResult<Vec<AppDeploymentBackup>> {
+        let b = self.app_deployment_backups.lock().await;
+        let mut out: Vec<AppDeploymentBackup> = b
+            .values()
+            .filter(|x| x.deployment_id == deployment_id && !x.deleted)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| b.created.cmp(&a.created).then(b.id.cmp(&a.id)));
+        Ok(out)
+    }
+
+    async fn get_app_deployment_backup(&self, id: u64) -> DbResult<AppDeploymentBackup> {
+        self.app_deployment_backups
+            .lock()
+            .await
+            .get(&id)
+            .filter(|b| !b.deleted)
+            .cloned()
+            .ok_or_else(|| anyhow!("app deployment backup not found").into())
+    }
+
+    async fn insert_app_deployment_backup(&self, backup: &AppDeploymentBackup) -> DbResult<u64> {
+        let mut b = self.app_deployment_backups.lock().await;
+        let new_id = b.keys().max().copied().unwrap_or(0) + 1;
+        b.insert(
+            new_id,
+            AppDeploymentBackup {
+                id: new_id,
+                ..backup.clone()
+            },
+        );
+        Ok(new_id)
+    }
+
+    async fn update_app_deployment_backup(&self, backup: &AppDeploymentBackup) -> DbResult<()> {
+        let mut b = self.app_deployment_backups.lock().await;
+        if let Some(x) = b.get_mut(&backup.id) {
+            // Mirrors the UPDATE's column list: everything else is immutable
+            // once the row exists.
+            x.object_key = backup.object_key.clone();
+            x.size_bytes = backup.size_bytes;
+            x.state = backup.state;
+            x.message = backup.message.clone();
+            x.started = backup.started;
+            x.completed = backup.completed;
+        }
+        Ok(())
+    }
+
+    async fn list_active_app_deployment_backups(
+        &self,
+        cluster_id: u64,
+    ) -> DbResult<Vec<AppDeploymentBackup>> {
+        let deployments = self.app_deployments.lock().await;
+        let b = self.app_deployment_backups.lock().await;
+        let mut out: Vec<AppDeploymentBackup> = b
+            .values()
+            .filter(|x| {
+                !x.deleted
+                    && matches!(x.state, AppBackupState::Pending | AppBackupState::Running)
+                    && deployments
+                        .get(&x.deployment_id)
+                        .is_some_and(|d| d.cluster_id == cluster_id)
+            })
+            .cloned()
+            .collect();
+        out.sort_by_key(|x| x.id);
+        Ok(out)
+    }
+
+    async fn last_scheduled_app_deployment_backup(
+        &self,
+        deployment_id: u64,
+    ) -> DbResult<Option<DateTime<Utc>>> {
+        let b = self.app_deployment_backups.lock().await;
+        Ok(b.values()
+            .filter(|x| x.deployment_id == deployment_id && x.scheduled)
+            .map(|x| x.created)
+            .max())
+    }
+
+    async fn delete_app_deployment_backup(&self, id: u64) -> DbResult<()> {
+        let mut b = self.app_deployment_backups.lock().await;
+        if let Some(x) = b.get_mut(&id) {
+            x.deleted = true;
+        }
+        Ok(())
+    }
+
     async fn delete_app_deployment(&self, id: u64) -> DbResult<()> {
         let mut d = self.app_deployments.lock().await;
         if let Some(x) = d.get_mut(&id) {
@@ -7017,8 +7111,10 @@ impl LNVPSNostrDb for MockDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
     use lnvps_db::{
-        AgentChannel, AgentMessageRole, IntervalType, LNVpsDbBase, SubscriptionPaymentType,
+        AgentChannel, AgentMessageRole, AppBackupMethod, IntervalType, LNVpsDbBase,
+        SubscriptionPaymentType,
     };
 
     fn user_msg(text: &str, channel: AgentChannel) -> NewAgentMessage {
@@ -9292,6 +9388,159 @@ mod tests {
         assert_eq!(db.list_user_app_deployments(1).await.unwrap().len(), 1);
         assert_eq!(db.list_all_app_deployments().await.unwrap().len(), 2);
         assert!(db.get_app_deployment(d1).await.unwrap().deleted);
+    }
+
+    #[tokio::test]
+    async fn test_app_deployment_backup_crud() {
+        let db = MockDb::default();
+        let app_id = db.insert_app(&mk_app("relay")).await.unwrap();
+        let cluster_a = db.insert_app_cluster(&mk_cluster("a", 1)).await.unwrap();
+        let cluster_b = db.insert_app_cluster(&mk_cluster("b", 1)).await.unwrap();
+
+        let mk_dep = |cluster_id: u64, li: u64, name: &str| AppDeployment {
+            id: 0,
+            user_id: 1,
+            app_id,
+            cluster_id,
+            resource_multiplier: 1,
+            subscription_line_item_id: li,
+            name: name.to_string(),
+            namespace: format!("app-{name}"),
+            hostname: None,
+            custom_domain: None,
+            custom_domain_verified: false,
+            config: None,
+            desired_state: AppDeploymentDesiredState::Running,
+            status: AppDeploymentStatus::Running,
+            status_message: None,
+            usage_cpu_milli: None,
+            usage_memory_bytes: None,
+            usage_storage_bytes: None,
+            usage_collected: None,
+            created: Utc::now(),
+            deleted: false,
+        };
+        let here = db
+            .insert_app_deployment(&mk_dep(cluster_a, 10, "here"))
+            .await
+            .unwrap();
+        let elsewhere = db
+            .insert_app_deployment(&mk_dep(cluster_b, 11, "elsewhere"))
+            .await
+            .unwrap();
+
+        let mk_backup =
+            |deployment_id: u64, service: &str, scheduled: bool, created: DateTime<Utc>| {
+                AppDeploymentBackup {
+                    id: 0,
+                    deployment_id,
+                    run_id: "run-1".to_string(),
+                    service: service.to_string(),
+                    method: AppBackupMethod::Command,
+                    artifact: format!("{service}.sql.gz"),
+                    object_key: None,
+                    size_bytes: None,
+                    state: AppBackupState::Pending,
+                    message: None,
+                    scheduled,
+                    created,
+                    started: None,
+                    completed: None,
+                    deleted: false,
+                }
+            };
+
+        let older = Utc::now() - Duration::hours(2);
+        let db_backup = db
+            .insert_app_deployment_backup(&mk_backup(here, "db", true, older))
+            .await
+            .unwrap();
+        let blobs = db
+            .insert_app_deployment_backup(&mk_backup(here, "blobs", false, Utc::now()))
+            .await
+            .unwrap();
+        let other = db
+            .insert_app_deployment_backup(&mk_backup(elsewhere, "db", false, Utc::now()))
+            .await
+            .unwrap();
+
+        // Listed newest first, and scoped to the deployment.
+        let listed = db.list_app_deployment_backups(here).await.unwrap();
+        assert_eq!(
+            listed.iter().map(|b| b.id).collect::<Vec<_>>(),
+            vec![blobs, db_backup]
+        );
+
+        // The operator only sees the backups on its own cluster.
+        let active = db
+            .list_active_app_deployment_backups(cluster_a)
+            .await
+            .unwrap();
+        assert_eq!(
+            active.iter().map(|b| b.id).collect::<Vec<_>>(),
+            vec![db_backup, blobs]
+        );
+        assert_eq!(
+            db.list_active_app_deployment_backups(cluster_b)
+                .await
+                .unwrap()
+                .iter()
+                .map(|b| b.id)
+                .collect::<Vec<_>>(),
+            vec![other]
+        );
+
+        // Progress write-back, and a completed backup drops out of the sweep.
+        let mut b = db.get_app_deployment_backup(db_backup).await.unwrap();
+        b.state = AppBackupState::Completed;
+        b.object_key = Some("deployments/1/run-1/db.sql.gz".to_string());
+        b.size_bytes = Some(4096);
+        b.completed = Some(Utc::now());
+        db.update_app_deployment_backup(&b).await.unwrap();
+        let reloaded = db.get_app_deployment_backup(db_backup).await.unwrap();
+        assert_eq!(reloaded.state, AppBackupState::Completed);
+        assert_eq!(reloaded.size_bytes, Some(4096));
+        assert_eq!(
+            db.list_active_app_deployment_backups(cluster_a)
+                .await
+                .unwrap()
+                .iter()
+                .map(|b| b.id)
+                .collect::<Vec<_>>(),
+            vec![blobs]
+        );
+
+        // Only scheduled runs answer "when did the schedule last run" — an
+        // on-demand backup must not push the automatic one back.
+        assert_eq!(
+            db.last_scheduled_app_deployment_backup(here).await.unwrap(),
+            Some(older)
+        );
+        assert_eq!(
+            db.last_scheduled_app_deployment_backup(elsewhere)
+                .await
+                .unwrap(),
+            None
+        );
+
+        // Soft delete hides the row from both reads.
+        db.delete_app_deployment_backup(blobs).await.unwrap();
+        assert_eq!(
+            db.list_app_deployment_backups(here)
+                .await
+                .unwrap()
+                .iter()
+                .map(|b| b.id)
+                .collect::<Vec<_>>(),
+            vec![db_backup]
+        );
+        assert!(db.get_app_deployment_backup(blobs).await.is_err());
+        assert!(
+            db.list_active_app_deployment_backups(cluster_a)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     fn mk_cluster(name: &str, region_id: u64) -> AppCluster {

--- a/lnvps_compose/Cargo.toml
+++ b/lnvps_compose/Cargo.toml
@@ -9,3 +9,8 @@ serde.workspace = true
 serde_yaml_ng.workspace = true
 regex = "1"
 rand = "0.9"
+# Backup schedules are cron expressions; croner takes the standard 5-field form
+# (no seconds column to trip up whoever writes the catalog entry) and answers
+# "when does this next fire" against a chrono timestamp.
+croner = "3.0"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/lnvps_compose/src/lib.rs
+++ b/lnvps_compose/src/lib.rs
@@ -15,8 +15,11 @@
 //! resolves `${…}` references. The Kubernetes object mapping lives elsewhere.
 
 use anyhow::{Result, anyhow, bail};
+use chrono::{DateTime, Utc};
+use croner::Cron;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 /// A parsed app compose document.
 #[derive(Debug, Clone, Deserialize)]
@@ -30,7 +33,127 @@ pub struct Compose {
     /// Customer-provided configuration fields (the deploy form).
     #[serde(default)]
     pub config: Vec<ConfigField>,
+    /// Automatic backup policy for the whole app. Omit for an app that is only
+    /// backed up when the customer asks.
+    #[serde(default)]
+    pub backup: Option<BackupPolicy>,
 }
+
+/// How often the operator runs an app's backups, and how many runs it keeps.
+///
+/// The policy is app-wide while the *method* is per service, because a run has
+/// to be a single point in time across the whole app: a relay's database dump
+/// and its blob volume taken hours apart do not restore into a consistent
+/// instance.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BackupPolicy {
+    /// When runs start, as a standard 5-field cron expression
+    /// (`minute hour day-of-month month day-of-week`) interpreted in **UTC**.
+    /// `0 3 * * *` is the common case: every day at 03:00.
+    ///
+    /// UTC rather than a customer timezone because the deployment has no
+    /// timezone of its own, and a schedule that silently shifted by an hour
+    /// twice a year is worse than one that is always where it was written.
+    pub schedule: String,
+    /// How many completed runs to keep; older ones are pruned with their
+    /// artifacts. Defaults to [`DEFAULT_BACKUP_RETENTION`].
+    #[serde(default)]
+    pub retention: Option<u32>,
+}
+
+impl BackupPolicy {
+    /// Declared retention, or [`DEFAULT_BACKUP_RETENTION`].
+    pub fn retention_or_default(&self) -> u32 {
+        self.retention.unwrap_or(DEFAULT_BACKUP_RETENTION)
+    }
+
+    /// The parsed schedule.
+    ///
+    /// Parsing at every use rather than caching one: a `Compose` is
+    /// deserialised from a stored row and cloned around, and the operator
+    /// evaluates this once per deployment per sweep, which is nowhere near
+    /// often enough to be worth a lazily-initialised field.
+    pub fn cron(&self) -> Result<Cron> {
+        Cron::from_str(&self.schedule).map_err(|e| {
+            anyhow!(
+                "backup schedule '{}' is not a valid cron: {e}",
+                self.schedule
+            )
+        })
+    }
+
+    /// The first run due strictly after `after`, in UTC.
+    pub fn next_run_after(&self, after: DateTime<Utc>) -> Result<DateTime<Utc>> {
+        self.cron()?
+            .find_next_occurrence(&after, false)
+            .map_err(|e| {
+                anyhow!(
+                    "backup schedule '{}' has no next occurrence after {after}: {e}",
+                    self.schedule
+                )
+            })
+    }
+
+    /// Whether a run is due now, given when the schedule last ran.
+    ///
+    /// `since` is the last scheduled run, or the deployment's creation time
+    /// when the schedule has never run — so a deployment does not get a backup
+    /// the instant it is created, and one that has been down past several
+    /// occurrences gets a single catch-up run rather than one per missed slot.
+    pub fn is_due(&self, since: DateTime<Utc>, now: DateTime<Utc>) -> Result<bool> {
+        Ok(self.next_run_after(since)? <= now)
+    }
+
+    /// Reject a schedule that fires faster than [`MIN_BACKUP_INTERVAL_MINUTES`].
+    ///
+    /// `* * * * *` is a valid cron and a way to fill a bucket with a copy of a
+    /// customer's data every minute, so the floor is enforced where the catalog
+    /// entry is written rather than discovered in a storage bill. Checked over
+    /// several consecutive occurrences because a pattern can be sparse in one
+    /// place and dense in another (`0,1 3 * * *` fires twice a minute apart).
+    fn validate_frequency(&self) -> Result<()> {
+        let cron = self.cron()?;
+        // A fixed reference instant, so the check does not depend on when it
+        // runs: 1 Jan, which every calendar-based pattern reaches.
+        let mut at = DateTime::<Utc>::from_timestamp(1_735_689_600, 0)
+            .ok_or_else(|| anyhow!("internal: bad reference time"))?;
+        for _ in 0..SCHEDULE_SAMPLES {
+            let next = cron.find_next_occurrence(&at, false).map_err(|e| {
+                anyhow!(
+                    "backup schedule '{}' has no next occurrence after {at}: {e}",
+                    self.schedule
+                )
+            })?;
+            if (next - at).num_minutes() < MIN_BACKUP_INTERVAL_MINUTES as i64 {
+                bail!(
+                    "backup schedule '{}' fires more often than every \
+                     {MIN_BACKUP_INTERVAL_MINUTES} minutes — each run stores a full copy of the \
+                     app's data",
+                    self.schedule
+                );
+            }
+            at = next;
+        }
+        Ok(())
+    }
+}
+
+/// How many consecutive occurrences [`BackupPolicy::validate_frequency`]
+/// inspects. Enough to catch a pattern that is dense in one part of the day
+/// and sparse elsewhere, without walking a year of a rare expression.
+const SCHEDULE_SAMPLES: usize = 24;
+
+/// Closest two scheduled runs may be. A full copy of the app's data is stored
+/// per run, so this is a storage floor, not a scheduling nicety.
+pub const MIN_BACKUP_INTERVAL_MINUTES: u32 = 60;
+
+/// Runs kept for an app whose `backup:` policy does not say.
+pub const DEFAULT_BACKUP_RETENTION: u32 = 7;
+
+/// Most runs an app may retain. Each retained run holds a full copy of every
+/// backed-up volume, so retention is storage the customer did not buy; a
+/// customer who wants a deeper history downloads the artifacts.
+pub const MAX_BACKUP_RETENTION: u32 = 30;
 
 /// A single service/container within an app.
 #[derive(Debug, Clone, Deserialize)]
@@ -608,6 +731,31 @@ fn compile_pattern(pattern: &str) -> Result<regex::Regex> {
         .map_err(|e| anyhow!("pattern '{pattern}' is not a valid regex: {e}"))
 }
 
+/// Longest accepted `backup.artifact` filename.
+const MAX_ARTIFACT_NAME_LEN: usize = 64;
+
+/// A `backup.artifact` is a filename, not a path.
+fn validate_artifact_name(service: &str, name: &str) -> Result<()> {
+    if name.is_empty() || name.len() > MAX_ARTIFACT_NAME_LEN {
+        bail!(
+            "service '{service}': backup artifact name must be 1-{MAX_ARTIFACT_NAME_LEN} characters"
+        );
+    }
+    if name.starts_with('.') {
+        bail!("service '{service}': backup artifact '{name}' must not start with a dot");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+    {
+        bail!(
+            "service '{service}': backup artifact '{name}' may only contain letters, digits, \
+             '.', '-' and '_'"
+        );
+    }
+    Ok(())
+}
+
 /// Config field input type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -976,7 +1124,9 @@ impl Compose {
                 }
             }
 
-            // A backup entry is exactly one of command | volume.
+            // A backup entry is exactly one of command | volume, and the
+            // artifact name is a filename we control the shape of (it becomes
+            // the tail of an object key).
             if let Some(b) = &svc.backup {
                 match (&b.command, &b.volume) {
                     (Some(_), Some(_)) => {
@@ -991,6 +1141,12 @@ impl Compose {
                         }
                     }
                     _ => {}
+                }
+                // The artifact name is appended to a server-derived object key
+                // and shown as a download filename, so it is a plain filename:
+                // no directory separators, no traversal, no leading dot.
+                if let Some(a) = &b.artifact {
+                    validate_artifact_name(sname, a)?;
                 }
             }
 
@@ -1063,7 +1219,38 @@ impl Compose {
                 compile_pattern(pattern).map_err(|e| anyhow!("config field '{}': {e}", f.name))?;
             }
         }
+
+        // A schedule with nothing to run would bill storage and produce empty
+        // runs forever, and reads in the catalog as if the app were protected.
+        if let Some(policy) = &self.backup {
+            if !self.services.values().any(|s| s.backup.is_some()) {
+                bail!(
+                    "backup schedule is set but no service declares a `backup:` method — there \
+                     would be nothing to capture"
+                );
+            }
+            let retention = policy.retention_or_default();
+            if !(1..=MAX_BACKUP_RETENTION).contains(&retention) {
+                bail!(
+                    "backup retention must be between 1 and {MAX_BACKUP_RETENTION} (got \
+                     {retention})"
+                );
+            }
+            policy.validate_frequency()?;
+        }
         Ok(())
+    }
+
+    /// Services that declare a backup method, in a stable order so a run's
+    /// artifacts are created the same way every time.
+    pub fn backup_services(&self) -> Vec<(&str, &Backup)> {
+        let mut out: Vec<(&str, &Backup)> = self
+            .services
+            .iter()
+            .filter_map(|(name, svc)| svc.backup.as_ref().map(|b| (name.as_str(), b)))
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(b.0));
+        out
     }
 
     /// Every distinct env var name referenced as `${…}` across all services —
@@ -2380,6 +2567,128 @@ config:
             Compose::parse("services:\n  a:\n    image: x\n    backup: { volume: nope }\n")
                 .is_err()
         );
+    }
+
+    /// The app-wide `backup:` policy: what it accepts, and the two ways it can
+    /// be written such that a customer would believe they had backups when
+    /// they did not.
+    #[test]
+    fn backup_policy_grammar() {
+        let with = |policy: &str, method: &str| {
+            Compose::parse(&format!(
+                "services:\n  db:\n    image: x\n    volumes:\n      - {{ name: data, path: \
+                 /data, size: 5Gi }}\n{method}{policy}"
+            ))
+        };
+        let method = "    backup: { volume: data }\n";
+
+        let c = with("backup: { schedule: \"0 3 * * *\" }\n", method).unwrap();
+        let policy = c.backup.as_ref().unwrap();
+        assert_eq!(policy.schedule, "0 3 * * *");
+        // Unset retention is the default, not "keep nothing".
+        assert_eq!(policy.retention_or_default(), DEFAULT_BACKUP_RETENTION);
+        assert_eq!(c.backup_services().len(), 1);
+        assert_eq!(c.backup_services()[0].0, "db");
+
+        assert_eq!(
+            with(
+                "backup: { schedule: \"0 4 * * 0\", retention: 2 }\n",
+                method
+            )
+            .unwrap()
+            .backup
+            .unwrap()
+            .retention_or_default(),
+            2
+        );
+
+        // A schedule with no service method captures nothing, but would read
+        // in the catalog as if the app were protected.
+        assert!(with("backup: { schedule: \"0 3 * * *\" }\n", "").is_err());
+        // Retention outside the accepted range, in both directions.
+        assert!(
+            with(
+                "backup: { schedule: \"0 3 * * *\", retention: 0 }\n",
+                method
+            )
+            .is_err()
+        );
+        assert!(
+            with(
+                "backup: { schedule: \"0 3 * * *\", retention: 31 }\n",
+                method
+            )
+            .is_err()
+        );
+        // Not a cron expression at all.
+        assert!(with("backup: { schedule: daily }\n", method).is_err());
+        assert!(with("backup: { schedule: \"0 3 * *\" }\n", method).is_err());
+        // Faster than the floor: every minute, and twice a minute apart within
+        // an otherwise daily pattern.
+        assert!(with("backup: { schedule: \"* * * * *\" }\n", method).is_err());
+        assert!(with("backup: { schedule: \"0,1 3 * * *\" }\n", method).is_err());
+        assert!(with("backup: { schedule: \"*/30 * * * *\" }\n", method).is_err());
+        // Exactly at the floor is allowed.
+        assert!(with("backup: { schedule: \"0 * * * *\" }\n", method).is_ok());
+        // No policy at all stays valid: on-demand backups need no schedule.
+        assert!(with("", method).unwrap().backup.is_none());
+    }
+
+    /// The operator asks one question of a schedule: is a run due? Answered
+    /// from the last run, so a deployment that was down through several
+    /// occurrences gets one catch-up run rather than one per missed slot.
+    #[test]
+    fn backup_schedule_due_from_last_run() {
+        let c = Compose::parse(
+            "services:\n  db:\n    image: x\n    backup: { command: [\"sh\"] }\nbackup: { \
+             schedule: \"0 3 * * *\" }\n",
+        )
+        .unwrap();
+        let policy = c.backup.as_ref().unwrap();
+        let at = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc);
+
+        // Next 03:00 UTC after a mid-morning run.
+        assert_eq!(
+            policy.next_run_after(at("2026-03-01T09:15:00Z")).unwrap(),
+            at("2026-03-02T03:00:00Z")
+        );
+
+        // Ran this morning, so nothing is due until tomorrow.
+        assert!(
+            !policy
+                .is_due(at("2026-03-01T03:00:00Z"), at("2026-03-01T23:00:00Z"))
+                .unwrap()
+        );
+        assert!(
+            policy
+                .is_due(at("2026-03-01T03:00:00Z"), at("2026-03-02T03:00:00Z"))
+                .unwrap()
+        );
+        // Down for a week: due, once.
+        assert!(
+            policy
+                .is_due(at("2026-03-01T03:00:00Z"), at("2026-03-08T12:00:00Z"))
+                .unwrap()
+        );
+    }
+
+    /// `artifact:` becomes the tail of an object key and the download
+    /// filename, so it is a filename and nothing else.
+    #[test]
+    fn backup_artifact_must_be_a_plain_filename() {
+        let app = |artifact: &str| {
+            Compose::parse(&format!(
+                "services:\n  db:\n    image: x\n    backup:\n      command: [\"sh\"]\n      \
+                 artifact: {artifact}\n"
+            ))
+        };
+        assert!(app("dump.sql").is_ok());
+        assert!(app("route96_db-1.sql").is_ok());
+        assert!(app("\"../../etc/passwd\"").is_err());
+        assert!(app("\"sub/dir.sql\"").is_err());
+        assert!(app("\".hidden\"").is_err());
+        assert!(app("\"\"").is_err());
+        assert!(app(&format!("\"{}\"", "a".repeat(65))).is_err());
     }
 
     #[test]

--- a/lnvps_db/migrations/20260829120000_app_deployment_backup.sql
+++ b/lnvps_db/migrations/20260829120000_app_deployment_backup.sql
@@ -1,0 +1,50 @@
+-- Backups of an app deployment's data (work/app-deployments.md increment 6).
+--
+-- One row per artifact, not per run: two services in one deployment back up
+-- with different images and different volumes, so a run fans out to one
+-- Kubernetes Job (and one uploaded object) per service. `run_id` groups the
+-- artifacts that belong to the same point in time.
+--
+-- `object_key` is server-derived and never client-supplied; the customer API
+-- addresses a backup only by `id`.
+CREATE TABLE app_deployment_backup
+(
+    id            INTEGER UNSIGNED  NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    deployment_id INTEGER UNSIGNED  NOT NULL,
+    -- Groups the artifacts captured by one run. UUID text so the operator can
+    -- mint it without a round-trip and use it in the object key.
+    run_id        VARCHAR(36)       NOT NULL,
+    -- Compose service this artifact came from.
+    service       VARCHAR(64)       NOT NULL,
+    -- 0 = command (logical dump), 1 = volume (raw tar).
+    method        SMALLINT UNSIGNED NOT NULL,
+    -- Download filename shown to the customer.
+    artifact      VARCHAR(128)      NOT NULL,
+    -- Object storage key; NULL until the run has been given one.
+    object_key    VARCHAR(255)      NULL     DEFAULT NULL,
+    -- Uploaded size, once observed.
+    size_bytes    BIGINT UNSIGNED   NULL     DEFAULT NULL,
+    -- 0 = pending, 1 = running, 2 = completed, 3 = failed.
+    state         SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+    -- Failure detail, or any note the operator wants to surface.
+    message       VARCHAR(500)      NULL     DEFAULT NULL,
+    -- 1 when this run was started by the app's schedule rather than by the
+    -- customer. Retention prunes both, but only scheduled runs answer "when
+    -- was the last automatic backup".
+    scheduled     BIT(1)            NOT NULL DEFAULT 0,
+    created       TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started       TIMESTAMP         NULL     DEFAULT NULL,
+    completed     TIMESTAMP         NULL     DEFAULT NULL,
+    -- Soft delete: the row outlives the object so a pruned or customer-deleted
+    -- backup cannot be re-listed while its object is still being removed.
+    deleted       BIT(1)            NOT NULL DEFAULT 0,
+    CONSTRAINT fk_app_deployment_backup_deployment FOREIGN KEY (deployment_id)
+        REFERENCES app_deployment (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+-- Listing a deployment's backups newest-first is the only read the API makes.
+CREATE INDEX ix_app_deployment_backup_deployment ON app_deployment_backup (deployment_id, created);
+-- The operator sweeps for work by state across every deployment on its cluster.
+CREATE INDEX ix_app_deployment_backup_state ON app_deployment_backup (state);
+CREATE INDEX ix_app_deployment_backup_run ON app_deployment_backup (run_id);

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -1890,6 +1890,37 @@ pub trait LNVpsDbBase: Send + Sync {
         Vec<AppDeploymentServiceUsage>,
         Vec<AppDeploymentVolumeUsage>,
     )>;
+    /// A deployment's backups, newest first, excluding deleted ones.
+    async fn list_app_deployment_backups(
+        &self,
+        deployment_id: u64,
+    ) -> DbResult<Vec<AppDeploymentBackup>>;
+    /// One backup by id. Callers check ownership through its deployment.
+    async fn get_app_deployment_backup(&self, id: u64) -> DbResult<AppDeploymentBackup>;
+    /// Record a backup artifact; returns its id. `id` on the input is ignored.
+    async fn insert_app_deployment_backup(&self, backup: &AppDeploymentBackup) -> DbResult<u64>;
+    /// Write back progress: state, object key, size, message and timestamps.
+    /// Everything else on the row is immutable once recorded.
+    async fn update_app_deployment_backup(&self, backup: &AppDeploymentBackup) -> DbResult<()>;
+    /// Backups still owing work (pending or running) across one cluster's
+    /// deployments — the operator's sweep, which is scoped to its own cluster
+    /// because only that operator can create the Jobs.
+    async fn list_active_app_deployment_backups(
+        &self,
+        cluster_id: u64,
+    ) -> DbResult<Vec<AppDeploymentBackup>>;
+    /// When the last *scheduled* run for a deployment started, so the operator
+    /// can tell whether the next one is due. `None` when the schedule has never
+    /// run. Customer-requested runs are excluded on purpose: an on-demand
+    /// backup must not silently cancel the automatic one.
+    async fn last_scheduled_app_deployment_backup(
+        &self,
+        deployment_id: u64,
+    ) -> DbResult<Option<DateTime<Utc>>>;
+    /// Soft-delete a backup (sets `deleted = 1`). The row outlives the object
+    /// so a pruned backup cannot be listed again while its object is still
+    /// being removed.
+    async fn delete_app_deployment_backup(&self, id: u64) -> DbResult<()>;
     /// Soft-delete a deployment (sets `deleted = 1`); the operator tears down
     /// the Kubernetes resources on its next reconcile.
     async fn delete_app_deployment(&self, id: u64) -> DbResult<()>;

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -3440,6 +3440,22 @@ impl InternetRegistry {
 mod tests {
     use super::*;
 
+    /// The backup enums are rendered into API responses and log lines, and
+    /// their numeric values are the stored column, so both are pinned.
+    #[test]
+    fn test_app_backup_enum_rendering() {
+        assert_eq!(AppBackupMethod::Command.to_string(), "command");
+        assert_eq!(AppBackupMethod::Volume.to_string(), "volume");
+        assert_eq!(AppBackupState::Pending.to_string(), "pending");
+        assert_eq!(AppBackupState::Running.to_string(), "running");
+        assert_eq!(AppBackupState::Completed.to_string(), "completed");
+        assert_eq!(AppBackupState::Failed.to_string(), "failed");
+        assert_eq!(AppBackupMethod::default(), AppBackupMethod::Command);
+        assert_eq!(AppBackupState::default(), AppBackupState::Pending);
+        assert_eq!(AppBackupMethod::Volume as u8, 1);
+        assert_eq!(AppBackupState::Failed as u8, 3);
+    }
+
     /// A subscription's billing state is what the customer API reports and what
     /// the operator gates on, so the three cases have to be exactly the two
     /// columns and nothing else (issue #253).
@@ -4641,6 +4657,91 @@ impl Display for AppDeploymentStatus {
             AppDeploymentStatus::Deleting => write!(f, "deleting"),
         }
     }
+}
+
+/// How an artifact was captured, mirroring the compose `backup:` method.
+#[derive(Clone, Copy, Debug, sqlx::Type, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[repr(u8)]
+#[serde(rename_all = "snake_case")]
+pub enum AppBackupMethod {
+    /// App-native logical dump, captured from the command's stdout.
+    #[default]
+    Command = 0,
+    /// Raw tar of a persistent volume.
+    Volume = 1,
+}
+
+impl Display for AppBackupMethod {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppBackupMethod::Command => write!(f, "command"),
+            AppBackupMethod::Volume => write!(f, "volume"),
+        }
+    }
+}
+
+/// Lifecycle of one backup artifact.
+///
+/// `Completed` is the only state in which an object exists to download; a
+/// `Failed` row is kept so the customer can see that a scheduled run did not
+/// produce the backup they are counting on.
+#[derive(Clone, Copy, Debug, sqlx::Type, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[repr(u8)]
+#[serde(rename_all = "snake_case")]
+pub enum AppBackupState {
+    /// Recorded, waiting for the operator to create the Job.
+    #[default]
+    Pending = 0,
+    /// The Job exists and is capturing or uploading.
+    Running = 1,
+    /// Uploaded; downloadable.
+    Completed = 2,
+    /// The capture or the upload failed; see `message`.
+    Failed = 3,
+}
+
+impl Display for AppBackupState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppBackupState::Pending => write!(f, "pending"),
+            AppBackupState::Running => write!(f, "running"),
+            AppBackupState::Completed => write!(f, "completed"),
+            AppBackupState::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+/// One captured artifact from one compose service.
+///
+/// A backup *run* covers the whole deployment, but each service that declares
+/// a `backup:` method produces its own artifact from its own Job, so the run is
+/// represented as the set of rows sharing a `run_id` rather than as a row of
+/// its own.
+#[derive(FromRow, Clone, Debug, PartialEq, Eq)]
+pub struct AppDeploymentBackup {
+    pub id: u64,
+    pub deployment_id: u64,
+    /// Groups the artifacts captured by the same run.
+    pub run_id: String,
+    /// Compose service the artifact came from.
+    pub service: String,
+    pub method: AppBackupMethod,
+    /// Download filename.
+    pub artifact: String,
+    /// Object storage key. Server-derived: the customer addresses a backup by
+    /// `id` and never supplies any part of a path.
+    pub object_key: Option<String>,
+    /// Uploaded size, once the object has been observed.
+    pub size_bytes: Option<u64>,
+    pub state: AppBackupState,
+    /// Failure detail, when there is one.
+    pub message: Option<String>,
+    /// Started by the app's schedule rather than by the customer.
+    pub scheduled: bool,
+    pub created: DateTime<Utc>,
+    pub started: Option<DateTime<Utc>>,
+    pub completed: Option<DateTime<Utc>>,
+    pub deleted: bool,
 }
 
 /// One compose service's last observed CPU and memory use.

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -1,18 +1,19 @@
 use crate::{
     AccessPolicy, AgentConversation, AgentConversationFilter, AgentConversationOverview,
-    AgentMessage, App, AppCluster, AppDeployment, AppDeploymentFilter, AppDeploymentServiceUsage,
-    AppDeploymentVolumeUsage, AppTag, AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace,
-    BulkMessageTarget, Company, DbError, DbResult, Discount, DiscountRedemption,
-    DiscountRedemptionWithCode, DnsServer, EncryptedString, IntervalType, IpRange,
-    IpRangeSubscription, IpSpacePricing, LNVpsDbBase, MarketplaceNode, MarketplaceNodeHealth,
-    MarketplaceNodeStatus, MarketplaceOperator, NewAgentMessage, PaymentMethod,
-    PaymentMethodConfig, PaymentType, Referral, ReferralCostUsage, ReferralPayout, Region,
-    RegionStats, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel, RouterTunnelTraffic,
-    Subscription, SubscriptionLineItem, SubscriptionPayment, SubscriptionPaymentWithCompany,
-    Tunnel, TunnelPool, TunnelRoute, User, UserPaymentMethod, UserSshKey, Vm, VmCostPlan,
-    VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate, VmFirewallPolicy, VmFirewallRule,
-    VmHistory, VmHost, VmHostDisk, VmIpAssignment, VmOsImage, VmTemplate, VmTrafficDaily,
-    VmTrafficSample, VmTrafficTotal, VpnDevice, VpnService, VpnSubscription, WebauthnCredential,
+    AgentMessage, App, AppBackupState, AppCluster, AppDeployment, AppDeploymentBackup,
+    AppDeploymentFilter, AppDeploymentServiceUsage, AppDeploymentVolumeUsage, AppTag,
+    AsnSubscription, AsnSubscriptionStatus, AvailableIpSpace, BulkMessageTarget, Company, DbError,
+    DbResult, Discount, DiscountRedemption, DiscountRedemptionWithCode, DnsServer, EncryptedString,
+    IntervalType, IpRange, IpRangeSubscription, IpSpacePricing, LNVpsDbBase, MarketplaceNode,
+    MarketplaceNodeHealth, MarketplaceNodeStatus, MarketplaceOperator, NewAgentMessage,
+    PaymentMethod, PaymentMethodConfig, PaymentType, Referral, ReferralCostUsage, ReferralPayout,
+    Region, RegionStats, Router, RouterBgpRoute, RouterBgpSession, RouterTunnel,
+    RouterTunnelTraffic, Subscription, SubscriptionLineItem, SubscriptionPayment,
+    SubscriptionPaymentWithCompany, Tunnel, TunnelPool, TunnelRoute, User, UserPaymentMethod,
+    UserSshKey, Vm, VmCostPlan, VmCustomPricing, VmCustomPricingDisk, VmCustomTemplate,
+    VmFirewallPolicy, VmFirewallRule, VmHistory, VmHost, VmHostDisk, VmIpAssignment, VmOsImage,
+    VmTemplate, VmTrafficDaily, VmTrafficSample, VmTrafficTotal, VpnDevice, VpnService,
+    VpnSubscription, WebauthnCredential,
 };
 #[cfg(feature = "admin")]
 use crate::{AdminDb, AdminRole, AdminRoleAssignment, AdminVmHost};
@@ -6255,6 +6256,109 @@ impl LNVpsDbBase for LNVpsDbMysql {
             services.fetch_all(&self.db).await?,
             volumes.fetch_all(&self.db).await?,
         ))
+    }
+
+    async fn list_app_deployment_backups(
+        &self,
+        deployment_id: u64,
+    ) -> DbResult<Vec<AppDeploymentBackup>> {
+        Ok(sqlx::query_as(
+            "SELECT * FROM app_deployment_backup WHERE deployment_id = ? AND deleted = 0 \
+             ORDER BY created DESC, id DESC",
+        )
+        .bind(deployment_id)
+        .fetch_all(&self.db)
+        .await?)
+    }
+
+    async fn get_app_deployment_backup(&self, id: u64) -> DbResult<AppDeploymentBackup> {
+        Ok(
+            sqlx::query_as("SELECT * FROM app_deployment_backup WHERE id = ? AND deleted = 0")
+                .bind(id)
+                .fetch_one(&self.db)
+                .await?,
+        )
+    }
+
+    async fn insert_app_deployment_backup(&self, backup: &AppDeploymentBackup) -> DbResult<u64> {
+        Ok(sqlx::query(
+            "INSERT INTO app_deployment_backup (deployment_id, run_id, service, method, artifact, \
+             object_key, size_bytes, state, message, scheduled, started, completed) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(backup.deployment_id)
+        .bind(&backup.run_id)
+        .bind(&backup.service)
+        .bind(backup.method)
+        .bind(&backup.artifact)
+        .bind(&backup.object_key)
+        .bind(backup.size_bytes)
+        .bind(backup.state)
+        .bind(&backup.message)
+        .bind(backup.scheduled)
+        .bind(backup.started)
+        .bind(backup.completed)
+        .execute(&self.db)
+        .await?
+        .last_insert_id())
+    }
+
+    async fn update_app_deployment_backup(&self, backup: &AppDeploymentBackup) -> DbResult<()> {
+        sqlx::query(
+            "UPDATE app_deployment_backup SET object_key = ?, size_bytes = ?, state = ?, \
+             message = ?, started = ?, completed = ? WHERE id = ?",
+        )
+        .bind(&backup.object_key)
+        .bind(backup.size_bytes)
+        .bind(backup.state)
+        .bind(&backup.message)
+        .bind(backup.started)
+        .bind(backup.completed)
+        .bind(backup.id)
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_active_app_deployment_backups(
+        &self,
+        cluster_id: u64,
+    ) -> DbResult<Vec<AppDeploymentBackup>> {
+        Ok(sqlx::query_as(
+            "SELECT b.* FROM app_deployment_backup b \
+             JOIN app_deployment d ON d.id = b.deployment_id \
+             WHERE d.cluster_id = ? AND b.deleted = 0 AND b.state IN (?, ?) \
+             ORDER BY b.id",
+        )
+        .bind(cluster_id)
+        .bind(AppBackupState::Pending)
+        .bind(AppBackupState::Running)
+        .fetch_all(&self.db)
+        .await?)
+    }
+
+    async fn last_scheduled_app_deployment_backup(
+        &self,
+        deployment_id: u64,
+    ) -> DbResult<Option<DateTime<Utc>>> {
+        // Deleted rows count: retention prunes old runs, and forgetting that a
+        // run happened because its artifact was pruned would restart the
+        // schedule from zero on every sweep.
+        Ok(sqlx::query_scalar(
+            "SELECT MAX(created) FROM app_deployment_backup \
+             WHERE deployment_id = ? AND scheduled = 1",
+        )
+        .bind(deployment_id)
+        .fetch_one(&self.db)
+        .await?)
+    }
+
+    async fn delete_app_deployment_backup(&self, id: u64) -> DbResult<()> {
+        sqlx::query("UPDATE app_deployment_backup SET deleted = 1 WHERE id = ?")
+            .bind(id)
+            .execute(&self.db)
+            .await?;
+        Ok(())
     }
 
     async fn delete_app_deployment(&self, id: u64) -> DbResult<()> {

--- a/work/app-deployments.md
+++ b/work/app-deployments.md
@@ -2,7 +2,9 @@
 
 **Status:** in-progress
 **Started:** 2026-07-24
-**Last updated:** 2026-07-25 (MVP increments 1–5 complete; backups (6) + L4/zap-stream (7) remain)
+**Last updated:** 2026-08-29 (increments 1–5 shipped, plus custom domains, usage reporting,
+resource multiplier, init/scratch/setup steps and the `catalog/` app set; backups (6) is the
+current work, L4/zap-stream (7) still open)
 
 ## Goal
 
@@ -152,17 +154,58 @@ images (higher isolation risk — design the boundary in now).
 - [x] **HAVEN / zap-stream** documented as not-yet-deployable: HAVEN needs a mounted `templates/`
       dir of binary assets + JSON lists (no self-contained image); zap-stream needs `expose: tcp/udp`.
 
-### Increment 6 — Volume backups (post-MVP)
-- [ ] Compose `backup:` grammar (per-service `command:` app-native dump | `volume:` raw tar;
-      top-level `backup: { schedule, retention }`).
-- [ ] Operator backup/restore **Jobs** in the deployment namespace (PVC mounted RO for backup;
-      app scaled to 0 for restore). Prefer logical dumps; CSI VolumeSnapshots for fast PITR if
-      the storage class supports it.
-- [ ] Delivery: on-demand artifact (LNVPS object storage) with one-time, Nip98-auth, time-boxed
-      download URLs; OR scheduled push to a customer-owned target (S3/WebDAV/**Blossom**).
-- [ ] API: `POST/GET /api/v1/app-deployments/{id}/backups`, `GET .../backups/{bid}` (download),
-      `POST .../backups/{bid}/restore`, `PATCH .../backup-config`.
-- [ ] **Security (see "Volume security" below) — mandatory before shipping.**
+### Increment 6 — Volume backups
+
+Scope decided with the user: artifacts land in **LNVPS-run S3-compatible object storage** with
+time-boxed signed download URLs; runs are **on-demand and scheduled**; **restore is a later
+increment** (it carries the archive-extraction risk documented under "Volume security").
+
+Per-service `backup:` (`command:` | `volume:` | `artifact:`) already parses in `lnvps_compose`
+and `catalog/route96.yaml` + `catalog/buzz.yaml` already declare it — nothing consumes it yet.
+
+Design (see "Backup execution" below for the detail):
+
+- A **run** covers the whole deployment; each service that declares `backup:` produces one
+  artifact, so one `app_deployment_backup` row per (run, service), grouped by `run_id`.
+- The operator, not Kubernetes, owns scheduling: a `CronJob` cannot write the DB row or hold a
+  fresh signed URL, so the reconcile loop evaluates the schedule and creates the run.
+- The Job never holds object-storage credentials. The operator signs a `PUT` URL, puts it in a
+  namespace Secret, and the Job uploads to it.
+
+#### 6a — Grammar + schema (no behaviour change)
+- [x] `lnvps_compose`: top-level `backup: { schedule, retention }`; cron schedule (UTC, 5-field,
+      hourly floor) + retention range; reject a top-level `backup:` on an app where no service
+      declares one; `next_run_after` / `is_due` for the operator.
+- [x] Migration + `AppDeploymentBackup` model (`run_id`, `service`, `method`, `artifact`,
+      `object_key`, `size_bytes`, `state`, `message`, `scheduled`, timestamps) +
+      `AppBackupMethod` / `AppBackupState`.
+- [x] DB trait (`list_app_deployment_backups`, `get_app_deployment_backup`, insert, update,
+      `list_active_app_deployment_backups` for the operator's sweep,
+      `last_scheduled_app_deployment_backup`, soft delete) + mysql impl + MockDb + unit tests.
+
+#### 6b — Object storage client
+- [ ] `lnvps_api_common::object_store`: S3-compatible SigV4 presign (`hmac`/`sha2` are already
+      dependencies — no SDK), `presign_put` / `presign_get`, signed `HEAD` (artifact size) and
+      `DELETE` (retention). Config: endpoint, region, bucket, keys, path-style.
+- [ ] Unit tests against the AWS SigV4 published test vectors.
+
+#### 6c — Operator: run the backups
+- [ ] Build a per-artifact Job in the deployment namespace: `volume:` tars the PVC mounted
+      **read-only**; `command:` runs the dump in an init container on the app image with the
+      service's env, into a shared `emptyDir`; an uploader container `PUT`s the file.
+- [ ] Schedule evaluation + retention pruning (delete the object, tombstone the row).
+- [ ] Job status → DB write-back (size from a signed `HEAD`), and GC of finished Jobs.
+
+#### 6d — Customer API + docs
+- [ ] `POST /api/v1/app-deployments/{id}/backups` (start a run), `GET .../backups` (list),
+      `GET .../backups/{bid}/download` (redirect to a short-lived signed URL), `DELETE .../{bid}`.
+- [ ] Ownership checks on every route, opaque IDs only (never a client-supplied path).
+- [ ] e2e test, API_DOCUMENTATION.md, API_CHANGELOG.md.
+
+#### Deferred to increment 6e — restore
+- [ ] Scale to 0, sanitized extraction (canonicalized entries, reject absolute paths / `..` /
+      out-of-tree links / device files), scale back up. See "Volume security".
+- [ ] `POST .../backups/{bid}/restore`, `PATCH .../backup-config`.
 
 ### Increment 7 (optional) — L4 apps + zap-stream-core
 - [ ] `expose: tcp/udp` via ingress-controller TCP/UDP ConfigMap (or NodePort); seed
@@ -291,9 +334,58 @@ config:                                       # rendered as the customer's deplo
   data). Top-level `backup: { schedule, retention }` for automatic runs.
 - Backup/restore run as **Jobs** in the deployment namespace: backup mounts the PVC **read-only**;
   restore scales the app to 0, prefers `mysql < dump`, else guarded untar, then scales back up.
-- Delivery: on-demand artifact in LNVPS object storage with one-time / time-boxed / Nip98-auth
-  download URLs; OR scheduled push to a customer-owned S3/WebDAV/**Blossom** target (keeps the
-  customer as data custodian; Blossom target is Nostr-native).
+- Delivery: on-demand artifact in LNVPS object storage with time-boxed signed download URLs. A
+  scheduled push to a customer-owned S3/WebDAV/**Blossom** target (customer stays data custodian)
+  is a later addition behind the same storage abstraction.
+
+## Backup execution (increment 6 design)
+
+**Why the operator schedules, not Kubernetes.** A `CronJob` fires inside the cluster, where there
+is no DB row to record the run against and no way to obtain a signed upload URL that has not
+expired. So the reconcile loop evaluates each deployment's `backup.schedule` against its last
+run, creates the rows, and creates the Jobs. On-demand runs enter the same path — the API only
+writes `pending` rows.
+
+**Schedule grammar.** `schedule:` is a standard 5-field cron expression in **UTC** (`0 3 * * *`
+is the expected shape for nearly every app), plus `retention: <count of runs>`. UTC because a
+deployment has no timezone of its own and a schedule that shifted by an hour twice a year is
+worse than one that stays where it was written. Parsed with `croner` (5-field, no seconds column
+to trip up a catalog author). A schedule may not fire more often than hourly — `* * * * *` is
+valid cron and a way to store a full copy of a customer's data every minute, so the floor is
+enforced at catalog admission across 24 consecutive occurrences, which also catches a pattern
+that is sparse overall but dense in one slot (`0,1 3 * * *`).
+
+**Due-ness is measured from the last run, not from the clock.** The operator asks
+`next_run_after(last_scheduled_run) <= now`, seeded from the deployment's creation time when the
+schedule has never run. A deployment that was down through several occurrences therefore gets one
+catch-up run rather than one per missed slot, and a fresh deployment does not get a backup the
+instant it is created.
+
+**One Job per artifact.** Two services in one deployment back up with different images and
+different PVCs, and a pod has one filesystem view per container set, so a run fans out to one Job
+per service. `run_id` groups them for the client.
+
+**The Job never sees storage credentials.** The operator signs a `PUT` URL valid for a few hours
+and writes it into a namespace Secret consumed as env. A compromised app image gets one
+write-only URL to its own key, not the bucket. The key is server-derived
+(`deployments/{deployment_id}/{run_id}/{service}.{ext}`) and never client-supplied.
+
+- `volume: <name>` — uploader container mounts that PVC **read-only**, `tar -czf` into an
+  `emptyDir`, then uploads. Read-only is what makes a backup of a compromised app safe to run.
+- `command: […]` — an **init container** on the *app's* image, with the service's resolved env
+  (so `$MARIADB_ROOT_PASSWORD` in the dump command resolves), stdout redirected through `gzip`
+  into a shared `emptyDir`; the uploader container then `PUT`s that file. It has to be a separate
+  container because the app image is not guaranteed to contain an HTTP client.
+
+**Why a file and not a stream.** A presigned `PUT` needs `Content-Length`; piping `tar` straight
+into `curl` forces chunked transfer encoding, which S3 rejects. The dump therefore lands in an
+`emptyDir` sized from the deployment's storage footprint before it is uploaded. That also caps a
+single artifact at the 5 GiB single-`PUT` limit — multipart is a later concern, and the catalog's
+current volumes are well under it.
+
+**Uploader image.** A stock `curl` image (busybox userland, so `tar` and `gzip` are present),
+pinned by digest and overridable in the operator config, so nothing new has to be built or
+published for this increment.
 
 ## Volume security (directory-traversal) — mandatory for increment 6
 


### PR DESCRIPTION
First increment of app-deployment backups (`work/app-deployments.md`, increment 6a). Grammar and
schema only: nothing runs a backup yet, so this changes no behaviour.

Per-service `backup:` (a dump command, or a volume to tar) has parsed since the compose crate
existed, and `catalog/route96.yaml` and `catalog/buzz.yaml` both declare it, but nothing said when
a backup should happen and nothing recorded that one had -- so nothing ever ran one.

## Compose: an app-wide schedule

`backup: { schedule: "0 3 * * *", retention: 7 }`. The policy is app-wide while the method stays
per service, because a run has to be a single point in time across the whole app: a relay's
database dump and its blob volume captured hours apart do not restore into a consistent instance.

- Standard 5-field cron in **UTC**, parsed with `croner` (no seconds column to trip up a catalog
  author). UTC because a deployment has no timezone of its own, and a schedule that shifted by an
  hour twice a year is worse than one that stays where it was written.
- **Hourly floor**, enforced at catalog admission across 24 consecutive occurrences. `* * * * *`
  is valid cron and a way to store a full copy of a customer's data every minute; checking a run
  of occurrences also rejects a pattern that is sparse overall and dense in one slot
  (`0,1 3 * * *`).
- `is_due` measures from the last run, not the wall clock, so a deployment that was down through
  several occurrences gets one catch-up run instead of one per missed slot.
- `artifact:` is now validated as a plain filename, since it becomes the tail of an object key and
  the download filename.

## Database: one row per artifact

A run fans out to one Job (and one object) per service, because two services back up with
different images and different volumes. `run_id` groups the artifacts from one point in time.

- `object_key` is server-derived; the API addresses a backup only by `id`, so no part of a storage
  path is ever client-supplied.
- Soft delete, so a pruned backup cannot be listed again while its object is still being removed.
- `scheduled` separates automatic runs from customer-requested ones, and
  `last_scheduled_app_deployment_backup` reads only the automatic ones: an on-demand backup must
  not push the schedule back. It counts deleted rows, or pruning an artifact would restart the
  schedule from zero on every sweep.
- The operator's sweep is scoped to one cluster, since only that cluster's operator can create the
  Jobs.

## What comes next

6b an S3-compatible signing client, 6c the operator Jobs and retention pruning, 6d the customer
API. Restore is deliberately a later increment: it carries the archive-extraction risk documented
under "Volume security" in the work file, and shipping capture first is what makes a restore worth
testing against.

## Testing

- `cargo test --workspace --exclude lnvps_e2e -- --test-threads=1` passes.
- New: `backup_policy_grammar`, `backup_schedule_due_from_last_run`,
  `backup_artifact_must_be_a_plain_filename`, `test_app_deployment_backup_crud`,
  `test_app_backup_enum_rendering`.
- The migration was applied against a scratch MariaDB by running the full migration set.
- `cargo clippy --workspace --all-features` and `cargo fmt --all --check` are clean.