### PR TITLE
fix(db): list_hosts_all must include deleted hosts

### DIFF
--- a/lnvps_api_admin/src/admin/vms.rs
+++ b/lnvps_api_admin/src/admin/vms.rs
@@ -1674,6 +1674,42 @@ mod tests {
         assert!(!infos[0].region_name.is_empty());
     }
 
+    /// Regression: a deleted host must still resolve for admin VM listings.
+    /// Deleting a host that has history flags it rather than removing the row
+    /// precisely so its VMs keep rendering, and listing VMs with
+    /// `include_deleted` returns exactly those VMs, so the batch's
+    /// `list_hosts_all()` must not filter deleted hosts out.
+    #[tokio::test]
+    async fn admin_vm_batch_resolves_deleted_host() {
+        use lnvps_api_common::MockDb;
+        use lnvps_db::{AdminDb, LNVpsDbBase};
+
+        let db = MockDb::default();
+        let user_id = db.upsert_user(&[1u8; 32]).await.unwrap();
+        let mut vm = MockDb::mock_vm();
+        vm.user_id = user_id;
+        vm.ssh_key_id = None;
+        let vm_id = db.insert_vm(&vm).await.unwrap();
+        db.delete_vm(vm_id).await.unwrap();
+        // The host has VM history, so this flags it instead of removing it
+        db.admin_delete_host(1).await.unwrap();
+
+        let db: std::sync::Arc<dyn lnvps_db::LNVpsDb> = std::sync::Arc::new(db);
+        assert!(
+            db.list_hosts_all().await.unwrap().iter().any(|h| h.id == 1),
+            "precondition: list_hosts_all() keeps deleted hosts"
+        );
+
+        let vms = vec![db.get_vm(vm_id).await.unwrap()];
+        let infos = load_admin_vm_infos(&db, &VmStateCache::new(), &vms)
+            .await
+            .unwrap();
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].host_id, 1);
+        assert!(!infos[0].host_name.is_empty());
+        assert!(!infos[0].region_name.is_empty());
+    }
+
     /// The list, single-VM and bulk-status endpoints all build their payload
     /// through [`AdminVmBatch`], which bulk-loads each table once.
     #[tokio::test]

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -1022,7 +1022,7 @@ impl LNVpsDbBase for MockDb {
 
     async fn list_hosts_all(&self) -> DbResult<Vec<VmHost>> {
         let hosts = self.hosts.lock().await;
-        Ok(hosts.values().filter(|h| !h.deleted).cloned().collect())
+        Ok(hosts.values().cloned().collect())
     }
 
     async fn list_hosts_paginated(&self, limit: u64, offset: u64) -> DbResult<(Vec<VmHost>, u64)> {

--- a/lnvps_db/src/lib.rs
+++ b/lnvps_db/src/lib.rs
@@ -287,12 +287,16 @@ pub trait LNVpsDbBase: Send + Sync {
     /// List VM's owned by a specific user
     async fn list_hosts(&self) -> DbResult<Vec<VmHost>>;
 
-    /// List every host, including disabled hosts and hosts in disabled regions.
+    /// List every host, including disabled and deleted hosts and hosts in
+    /// disabled regions.
     ///
-    /// `enabled` is a scheduling flag — "place no new VMs here" — not a claim
-    /// that the host has stopped existing. Reconciliation observes physical
-    /// reality and must see every host; only placement/capacity paths should
-    /// use the filtered [LNVpsDbBase::list_hosts].
+    /// `enabled` is a scheduling flag - "place no new VMs here" - not a claim
+    /// that the host has stopped existing, and `deleted` only hides the host
+    /// from listings. Reconciliation observes physical reality and must see
+    /// every host, and bulk VM loads resolve `vm.host_id` through this list, so
+    /// it must never filter: a deleted VM on a deleted host still has to render.
+    /// Only placement/capacity paths should use the filtered
+    /// [LNVpsDbBase::list_hosts].
     async fn list_hosts_all(&self) -> DbResult<Vec<VmHost>>;
 
     /// List hosts with pagination

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -717,7 +717,7 @@ impl LNVpsDbBase for LNVpsDbMysql {
     }
 
     async fn list_hosts_all(&self) -> DbResult<Vec<VmHost>> {
-        Ok(sqlx::query_as("select * from vm_host where deleted = 0")
+        Ok(sqlx::query_as("select * from vm_host")
             .fetch_all(&self.db)
             .await?)
     }


### PR DESCRIPTION
Follow-up to #404.

That PR filtered deleted hosts out of `list_hosts_all()` along with the listing queries, which is wrong: `list_hosts_all()` is the bulk lookup that resolves `vm.host_id`, so admin VM listings would fail with "VM references non-existent host" for any VM that ran on a deleted host. Listing VMs with `include_deleted` returns exactly those VMs, and a host with history is flagged rather than removed precisely so its VMs keep rendering, so this list has to stay unfiltered.

- `lnvps_db/src/mysql.rs`, `lnvps_api_common/src/mock.rs` - drop the `deleted` filter from `list_hosts_all`
- `lnvps_db/src/lib.rs` - the trait doc now says why it must never filter
- `lnvps_api_admin/src/admin/vms.rs` - regression test: a soft-deleted VM on a deleted host still resolves its host and region through `AdminVmBatch`

The placement and listing paths (`list_hosts`, both paginated listings, the admin host listing, region host counts and stats, marketplace node host) keep excluding deleted hosts, as does `get_marketplace_node_host` so a probe cannot re-enable a decommissioned host.