### PR TITLE
Regions report what else is configured in them

### DIFF
--- a/ADMIN_API_ENDPOINTS.md
+++ b/ADMIN_API_ENDPOINTS.md
@@ -1819,6 +1819,24 @@ Required Permission: `hosts::view`
 Returns paginated list of VM host regions with configuration details, host counts, and statistics (only active VMs are
 counted). Each region carries `country_code` (ISO 3166-1 alpha-2, or `null` if not set).
 
+Each region also carries counts of what else is configured there, so an operator
+can see what a region holds before touching it:
+
+| Field | Counts |
+|---|---|
+| `ip_ranges` | IP ranges in the region, enabled or not |
+| `vm_templates` | VM templates sold in the region, enabled or not |
+| `app_clusters` | App clusters in the region |
+| `app_deployments` | Live deployments on those clusters (soft-deleted ones are excluded) |
+| `tunnel_pools` | Tunnel pools terminating in the region |
+| `vpn_services` | VPN services sold there, counted once each however many interfaces they terminate on |
+| `routers` | Routers serving the region |
+
+`routers` is derived rather than stored: a router has no region column, so it is
+counted through the tunnel pools that terminate in the region and the access
+policies its IP ranges use, de-duplicated so a router reached both ways counts
+once.
+
 #### Get Region Details
 
 ```

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Regions report what else is in them** — `GET /api/admin/v1/regions` and `GET /api/admin/v1/regions/{id}` now also return `ip_ranges`, `vm_templates`, `app_clusters`, `app_deployments`, `tunnel_pools`, `vpn_services` and `routers` alongside the existing host, VM and IP figures, so an admin can see what a region holds without opening six other pages first.
+
+  `routers` is derived: a router has no region column, so it is counted through the tunnel pools terminating in the region and the access policies its IP ranges use, de-duplicated so a router reached both ways counts once. `vpn_services` is likewise distinct, because one service may terminate on several interfaces in the same region, and `app_deployments` excludes soft-deleted rows since a deleted deployment is not running there.
+
 - **Host deletion**: `DELETE /api/admin/v1/hosts/{id}`, guarded by `hosts::delete`. Refused while the host has active VMs. A host that never ran a VM is removed along with its disk records; one that did keeps its row, now flagged `deleted` and forced `enabled: false`, because `vm.host_id` and `vm.disk_id` are foreign keys and those VMs are billing history.
 
   Deleted hosts are excluded from `GET /api/admin/v1/hosts`, from the region host counts and from region stats, but `GET /api/admin/v1/hosts/{id}` still returns one so admin views resolving a host from a historical VM keep working. Host responses carry a new `deleted` boolean.

--- a/lnvps_api_admin/src/admin/model.rs
+++ b/lnvps_api_admin/src/admin/model.rs
@@ -1329,6 +1329,23 @@ pub struct AdminRegionInfo {
     /// Active IPv6 assignments in this region. There is no matching "available"
     /// figure: an IPv6 range's free space is effectively unbounded.
     pub ipv6_assignments: u64,
+    /// IP ranges configured here, enabled or not.
+    pub ip_ranges: u64,
+    /// VM templates sold here, enabled or not.
+    pub vm_templates: u64,
+    /// App clusters here.
+    pub app_clusters: u64,
+    /// Live app deployments on those clusters.
+    pub app_deployments: u64,
+    /// Tunnel pools terminating here.
+    pub tunnel_pools: u64,
+    /// VPN services sold here, counted once each however many interfaces they
+    /// terminate on in this region.
+    pub vpn_services: u64,
+    /// Routers serving the region, through the tunnel pools that terminate here
+    /// and the access policies its IP ranges use. A router has no region column,
+    /// so this is what "routers in a region" can mean.
+    pub routers: u64,
 }
 
 #[derive(Deserialize)]

--- a/lnvps_api_admin/src/admin/regions.rs
+++ b/lnvps_api_admin/src/admin/regions.rs
@@ -50,6 +50,13 @@ async fn region_info(db: &Arc<dyn LNVpsDb>, region: Region) -> Result<AdminRegio
         ipv4_assignments: stats.ipv4_assignments,
         ipv4_available,
         ipv6_assignments: stats.ipv6_assignments,
+        ip_ranges: stats.ip_ranges,
+        vm_templates: stats.vm_templates,
+        app_clusters: stats.app_clusters,
+        app_deployments: stats.app_deployments,
+        tunnel_pools: stats.tunnel_pools,
+        vpn_services: stats.vpn_services,
+        routers: stats.routers,
     })
 }
 
@@ -156,7 +163,8 @@ async fn admin_create_region(
         )
         .await?;
 
-    // Get the created region
+    // Get the created region. Everything hangs off it, so a region that was
+    // created a moment ago has none of it and the counts are all zero.
     let region = this.db.get_host_region(region_id).await?;
     let region_info = AdminRegionInfo {
         id: region.id,
@@ -164,7 +172,7 @@ async fn admin_create_region(
         enabled: region.enabled,
         company_id: region.company_id,
         country_code: region.country_code,
-        host_count: 0, // New region has no hosts
+        host_count: 0,
         total_vms: 0,
         total_cpu_cores: 0,
         total_memory_bytes: 0,
@@ -172,6 +180,13 @@ async fn admin_create_region(
         ipv4_assignments: 0,
         ipv4_available: 0,
         ipv6_assignments: 0,
+        ip_ranges: 0,
+        vm_templates: 0,
+        app_clusters: 0,
+        app_deployments: 0,
+        tunnel_pools: 0,
+        vpn_services: 0,
+        routers: 0,
     };
 
     ApiData::ok(region_info)
@@ -240,6 +255,7 @@ struct RegionDeleteResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use lnvps_api_common::MockDb;
     use lnvps_db::{AdminDb, VmIpAssignment};
 
@@ -373,5 +389,111 @@ mod tests {
         assert_eq!(info.ipv4_assignments, 1);
         assert_eq!(info.ipv6_assignments, 1);
         assert_eq!(info.ipv4_available, MOCK_REGION_IPV4_USABLE - 1);
+    }
+
+    /// The related-resource counts, which are what an operator reads to answer
+    /// "what else is in this region" before touching it.
+    #[tokio::test]
+    async fn region_info_counts_related_resources() {
+        let (db, dyn_db) = mock_db().await;
+
+        let cluster_id = dyn_db
+            .insert_app_cluster(&lnvps_db::AppCluster {
+                id: 0,
+                name: "eu-1".to_string(),
+                region_id: 1,
+                ingress_domain: "apps.example.com".to_string(),
+                enabled: true,
+                capacity_cpu_milli: 1000,
+                capacity_memory_bytes: 1024,
+                capacity_storage_bytes: 1024,
+                created: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        {
+            let mut deployments = db.app_deployments.lock().await;
+            for (id, deleted) in [(1u64, false), (2, false), (3, true)] {
+                deployments.insert(
+                    id,
+                    lnvps_db::AppDeployment {
+                        id,
+                        user_id: 1,
+                        app_id: 1,
+                        cluster_id,
+                        resource_multiplier: 1,
+                        subscription_line_item_id: 0,
+                        name: format!("d{id}"),
+                        namespace: format!("app-d{id}"),
+                        hostname: None,
+                        custom_domain: None,
+                        custom_domain_verified: false,
+                        config: None,
+                        desired_state: Default::default(),
+                        status: Default::default(),
+                        status_message: None,
+                        usage_cpu_milli: None,
+                        usage_memory_bytes: None,
+                        usage_storage_bytes: None,
+                        usage_collected: None,
+                        created: Utc::now(),
+                        deleted,
+                    },
+                );
+            }
+        }
+
+        {
+            // Two interfaces on one route server, both in region 1, so the pool
+            // count is two but the router count is one.
+            let mut pools = db.tunnel_pools.lock().await;
+            for id in [1u64, 2] {
+                pools.insert(
+                    id,
+                    lnvps_db::TunnelPool {
+                        id,
+                        router_id: 7,
+                        region_id: 1,
+                        name: format!("pool{id}"),
+                        ..Default::default()
+                    },
+                );
+            }
+            // One service terminating on both of them is still one service.
+            let mut links = db.vpn_service_pools.lock().await;
+            links.insert(1, 42);
+            links.insert(2, 42);
+        }
+
+        let info = region_info(&dyn_db, dyn_db.get_host_region(1).await.unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(info.app_clusters, 1);
+        // The soft-deleted deployment is not running anywhere, so it is not counted
+        assert_eq!(info.app_deployments, 2);
+        assert_eq!(info.tunnel_pools, 2);
+        assert_eq!(info.vpn_services, 1);
+        assert_eq!(info.routers, 1);
+        assert_eq!(
+            info.ip_ranges,
+            dyn_db.list_ip_range_in_region(1).await.unwrap().len() as u64
+        );
+
+        // A region with nothing attached reports zero rather than the totals
+        let empty_id = dyn_db
+            .admin_create_region("Nowhere", true, 1, None)
+            .await
+            .unwrap();
+        let empty = region_info(&dyn_db, dyn_db.get_host_region(empty_id).await.unwrap())
+            .await
+            .unwrap();
+        assert_eq!(empty.app_clusters, 0);
+        assert_eq!(empty.app_deployments, 0);
+        assert_eq!(empty.tunnel_pools, 0);
+        assert_eq!(empty.vpn_services, 0);
+        assert_eq!(empty.routers, 0);
+        assert_eq!(empty.ip_ranges, 0);
     }
 }

--- a/lnvps_api_common/src/mock.rs
+++ b/lnvps_api_common/src/mock.rs
@@ -6413,6 +6413,50 @@ impl lnvps_db::AdminDb for MockDb {
             }
         }
 
+        let region_ranges: Vec<&IpRange> = ranges
+            .values()
+            .filter(|r| r.region_id == region_id)
+            .collect();
+
+        let templates = self.templates.lock().await;
+        let clusters = self.app_clusters.lock().await;
+        let region_clusters: Vec<u64> = clusters
+            .values()
+            .filter(|c| c.region_id == region_id)
+            .map(|c| c.id)
+            .collect();
+        let deployments = self.app_deployments.lock().await;
+        let app_deployments = deployments
+            .values()
+            .filter(|d| !d.deleted && region_clusters.contains(&d.cluster_id))
+            .count() as u64;
+
+        let pools = self.tunnel_pools.lock().await;
+        let region_pools: Vec<&TunnelPool> = pools
+            .values()
+            .filter(|p| p.region_id == region_id)
+            .collect();
+        let service_pools = self.vpn_service_pools.lock().await;
+        let vpn_services: HashSet<u64> = region_pools
+            .iter()
+            .filter_map(|p| service_pools.get(&p.id).copied())
+            .collect();
+
+        // A router has no region of its own, so it belongs to one through the
+        // pools terminating here and the access policies the region's ranges
+        // use. A set, because a router reached both ways is still one router.
+        let policies = self.access_policy.lock().await;
+        let mut routers: HashSet<u64> = region_pools.iter().map(|p| p.router_id).collect();
+        for range in &region_ranges {
+            if let Some(router_id) = range
+                .access_policy_id
+                .and_then(|id| policies.get(&id))
+                .and_then(|p| p.router_id)
+            {
+                routers.insert(router_id);
+            }
+        }
+
         Ok(RegionStats {
             host_count: region_hosts.len() as u64,
             total_vms: region_vms.len() as u64,
@@ -6421,6 +6465,16 @@ impl lnvps_db::AdminDb for MockDb {
             total_ip_assignments,
             ipv4_assignments,
             ipv6_assignments,
+            ip_ranges: region_ranges.len() as u64,
+            vm_templates: templates
+                .values()
+                .filter(|t| t.region_id == region_id)
+                .count() as u64,
+            app_clusters: region_clusters.len() as u64,
+            app_deployments,
+            tunnel_pools: region_pools.len() as u64,
+            vpn_services: vpn_services.len() as u64,
+            routers: routers.len() as u64,
         })
     }
     async fn admin_transfer_vm(&self, vm_id: u64, new_user_id: u64) -> DbResult<()> {

--- a/lnvps_db/src/model.rs
+++ b/lnvps_db/src/model.rs
@@ -2593,6 +2593,23 @@ pub struct RegionStats {
     pub ipv4_assignments: u64,
     /// Active IPv6 assignments (assignments whose `ip_range` is an IPv6 CIDR)
     pub ipv6_assignments: u64,
+    /// IP ranges configured in the region, enabled or not.
+    pub ip_ranges: u64,
+    /// VM templates sold in the region, enabled or not.
+    pub vm_templates: u64,
+    /// App clusters in the region.
+    pub app_clusters: u64,
+    /// Live (non-deleted) app deployments on those clusters.
+    pub app_deployments: u64,
+    /// Tunnel pools terminating in the region.
+    pub tunnel_pools: u64,
+    /// Distinct VPN services sold in the region, i.e. those with a pool here.
+    pub vpn_services: u64,
+    /// Distinct routers serving the region, counted through the tunnel pools
+    /// that terminate here and the access policies its IP ranges use. A router
+    /// has no region of its own, so this is the only thing "routers in a
+    /// region" can mean.
+    pub routers: u64,
 }
 
 #[derive(Clone, Debug, sqlx::Type)]

--- a/lnvps_db/src/mysql.rs
+++ b/lnvps_db/src/mysql.rs
@@ -7296,7 +7296,23 @@ impl AdminDb for LNVpsDbMysql {
         // with identical cpu/memory were counted once. Compute host totals and
         // VM/IP counts in separate subqueries to avoid both the value-dedup bug
         // and row multiplication from the joins.
-        let row: (i64, i64, Option<u64>, Option<u64>, i64, i64, i64) = sqlx::query_as(
+        #[allow(clippy::type_complexity)]
+        let row: (
+            i64,
+            i64,
+            Option<u64>,
+            Option<u64>,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+        ) = sqlx::query_as(
             r#"
             SELECT
                 (SELECT COUNT(*) FROM vm_host WHERE region_id = ? AND deleted = 0) as host_count,
@@ -7321,9 +7337,40 @@ impl AdminDb for LNVpsDbMysql {
                     JOIN vm_host h ON v.host_id = h.id
                     JOIN ip_range r ON ip.ip_range_id = r.id
                     WHERE h.region_id = ? AND v.deleted = 0 AND ip.deleted = 0
-                      AND r.cidr LIKE '%:%') as ipv6_assignments
+                      AND r.cidr LIKE '%:%') as ipv6_assignments,
+                (SELECT COUNT(*) FROM ip_range WHERE region_id = ?) as ip_ranges,
+                (SELECT COUNT(*) FROM vm_template WHERE region_id = ?) as vm_templates,
+                (SELECT COUNT(*) FROM app_cluster WHERE region_id = ?) as app_clusters,
+                (SELECT COUNT(*) FROM app_deployment d
+                    JOIN app_cluster c ON d.cluster_id = c.id
+                    WHERE c.region_id = ? AND d.deleted = 0) as app_deployments,
+                (SELECT COUNT(*) FROM tunnel_pool WHERE region_id = ?) as tunnel_pools,
+                -- Distinct, because one service may terminate on several
+                -- interfaces in the same region.
+                (SELECT COUNT(DISTINCT p.vpn_service_id) FROM vpn_service_pool p
+                    JOIN tunnel_pool t ON p.tunnel_pool_id = t.id
+                    WHERE t.region_id = ?) as vpn_services,
+                -- A router carries no region of its own, so it belongs to a
+                -- region through the tunnel pools terminating there and the
+                -- access policies its IP ranges use. UNION de-duplicates a
+                -- router reached both ways.
+                (SELECT COUNT(*) FROM (
+                    SELECT router_id FROM tunnel_pool WHERE region_id = ?
+                    UNION
+                    SELECT a.router_id FROM ip_range r
+                        JOIN access_policy a ON r.access_policy_id = a.id
+                        WHERE r.region_id = ? AND a.router_id IS NOT NULL
+                ) routers) as routers
             "#,
         )
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
+        .bind(region_id)
         .bind(region_id)
         .bind(region_id)
         .bind(region_id)
@@ -7342,6 +7389,13 @@ impl AdminDb for LNVpsDbMysql {
             total_ip_assignments: row.4 as u64,
             ipv4_assignments: row.5 as u64,
             ipv6_assignments: row.6 as u64,
+            ip_ranges: row.7 as u64,
+            vm_templates: row.8 as u64,
+            app_clusters: row.9 as u64,
+            app_deployments: row.10 as u64,
+            tunnel_pools: row.11 as u64,
+            vpn_services: row.12 as u64,
+            routers: row.13 as u64,
         })
     }
 


### PR DESCRIPTION
A region listing answered "how many hosts, VMs and addresses", which is the fleet question. The one an operator asks before touching a region is what else is in it, and answering that meant opening the IP ranges, templates, clusters, deployments, routers, tunnel pools and VPN services pages one at a time and filtering each.

`GET /api/admin/v1/regions` and `GET /api/admin/v1/regions/{id}` now also return:

| Field | Counts |
|---|---|
| `ip_ranges` | IP ranges in the region, enabled or not |
| `vm_templates` | VM templates sold in the region, enabled or not |
| `app_clusters` | App clusters in the region |
| `app_deployments` | Live deployments on those clusters |
| `tunnel_pools` | Tunnel pools terminating in the region |
| `vpn_services` | VPN services sold there |
| `routers` | Routers serving the region |

The counts are added to the existing single stats query rather than to new endpoints, so a region list still costs one round trip per region.

Two of them are not a plain `COUNT(*)`:

- **`routers` is derived.** A router has no region column, so it is the union of routers behind the region's tunnel pools and behind the access policies its IP ranges use, de-duplicated. A router reached both ways is one router.
- **`vpn_services` is distinct**, because one service may terminate on several interfaces in the same region.

`app_deployments` excludes soft-deleted rows: the row survives the delete, but the deployment is not running there.

The mock implementation mirrors the SQL, and `region_info_counts_related_resources` pins the three cases a naive version gets wrong (soft-deleted deployment not counted, two pools on one router are one router, one service on two pools is one service). A region created a moment ago reports zeros rather than the caller's previous totals.

Docs updated in `ADMIN_API_ENDPOINTS.md` and `API_CHANGELOG.md`. `cargo fmt` and clippy are clean, and the 197 admin tests pass.