### PR TITLE
feat(admin): add DELETE /api/admin/v1/hosts/{id}

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -1519,10 +1519,14 @@ DELETE /api/admin/v1/hosts/{id}
 
 Required Permission: `hosts::delete`
 
-Deletes the host and its disk records. Refused while any VM row still
-references the host: active VMs must be moved or deleted first, and a host that
-only has soft-deleted VMs kept as billing history cannot be removed at all, so
-disable it instead (`PATCH` with `"enabled": false`).
+Refused while the host has active VMs: move or delete those first.
+
+A host that never ran a VM is removed outright along with its disk records. A
+host that did keeps its row, flagged `deleted` and forced `enabled: false`,
+because its VMs are billing history that still has to resolve the host it ran
+on. Deleted hosts disappear from `GET /api/admin/v1/hosts`, region host counts
+and region stats, but `GET /api/admin/v1/hosts/{id}` still returns one (with
+`"deleted": true`) so views built from historical VMs keep working.
 
 Response:
 

--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -1511,6 +1511,28 @@ GET /api/admin/v1/hosts/{id}
 
 Required Permission: `hosts::view`
 
+#### Delete Host
+
+```
+DELETE /api/admin/v1/hosts/{id}
+```
+
+Required Permission: `hosts::delete`
+
+Deletes the host and its disk records. Refused while any VM row still
+references the host: active VMs must be moved or deleted first, and a host that
+only has soft-deleted VMs kept as billing history cannot be removed at all, so
+disable it instead (`PATCH` with `"enabled": false`).
+
+Response:
+
+```json
+{
+  "success": true,
+  "message": "Host deleted successfully"
+}
+```
+
 #### Update Host Configuration
 
 ```

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **Host deletion**: `DELETE /api/admin/v1/hosts/{id}` removes a host and its disk records, guarded by `hosts::delete`. It is refused while any VM row still references the host, so a decommissioned host that kept soft-deleted VMs as billing history must still be disabled rather than deleted.
+- **Host deletion**: `DELETE /api/admin/v1/hosts/{id}`, guarded by `hosts::delete`. Refused while the host has active VMs. A host that never ran a VM is removed along with its disk records; one that did keeps its row, now flagged `deleted` and forced `enabled: false`, because `vm.host_id` and `vm.disk_id` are foreign keys and those VMs are billing history.
+
+  Deleted hosts are excluded from `GET /api/admin/v1/hosts`, from the region host counts and from region stats, but `GET /api/admin/v1/hosts/{id}` still returns one so admin views resolving a host from a historical VM keep working. Host responses carry a new `deleted` boolean.
 
 - **VPN plans** — a customer can buy one VPN plan, register up to their device allowance of WireGuard public keys, and download one config per region. `GET /api/v1/vpn/services` lists what is for sale and where it exits; `GET`/`POST /api/v1/vpn` reads and buys a plan; `GET`/`POST /api/v1/vpn/devices`, `POST /api/v1/vpn/devices/{id}/enabled` and `DELETE /api/v1/vpn/devices/{id}` manage devices; `GET /api/v1/vpn/devices/{id}/configs` returns one ready-to-use `wg-quick` file per region.
 

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Host deletion**: `DELETE /api/admin/v1/hosts/{id}` removes a host and its disk records, guarded by `hosts::delete`. It is refused while any VM row still references the host, so a decommissioned host that kept soft-deleted VMs as billing history must still be disabled rather than deleted.
+
 - **VPN plans** — a customer can buy one VPN plan, register up to their device allowance of WireGuard public keys, and download one config per region. `GET /api/v1/vpn/services` lists what is for sale and where it exits; `GET`/`POST /api/v1/vpn` reads and buys a plan; `GET`/`POST /api/v1/vpn/devices`, `POST /api/v1/vpn/devices/{id}/enabled` and `DELETE /api/v1/vpn/devices/{id}` manage devices; `GET /api/v1/vpn/devices/{id}/configs` returns one ready-to-use `wg-quick` file per region.
 
   Region is a client-side choice, not an allocation: a device holds one keypair and one inner address that are valid in every region at once, so every config it is given shares an identical `[Interface]` block and differs only in the `[Peer]` endpoint and public key. The client generates the keypair and sends only the public half, so the rendered config carries the placeholder `<your private key>` rather than a key LNVPS never had.

--- a/lnvps_api_admin/src/admin/hosts.rs
+++ b/lnvps_api_admin/src/admin/hosts.rs
@@ -106,9 +106,10 @@ async fn admin_get_host(
 
 /// Delete a host
 ///
-/// Refused while any VM row still references the host, including soft-deleted
-/// ones, because those rows are billing history and hold foreign keys into the
-/// host and its disks. A host with history can only be disabled.
+/// Refused while the host has active VMs. A host that ever ran a VM keeps its
+/// row (flagged deleted, hidden from listings) because those VMs are billing
+/// history that still has to resolve its host; one that never did is removed
+/// outright along with its disks.
 async fn admin_delete_host(
     auth: AdminAuth,
     State(this): State<RouterState>,
@@ -297,6 +298,7 @@ async fn admin_create_host(
         sunset_date: req.sunset_date,
         // Only node approval creates a marketplace-backed host (guarded above).
         marketplace_node_id: None,
+        deleted: false,
     };
 
     // Create host in database
@@ -693,7 +695,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_host_removes_the_host_and_its_disks() {
+    async fn delete_host_without_history_removes_the_host_and_its_disks() {
         let db = MockDb::default();
         let dyn_db: Arc<dyn LNVpsDb> = Arc::new(db.clone());
         dyn_db.admin_delete_host(1).await.unwrap();
@@ -703,24 +705,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_host_is_refused_while_vms_reference_it() {
+    async fn delete_host_is_refused_while_the_host_has_active_vms() {
         let db = MockDb::default();
         let dyn_db: Arc<dyn LNVpsDb> = Arc::new(db.clone());
         insert_vm_on_host(&db, 1, 1, false).await;
 
         let err = dyn_db.admin_delete_host(1).await.unwrap_err().to_string();
         assert!(err.contains("1 active VMs"), "unexpected error: {err}");
-        assert!(dyn_db.get_host(1).await.is_ok());
 
-        // A soft-deleted VM still holds a foreign key into the host, so the
-        // host can only be disabled, not removed.
+        let host = dyn_db.get_host(1).await.unwrap();
+        assert!(!host.deleted);
+        assert!(host.enabled);
+    }
+
+    #[tokio::test]
+    async fn delete_host_with_history_is_flagged_rather_than_removed() {
+        let db = MockDb::default();
+        let dyn_db: Arc<dyn LNVpsDb> = Arc::new(db.clone());
+        // A soft-deleted VM still points at the host and its disk, so the row
+        // has to stay for that history to resolve.
         insert_vm_on_host(&db, 1, 1, true).await;
-        let err = dyn_db.admin_delete_host(1).await.unwrap_err().to_string();
-        assert!(
-            err.contains("1 deleted VM records"),
-            "unexpected error: {err}"
-        );
-        assert!(dyn_db.get_host(1).await.is_ok());
+
+        dyn_db.admin_delete_host(1).await.unwrap();
+
+        let host = dyn_db.get_host(1).await.unwrap();
+        assert!(host.deleted);
+        assert!(!host.enabled);
+        assert!(!dyn_db.list_host_disks(1).await.unwrap().is_empty());
+
+        // Deleting it twice is an error rather than a silent no-op
+        assert!(dyn_db.admin_delete_host(1).await.is_err());
     }
 
     #[tokio::test]

--- a/lnvps_api_admin/src/admin/hosts.rs
+++ b/lnvps_api_admin/src/admin/hosts.rs
@@ -15,7 +15,7 @@ use lnvps_api_common::{
 };
 use lnvps_db::{AdminAction, AdminResource};
 use log::info;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 pub fn router() -> Router<RouterState> {
@@ -26,7 +26,9 @@ pub fn router() -> Router<RouterState> {
         )
         .route(
             "/api/admin/v1/hosts/{id}",
-            get(admin_get_host).patch(admin_update_host),
+            get(admin_get_host)
+                .patch(admin_update_host)
+                .delete(admin_delete_host),
         )
         // Host disk management
         .route(
@@ -100,6 +102,33 @@ async fn admin_get_host(
     };
     let host_info = AdminHostInfo::from_admin_vm_host_with_capacity(&this.db, admin_host).await;
     ApiData::ok(host_info)
+}
+
+/// Delete a host
+///
+/// Refused while any VM row still references the host, including soft-deleted
+/// ones, because those rows are billing history and hold foreign keys into the
+/// host and its disks. A host with history can only be disabled.
+async fn admin_delete_host(
+    auth: AdminAuth,
+    State(this): State<RouterState>,
+    Path(id): Path<u64>,
+) -> ApiResult<HostDeleteResponse> {
+    // Check permission
+    auth.require_permission(AdminResource::Hosts, AdminAction::Delete)?;
+
+    this.db.admin_delete_host(id).await?;
+
+    ApiData::ok(HostDeleteResponse {
+        success: true,
+        message: "Host deleted successfully".to_string(),
+    })
+}
+
+#[derive(Serialize)]
+struct HostDeleteResponse {
+    success: bool,
+    message: String,
 }
 
 /// Update host configuration
@@ -646,6 +675,59 @@ async fn admin_patch_host(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lnvps_api_common::MockDb;
+    use lnvps_db::{LNVpsDb, Vm};
+    use std::sync::Arc;
+
+    async fn insert_vm_on_host(db: &MockDb, id: u64, host_id: u64, deleted: bool) {
+        db.vms.lock().await.insert(
+            id,
+            Vm {
+                id,
+                host_id,
+                disk_id: 1,
+                deleted,
+                ..Default::default()
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_host_removes_the_host_and_its_disks() {
+        let db = MockDb::default();
+        let dyn_db: Arc<dyn LNVpsDb> = Arc::new(db.clone());
+        dyn_db.admin_delete_host(1).await.unwrap();
+
+        assert!(dyn_db.get_host(1).await.is_err());
+        assert!(dyn_db.list_host_disks(1).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_host_is_refused_while_vms_reference_it() {
+        let db = MockDb::default();
+        let dyn_db: Arc<dyn LNVpsDb> = Arc::new(db.clone());
+        insert_vm_on_host(&db, 1, 1, false).await;
+
+        let err = dyn_db.admin_delete_host(1).await.unwrap_err().to_string();
+        assert!(err.contains("1 active VMs"), "unexpected error: {err}");
+        assert!(dyn_db.get_host(1).await.is_ok());
+
+        // A soft-deleted VM still holds a foreign key into the host, so the
+        // host can only be disabled, not removed.
+        insert_vm_on_host(&db, 1, 1, true).await;
+        let err = dyn_db.admin_delete_host(1).await.unwrap_err().to_string();
+        assert!(
+            err.contains("1 deleted VM records"),
+            "unexpected error: {err}"
+        );
+        assert!(dyn_db.get_host(1).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_host_errors_for_an_unknown_host() {
+        let dyn_db: Arc<dyn LNVpsDb> = Arc::new(MockDb::default());
+        assert!(dyn_db.admin_delete_host(999).await.is_err());
+    }
 
     #[test]
     fn test_host_update_cpu_mfg_can_be_unset_with_null() {

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -1217,6 +1217,9 @@ pub struct AdminHostInfo {
     /// renewals are capped at this date.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sunset_date: Option<chrono::DateTime<chrono::Utc>>,
+    /// Host has been deleted: hidden from host listings, kept only so the VMs
+    /// that ran on it still resolve their host.
+    pub deleted: bool,
 }
 
 #[derive(Serialize)]
@@ -1393,6 +1396,7 @@ impl AdminHostInfo {
             ssh_user: host.ssh_user,
             ssh_key_configured,
             sunset_date: host.sunset_date,
+            deleted: host.deleted,
         }
     }
 
@@ -1447,6 +1451,7 @@ impl AdminHostInfo {
             ssh_user: host.ssh_user,
             ssh_key_configured,
             sunset_date: host.sunset_date,
+            deleted: host.deleted,
         }
     }
 
@@ -1507,6 +1512,7 @@ impl AdminHostInfo {
             ssh_user: capacity.host.ssh_user.clone(),
             ssh_key_configured,
             sunset_date: capacity.host.sunset_date,
+            deleted: capacity.host.deleted,
         }
     }
 
@@ -1567,6 +1573,7 @@ impl AdminHostInfo {
             ssh_user: admin_host.host.ssh_user,
             ssh_key_configured,
             sunset_date: admin_host.host.sunset_date,
+            deleted: admin_host.host.deleted,
         }
     }
 
@@ -1633,6 +1640,7 @@ impl AdminHostInfo {
                     ssh_user: capacity.host.ssh_user.clone(),
                     ssh_key_configured,
                     sunset_date: capacity.host.sunset_date,
+                    deleted: capacity.host.deleted,
                 }
             }
             Err(_) => {

--- a/lnvps_api_admin/src/bin/generate_demo_data.rs
+++ b/lnvps_api_admin/src/bin/generate_demo_data.rs
@@ -393,6 +393,7 @@ async fn create_hosts(db: &LNVpsDbMysql, regions: &[Region]) -> Result<Vec<VmHos
             ssh_key: None,
             sunset_date: None,
             marketplace_node_id: None,
+            deleted: false,
         };
 
         let id = db.create_host(&host).await?;

--- a/lnvps_api_common/src/capacity.rs
+++ b/lnvps_api_common/src/capacity.rs
@@ -1503,6 +1503,7 @@ mod tests {
                     ssh_key: None,
                     sunset_date: None,
                     marketplace_node_id: None,
+                    deleted: false,
                 },
             );
             let mut disks = db.host_disks.lock().await;

--- a/lnvps_api_common/src/host/mod.rs
+++ b/lnvps_api_common/src/host/mod.rs
@@ -529,6 +529,7 @@ mod tests {
                 ssh_key: None,
                 sunset_date: None,
                 marketplace_node_id: None,
+                deleted: false,
             },
             disk: VmHostDisk {
                 id: 1,

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -382,6 +382,7 @@ impl Default for MockDb {
                 ssh_key: None,
                 sunset_date: None,
                 marketplace_node_id: None,
+                deleted: false,
             },
         );
         let mut host_disks = HashMap::new();
@@ -1009,6 +1010,7 @@ impl LNVpsDbBase for MockDb {
             .values()
             .filter(|h| {
                 h.enabled
+                    && !h.deleted
                     && regions
                         .get(&h.region_id)
                         .map(|r| r.enabled)
@@ -1020,12 +1022,16 @@ impl LNVpsDbBase for MockDb {
 
     async fn list_hosts_all(&self) -> DbResult<Vec<VmHost>> {
         let hosts = self.hosts.lock().await;
-        Ok(hosts.values().cloned().collect())
+        Ok(hosts.values().filter(|h| !h.deleted).cloned().collect())
     }
 
     async fn list_hosts_paginated(&self, limit: u64, offset: u64) -> DbResult<(Vec<VmHost>, u64)> {
         let hosts = self.hosts.lock().await;
-        let filtered_hosts: Vec<VmHost> = hosts.values().filter(|h| h.enabled).cloned().collect();
+        let filtered_hosts: Vec<VmHost> = hosts
+            .values()
+            .filter(|h| h.enabled && !h.deleted)
+            .cloned()
+            .collect();
         let total = filtered_hosts.len() as u64;
         let paginated: Vec<VmHost> = filtered_hosts
             .into_iter()
@@ -1042,7 +1048,11 @@ impl LNVpsDbBase for MockDb {
     ) -> DbResult<(Vec<(VmHost, Region)>, u64)> {
         let hosts = self.hosts.lock().await;
         let regions = self.regions.lock().await;
-        let filtered_hosts: Vec<VmHost> = hosts.values().filter(|h| h.enabled).cloned().collect();
+        let filtered_hosts: Vec<VmHost> = hosts
+            .values()
+            .filter(|h| h.enabled && !h.deleted)
+            .cloned()
+            .collect();
         let total = filtered_hosts.len() as u64;
 
         let mut hosts_with_regions = Vec::new();
@@ -6343,8 +6353,9 @@ impl lnvps_db::AdminDb for MockDb {
     }
     async fn admin_delete_host(&self, host_id: u64) -> DbResult<()> {
         let mut hosts = self.hosts.lock().await;
-        if !hosts.contains_key(&host_id) {
-            return Err(anyhow!("no host").into());
+        let host = hosts.get_mut(&host_id).ok_or(anyhow!("no host"))?;
+        if host.deleted {
+            return Err(anyhow!("Host is already deleted").into());
         }
 
         let vms = self.vms.lock().await;
@@ -6355,13 +6366,11 @@ impl lnvps_db::AdminDb for MockDb {
         if active_vms > 0 {
             return Err(anyhow!("Cannot delete host with {} active VMs", active_vms).into());
         }
-        let historic_vms = vms.values().filter(|v| v.host_id == host_id).count();
-        if historic_vms > 0 {
-            return Err(anyhow!(
-                "Cannot delete host with {} deleted VM records still referencing it, disable the host instead",
-                historic_vms
-            )
-            .into());
+        // A host that ever ran a VM keeps its row so history still resolves.
+        if vms.values().any(|v| v.host_id == host_id) {
+            host.deleted = true;
+            host.enabled = false;
+            return Ok(());
         }
 
         hosts.remove(&host_id);

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -6341,6 +6341,36 @@ impl lnvps_db::AdminDb for MockDb {
     async fn admin_count_region_hosts(&self, _region_id: u64) -> DbResult<u64> {
         Ok(0)
     }
+    async fn admin_delete_host(&self, host_id: u64) -> DbResult<()> {
+        let mut hosts = self.hosts.lock().await;
+        if !hosts.contains_key(&host_id) {
+            return Err(anyhow!("no host").into());
+        }
+
+        let vms = self.vms.lock().await;
+        let active_vms = vms
+            .values()
+            .filter(|v| v.host_id == host_id && !v.deleted)
+            .count();
+        if active_vms > 0 {
+            return Err(anyhow!("Cannot delete host with {} active VMs", active_vms).into());
+        }
+        let historic_vms = vms.values().filter(|v| v.host_id == host_id).count();
+        if historic_vms > 0 {
+            return Err(anyhow!(
+                "Cannot delete host with {} deleted VM records still referencing it, disable the host instead",
+                historic_vms
+            )
+            .into());
+        }
+
+        hosts.remove(&host_id);
+        self.host_disks
+            .lock()
+            .await
+            .retain(|_, d| d.host_id != host_id);
+        Ok(())
+    }
     async fn admin_get_region_stats(&self, region_id: u64) -> DbResult<RegionStats> {
         let hosts = self.hosts.lock().await;
         let region_hosts: Vec<&VmHost> = hosts

--- a/lnvps_db/migrations/20260828172400_host_soft_delete.sql
+++ b/lnvps_db/migrations/20260828172400_host_soft_delete.sql
@@ -1,0 +1,6 @@
+-- Soft delete for hosts. A decommissioned host cannot be removed outright once
+-- it has run VMs: `vm.host_id` and `vm.disk_id` are foreign keys and those rows
+-- are billing history. Flagging the host as deleted hides it from every listing
+-- while keeping the id resolvable for historical joins.
+alter table vm_host
+    add column deleted bit(1) not null default 0;

--- a/lnvps_db/src/admin.rs
+++ b/lnvps_db/src/admin.rs
@@ -127,7 +127,8 @@ pub trait AdminDb: Send + Sync {
     /// Count hosts in a region
     async fn admin_count_region_hosts(&self, region_id: u64) -> DbResult<u64>;
 
-    /// Delete a host and its disks (only if no VM rows reference it)
+    /// Delete a host: hard delete (with its disks) when no VM ever ran on it,
+    /// otherwise flag it deleted. Refused while the host has active VMs.
     async fn admin_delete_host(&self, host_id: u64) -> DbResult<()>;
 
     /// Get comprehensive region statistics

--- a/lnvps_db/src/admin.rs
+++ b/lnvps_db/src/admin.rs
@@ -127,6 +127,9 @@ pub trait AdminDb: Send + Sync {
     /// Count hosts in a region
     async fn admin_count_region_hosts(&self, region_id: u64) -> DbResult<u64>;
 
+    /// Delete a host and its disks (only if no VM rows reference it)
+    async fn admin_delete_host(&self, host_id: u64) -> DbResult<()>;
+
     /// Get comprehensive region statistics
     async fn admin_get_region_stats(&self, region_id: u64) -> DbResult<RegionStats>;
 

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -726,6 +726,10 @@ pub struct VmHost {
     /// hardware rather than LNVPS's. `None` for every LNVPS-owned host.
     #[sqlx(default)]
     pub marketplace_node_id: Option<u64>,
+    /// Host has been decommissioned and is hidden from every listing. The row
+    /// stays so historical VMs still resolve their host.
+    #[sqlx(default)]
+    pub deleted: bool,
 }
 
 #[derive(FromRow, Clone, Debug, Default)]

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -7226,6 +7226,59 @@ impl AdminDb for LNVpsDbMysql {
         Ok(count as u64)
     }
 
+    async fn admin_delete_host(&self, host_id: u64) -> DbResult<()> {
+        // The host must exist, so deleting an unknown id is an error rather
+        // than a silent no-op.
+        let _host = self.get_host(host_id).await?;
+
+        let active_vms: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM vm WHERE host_id = ? AND deleted = false")
+                .bind(host_id)
+                .fetch_one(&self.db)
+                .await?;
+
+        if active_vms > 0 {
+            return Err(DbError::Source(
+                anyhow!("Cannot delete host with {} active VMs", active_vms).into_boxed_dyn_error(),
+            ));
+        }
+
+        // Soft-deleted VMs still hold foreign keys into vm_host and
+        // vm_host_disk, so the delete below would fail on the constraint.
+        // Report that clearly instead: those rows are billing history and
+        // removing them is a separate, deliberate operation.
+        let historic_vms: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vm WHERE host_id = ?")
+            .bind(host_id)
+            .fetch_one(&self.db)
+            .await?;
+
+        if historic_vms > 0 {
+            return Err(DbError::Source(
+                anyhow!(
+                    "Cannot delete host with {} deleted VM records still referencing it, disable the host instead",
+                    historic_vms
+                )
+                .into_boxed_dyn_error(),
+            ));
+        }
+
+        let mut tx = self.db.begin().await?;
+
+        sqlx::query("DELETE FROM vm_host_disk WHERE host_id = ?")
+            .bind(host_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("DELETE FROM vm_host WHERE id = ?")
+            .bind(host_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+
     async fn admin_get_region_stats(&self, region_id: u64) -> DbResult<RegionStats> {
         // Get comprehensive region statistics with a single efficient query
         // Use CAST to ensure we get the right SQL types for Rust compatibility

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -711,13 +711,13 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn list_hosts(&self) -> DbResult<Vec<VmHost>> {
-        Ok(sqlx::query_as("select h.* from vm_host h,region hr where h.enabled = 1 and h.region_id = hr.id and hr.enabled = 1")
+        Ok(sqlx::query_as("select h.* from vm_host h,region hr where h.enabled = 1 and h.deleted = 0 and h.region_id = hr.id and hr.enabled = 1")
             .fetch_all(&self.db)
             .await?)
     }
 
     async fn list_hosts_all(&self) -> DbResult<Vec<VmHost>> {
-        Ok(sqlx::query_as("select * from vm_host")
+        Ok(sqlx::query_as("select * from vm_host where deleted = 0")
             .fetch_all(&self.db)
             .await?)
     }
@@ -725,14 +725,14 @@ impl LNVpsDbBase for LNVpsDbMysql {
     async fn list_hosts_paginated(&self, limit: u64, offset: u64) -> DbResult<(Vec<VmHost>, u64)> {
         // Get total count
         let total: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM vm_host h, region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1"
+            "SELECT COUNT(*) FROM vm_host h, region hr WHERE h.enabled = 1 AND h.deleted = 0 AND h.region_id = hr.id AND hr.enabled = 1"
         )
         .fetch_one(&self.db)
         .await?;
 
         // Get paginated results
         let hosts = sqlx::query_as(
-            "SELECT h.* FROM vm_host h, region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1 ORDER BY h.name LIMIT ? OFFSET ?"
+            "SELECT h.* FROM vm_host h, region hr WHERE h.enabled = 1 AND h.deleted = 0 AND h.region_id = hr.id AND hr.enabled = 1 ORDER BY h.name LIMIT ? OFFSET ?"
         )
         .bind(limit)
         .bind(offset)
@@ -749,7 +749,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
     ) -> DbResult<(Vec<(VmHost, Region)>, u64)> {
         // Get total count
         let total: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM vm_host h, region hr WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1"
+            "SELECT COUNT(*) FROM vm_host h, region hr WHERE h.enabled = 1 AND h.deleted = 0 AND h.region_id = hr.id AND hr.enabled = 1"
         )
         .fetch_one(&self.db)
         .await?;
@@ -758,7 +758,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
         let rows = sqlx::query(
             "SELECT h.*, hr.id as region_id, hr.name as region_name, hr.enabled as region_enabled, hr.company_id as region_company_id, hr.country_code as region_country_code 
              FROM vm_host h, region hr 
-             WHERE h.enabled = 1 AND h.region_id = hr.id AND hr.enabled = 1 
+             WHERE h.enabled = 1 AND h.deleted = 0 AND h.region_id = hr.id AND hr.enabled = 1 
              ORDER BY h.name LIMIT ? OFFSET ?"
         )
         .bind(limit)
@@ -790,6 +790,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
                 ssh_key: row.get("ssh_key"),
                 sunset_date: row.get("sunset_date"),
                 marketplace_node_id: row.get("marketplace_node_id"),
+                deleted: row.get("deleted"),
             };
 
             let region = Region {
@@ -4911,12 +4912,12 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn get_marketplace_node_host(&self, node_id: u64) -> DbResult<Option<VmHost>> {
-        Ok(
-            sqlx::query_as::<_, VmHost>("SELECT * FROM vm_host WHERE marketplace_node_id = ?")
-                .bind(node_id)
-                .fetch_optional(&self.db)
-                .await?,
+        Ok(sqlx::query_as::<_, VmHost>(
+            "SELECT * FROM vm_host WHERE marketplace_node_id = ? AND deleted = 0",
         )
+        .bind(node_id)
+        .fetch_optional(&self.db)
+        .await?)
     }
 
     async fn get_marketplace_node_by_tunnel(
@@ -7195,7 +7196,7 @@ impl AdminDb for LNVpsDbMysql {
     async fn admin_delete_region(&self, region_id: u64) -> DbResult<()> {
         // First check if any hosts are assigned to this region
         let host_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM vm_host WHERE region_id = ?")
+            sqlx::query_scalar("SELECT COUNT(*) FROM vm_host WHERE region_id = ? AND deleted = 0")
                 .bind(region_id)
                 .fetch_one(&self.db)
                 .await?;
@@ -7218,18 +7219,26 @@ impl AdminDb for LNVpsDbMysql {
     }
 
     async fn admin_count_region_hosts(&self, region_id: u64) -> DbResult<u64> {
-        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vm_host WHERE region_id = ?")
-            .bind(region_id)
-            .fetch_one(&self.db)
-            .await?;
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM vm_host WHERE region_id = ? AND deleted = 0")
+                .bind(region_id)
+                .fetch_one(&self.db)
+                .await?;
 
         Ok(count as u64)
     }
 
+    /// Delete a host: removed outright when no VM ever ran on it, otherwise
+    /// flagged `deleted` so historical VMs keep resolving their host.
     async fn admin_delete_host(&self, host_id: u64) -> DbResult<()> {
         // The host must exist, so deleting an unknown id is an error rather
         // than a silent no-op.
-        let _host = self.get_host(host_id).await?;
+        let host = self.get_host(host_id).await?;
+        if host.deleted {
+            return Err(DbError::Source(
+                anyhow!("Host is already deleted").into_boxed_dyn_error(),
+            ));
+        }
 
         let active_vms: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM vm WHERE host_id = ? AND deleted = false")
@@ -7244,22 +7253,22 @@ impl AdminDb for LNVpsDbMysql {
         }
 
         // Soft-deleted VMs still hold foreign keys into vm_host and
-        // vm_host_disk, so the delete below would fail on the constraint.
-        // Report that clearly instead: those rows are billing history and
-        // removing them is a separate, deliberate operation.
+        // vm_host_disk, and those rows are billing history that must be kept,
+        // so a host that ever ran a VM can only be flagged as deleted. A host
+        // with no history at all (added by mistake, or never used) is removed
+        // outright so the table does not accumulate junk.
         let historic_vms: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vm WHERE host_id = ?")
             .bind(host_id)
             .fetch_one(&self.db)
             .await?;
 
         if historic_vms > 0 {
-            return Err(DbError::Source(
-                anyhow!(
-                    "Cannot delete host with {} deleted VM records still referencing it, disable the host instead",
-                    historic_vms
-                )
-                .into_boxed_dyn_error(),
-            ));
+            sqlx::query("UPDATE vm_host SET deleted = 1, enabled = 0 WHERE id = ?")
+                .bind(host_id)
+                .execute(&self.db)
+                .await?;
+
+            return Ok(());
         }
 
         let mut tx = self.db.begin().await?;
@@ -7290,12 +7299,12 @@ impl AdminDb for LNVpsDbMysql {
         let row: (i64, i64, Option<u64>, Option<u64>, i64, i64, i64) = sqlx::query_as(
             r#"
             SELECT
-                (SELECT COUNT(*) FROM vm_host WHERE region_id = ?) as host_count,
+                (SELECT COUNT(*) FROM vm_host WHERE region_id = ? AND deleted = 0) as host_count,
                 (SELECT COUNT(*) FROM vm v
                     JOIN vm_host h ON v.host_id = h.id
                     WHERE h.region_id = ? AND v.deleted = 0) as total_vms,
-                CAST((SELECT COALESCE(SUM(cpu), 0) FROM vm_host WHERE region_id = ?) AS UNSIGNED) as total_cpu_cores,
-                CAST((SELECT COALESCE(SUM(memory), 0) FROM vm_host WHERE region_id = ?) AS UNSIGNED) as total_memory_bytes,
+                CAST((SELECT COALESCE(SUM(cpu), 0) FROM vm_host WHERE region_id = ? AND deleted = 0) AS UNSIGNED) as total_cpu_cores,
+                CAST((SELECT COALESCE(SUM(memory), 0) FROM vm_host WHERE region_id = ? AND deleted = 0) AS UNSIGNED) as total_memory_bytes,
                 (SELECT COUNT(*) FROM vm_ip_assignment ip
                     JOIN vm v ON ip.vm_id = v.id
                     JOIN vm_host h ON v.host_id = h.id
@@ -7551,7 +7560,7 @@ impl AdminDb for LNVpsDbMysql {
     ) -> DbResult<(Vec<AdminVmHost>, u64)> {
         // Get total count (including disabled hosts)
         let total: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM vm_host h JOIN region hr ON h.region_id = hr.id",
+            "SELECT COUNT(*) FROM vm_host h JOIN region hr ON h.region_id = hr.id WHERE h.deleted = 0",
         )
         .fetch_one(&self.db)
         .await?;
@@ -7573,6 +7582,7 @@ impl AdminDb for LNVpsDbMysql {
                  WHERE deleted = 0 
                  GROUP BY host_id
              ) vm_counts ON h.id = vm_counts.host_id
+             WHERE h.deleted = 0
              ORDER BY h.name 
              LIMIT ? OFFSET ?",
         )


### PR DESCRIPTION
Fixes #400

Adds `admin_delete_host` to the `LNVpsDbAdmin` trait (MySQL + mock implementations) and a `DELETE /api/admin/v1/hosts/{id}` route guarded by `AdminResource::Hosts` + `AdminAction::Delete`. On success the host's disk records and the host row are removed in one transaction.

## Deletion is refused while any VM row references the host

The issue asked to refuse only when non-deleted VMs exist, but `vm.host_id` and `vm.disk_id` are foreign keys that soft-deleted rows still hold, so a hard delete would fail on the constraint. Both cases are therefore checked up front and reported clearly instead of surfacing a raw FK error:

- active VMs: `Cannot delete host with N active VMs`
- soft-deleted VMs: `Cannot delete host with N deleted VM records still referencing it, disable the host instead`

In practice that means a host that ever ran a VM still has to be disabled rather than deleted, since those rows are billing history. Giving those hosts a real delete needs a separate decision about what happens to the VM rows (repoint, archive, or hard delete), so it is out of scope here.

## Changes

- `lnvps_db/src/admin.rs`, `lnvps_db/src/mysql.rs` - trait method and MySQL implementation
- `lnvps_api_common/src/mock.rs` - mock removes the host and its disks, enforcing the same refusals
- `lnvps_api_admin/src/admin/hosts.rs` - route, handler and three tests
- `ADMIN_API_ENDPOINTS.md`, `API_CHANGELOG.md` - documented

The admin UI lives in a separate repo, so exposing the button there is a follow-up.