### PR TITLE
Run app deployment backups as Kubernetes Jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "uuid",
  "wiremock",

--- a/catalog/buzz.yaml
+++ b/catalog/buzz.yaml
@@ -21,7 +21,10 @@ services:
       # writable dir, but not a persistent one
       - { path: /var/run/postgresql, size: 32Mi }
     backup:
-      command: ["sh", "-c", "exec pg_dumpall -U buzz"]
+      # Runs in its own pod on this image, so it connects to the service over
+      # the network (-h db); the default unix socket exists only inside
+      # postgres' own container. PGPASSWORD comes from the service's env.
+      command: ["sh", "-c", "PGPASSWORD=$POSTGRES_PASSWORD exec pg_dumpall -h db -U buzz"]
       artifact: buzz.sql
   redis:
     image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
@@ -134,3 +137,6 @@ secrets:
 config:
   - { name: owner_pubkey, label: "Owner pubkey (64-char hex)", type: string, required: true,
       pattern: "[0-9a-fA-F]{64}" }
+# Daily at 03:00 UTC, keeping a week of restore points. Each run captures
+# every service that declares a `backup:` method above, at one point in time.
+backup: { schedule: "0 3 * * *", retention: 7 }

--- a/catalog/route96.yaml
+++ b/catalog/route96.yaml
@@ -18,7 +18,10 @@ services:
       - { path: /tmp }
       - { path: /run/mysqld, size: 32Mi }
     backup:
-      command: ["sh", "-c", "exec mariadb-dump --all-databases -uroot -p\"$MARIADB_ROOT_PASSWORD\""]
+      # Runs in its own pod on this image, so it connects to the service over
+      # the network (-h db); the default unix socket exists only inside the
+      # database's own container.
+      command: ["sh", "-c", "exec mariadb-dump -h db --all-databases -uroot -p\"$MARIADB_ROOT_PASSWORD\""]
       artifact: route96.sql
   route96:
     image: voidic/route96:latest@sha256:90712a96eed391b43bd82280d22ed909899c9b94a5ff162178ca78803d46d4d5
@@ -41,3 +44,6 @@ services:
       volume: blobs
 secrets:
   - { name: DB_ROOT_PASSWORD, generate: password }
+# Daily at 03:00 UTC, keeping a week of restore points. Each run captures
+# every service that declares a `backup:` method above, at one point in time.
+backup: { schedule: "0 3 * * *", retention: 7 }

--- a/docs/agents/e2e-tests.md
+++ b/docs/agents/e2e-tests.md
@@ -43,7 +43,12 @@ docker compose up -d
 cargo test --workspace --exclude lnvps_e2e -- --test-threads=1
 ```
 
-After the `lnvps_e2e` suite, `run-e2e.sh` also runs `cargo test -p lnvps_api_common --features linux-ssh --test ssh_client`: `SshClient` talks SSH rather than HTTP, so it is covered against the `sshd` service in `docker-compose.e2e.yaml` (command exec, SFTP upload, unix-socket tunnel, auth failure) instead of through the API. Those tests skip themselves when `LNVPS_TEST_SSH_ADDR` / `LNVPS_TEST_SSH_KEY` are unset, so a plain `cargo test --workspace` does not need the stack.
+After the `lnvps_e2e` suite, `run-e2e.sh` runs two more suites that use the libraries directly rather than over HTTP. Both skip themselves when their environment variables are unset, so a plain `cargo test --workspace` does not need the stack — and `run-e2e.sh` checks the service is reachable first, since a skipped suite would otherwise pass the run without testing anything.
+
+- `cargo test -p lnvps_api_common --features linux-ssh --test ssh_client` — `SshClient` talks SSH, so it is covered against the `sshd` service in `docker-compose.e2e.yaml` (command exec, SFTP upload, unix-socket tunnel, auth failure). Needs `LNVPS_TEST_SSH_ADDR` / `LNVPS_TEST_SSH_KEY`.
+- `cargo test -p lnvps_api_common --test object_store` and the operator's `the_uploader_script_really_uploads` — backup artifact storage against the `rustfs` service (the same S3 implementation the app catalog ships). Needs `LNVPS_TEST_S3_ENDPOINT` / `LNVPS_TEST_S3_ACCESS_KEY` / `LNVPS_TEST_S3_SECRET_KEY`.
+
+  The unit tests pin our SigV4 output against AWS's published vector, which proves the arithmetic but not that a *server* accepts it: a canonical request that differs by a byte fails as an opaque 403 at the bucket. These cover the presigned round trip (upload, size, download with the signed filename, delete), that an upload URL grants nothing beyond its own key or method, and that expiry is enforced. The operator test then runs the uploader's **actual command line** in the image the Job names, so a busybox `tar` flag or a `curl` invocation a real S3 server refuses is caught here rather than by a customer with no backup.
 
 The user API is built and run with `--features agent` so the live-chat support websocket exists for `agent_chat.rs`; it is not a default feature.
 
@@ -72,6 +77,9 @@ The API servers must be configured to connect to the same per-run database. In C
 | `LNVPS_NO_DEV_SETUP` | *(unset)* | Set to any value to suppress `dev_setup.sql` on startup (debug builds only). Always set by `run-e2e.sh`. |
 | `LNVPS_TEST_SSH_ADDR` | *(unset)* | `host:port` of the compose `sshd` service; set by `run-e2e.sh` to `localhost:2222`. |
 | `LNVPS_TEST_SSH_KEY` | *(unset)* | Client private key for that sshd, generated into `volumes/e2e-sshd/` on first start. |
+| `LNVPS_TEST_S3_ENDPOINT` | *(unset)* | S3 endpoint for the object-store tests; set by `run-e2e.sh` to `http://localhost:9400` (the compose `rustfs`). |
+| `LNVPS_TEST_S3_ACCESS_KEY` | *(unset)* | Access key for that endpoint; `e2eaccesskey` in the compose file. |
+| `LNVPS_TEST_S3_SECRET_KEY` | *(unset)* | Secret key for that endpoint; `e2esecretkey` in the compose file. |
 | `NOSTR_SECRET_KEY` | *(random)* | Hex Nostr secret key for user identity |
 | `ADMIN_NOSTR_SECRET_KEY` | *(random)* | Hex Nostr secret key for admin identity |
 

--- a/docs/managed-app-examples.md
+++ b/docs/managed-app-examples.md
@@ -58,6 +58,34 @@ read-only, mounted via subPath), `depends_on`, `backup`, `user`,
 resolves to `{deployment-name}.{cluster-ingress-domain}`; a service name
 resolves to its in-namespace DNS (e.g. `db:3306`).
 
+**`backup`** — per service, either `command:` (an app-native dump, whose stdout
+becomes the artifact) or `volume:` (a raw tar of one named volume), plus an
+optional `artifact:` filename. A top-level `backup: { schedule, retention }`
+turns it into an automatic run: a 5-field cron expression in **UTC** (no faster
+than hourly) and how many runs to keep. A run captures every service that
+declares a method, at one point in time.
+
+The capture runs in its **own pod**, not in the app's container, so a
+`command:` must reach its service over the network by the compose service name:
+
+```yaml
+  db:
+    ports:                      # a service with no ports has no DNS name
+      - { name: postgres, container: 5432, protocol: tcp, expose: none }
+    backup:
+      command: ["sh", "-c", "PGPASSWORD=$POSTGRES_PASSWORD exec pg_dumpall -h db -U buzz"]
+      artifact: buzz.sql
+  blobs:
+    backup:
+      volume: media             # tarred from a read-only mount of the PVC
+backup: { schedule: "0 3 * * *", retention: 7 }
+```
+
+`pg_dumpall` or `mariadb-dump` left to its default connects to a unix socket
+that exists only inside the service's own container, and fails there. The dump
+sees the service's resolved env, so a generated password is available to it as
+the app has it.
+
 **`volumes[].label`** — optional, and what a **buyer** gets from that volume:
 `events`, `media`, `database`, `files`. Surfaced per volume on
 `GET /api/v1/apps`, so a listing can say "10 GB events + 20 GB media" instead of

--- a/lnvps_api_common/src/object_store.rs
+++ b/lnvps_api_common/src/object_store.rs
@@ -43,7 +43,13 @@ pub struct ObjectStoreConfig {
     #[serde(default = "default_region")]
     pub region: String,
     pub bucket: String,
+    /// Credentials. Defaulted so a deployment can keep them out of a config
+    /// file that lives in a ConfigMap and supply them from a Secret through the
+    /// environment instead; `ObjectStore::new` rejects a pair that is still
+    /// empty by then.
+    #[serde(default)]
     pub access_key: String,
+    #[serde(default)]
     pub secret_key: String,
     /// Address the bucket as a path (`endpoint/bucket/key`) rather than as a
     /// subdomain. Defaults to true, because that is what self-hosted services
@@ -71,6 +77,9 @@ impl ObjectStore {
     pub fn new(config: ObjectStoreConfig) -> Result<Self> {
         if config.endpoint.trim().is_empty() || config.bucket.trim().is_empty() {
             bail!("object storage needs an endpoint and a bucket");
+        }
+        if config.access_key.trim().is_empty() || config.secret_key.trim().is_empty() {
+            bail!("object storage needs an access key and a secret key");
         }
         if !config.endpoint.starts_with("http://") && !config.endpoint.starts_with("https://") {
             bail!(
@@ -471,6 +480,12 @@ mod tests {
         cfg.endpoint = "https://s3.example.com".to_string();
         cfg.bucket = String::new();
         assert!(ObjectStore::new(cfg.clone()).is_err(), "bucket is required");
+        cfg.bucket = "backups".to_string();
+        cfg.secret_key = String::new();
+        assert!(
+            ObjectStore::new(cfg.clone()).is_err(),
+            "credentials left to the environment must actually arrive"
+        );
 
         let store = test_store();
         assert!(store.presign_put("", Duration::from_secs(60)).is_err());
@@ -486,13 +501,19 @@ mod tests {
     /// Defaults exist so a config only has to carry what is site-specific.
     #[test]
     fn config_defaults_cover_the_self_hosted_case() {
-        let cfg: ObjectStoreConfig = serde_yaml_ng::from_str(
-            "endpoint: https://minio.internal:9000\nbucket: backups\naccess-key: k\nsecret-key: s\n",
-        )
-        .unwrap();
+        let cfg: ObjectStoreConfig =
+            serde_yaml_ng::from_str("endpoint: https://minio.internal:9000\nbucket: backups\n")
+                .unwrap();
         assert_eq!(cfg.region, "us-east-1");
+        // Credentials may arrive from the environment rather than the file.
+        assert!(cfg.access_key.is_empty());
         assert!(cfg.path_style, "self-hosted services need path style");
-        let store = ObjectStore::new(cfg).unwrap();
+        let store = ObjectStore::new(ObjectStoreConfig {
+            access_key: "k".to_string(),
+            secret_key: "s".to_string(),
+            ..cfg
+        })
+        .unwrap();
         assert_eq!(store.bucket(), "backups");
     }
 

--- a/lnvps_api_common/src/object_store.rs
+++ b/lnvps_api_common/src/object_store.rs
@@ -99,8 +99,34 @@ impl ObjectStore {
         &self.config.bucket
     }
 
+    /// Create the bucket, tolerating one that already exists.
+    ///
+    /// For provisioning a fresh store (and for tests against a real
+    /// S3-compatible server). Deliberately **not** called on the operator's
+    /// startup path: creating buckets is a permission the operator's key should
+    /// not need to hold just to write objects into a bucket somebody else made.
+    pub async fn create_bucket(&self) -> Result<()> {
+        let url = self.presign("PUT", "", Duration::from_secs(60), &[], Utc::now())?;
+        let resp = self
+            .client
+            .put(&url)
+            .send()
+            .await
+            .with_context(|| format!("could not create bucket '{}'", self.config.bucket))?;
+        // 409 is the bucket already existing, which is the desired end state.
+        if resp.status().is_success() || resp.status() == reqwest::StatusCode::CONFLICT {
+            return Ok(());
+        }
+        bail!(
+            "creating bucket '{}' returned {}",
+            self.config.bucket,
+            resp.status()
+        )
+    }
+
     /// A URL the holder may upload exactly one object to.
     pub fn presign_put(&self, key: &str, expires_in: Duration) -> Result<String> {
+        check_key(key)?;
         self.presign("PUT", key, expires_in, &[], Utc::now())
     }
 
@@ -122,6 +148,7 @@ impl ObjectStore {
                 format!("attachment; filename=\"{}\"", sanitise_filename(f)),
             )
         });
+        check_key(key)?;
         let extra: Vec<(String, String)> = disposition.into_iter().collect();
         self.presign("GET", key, expires_in, &extra, Utc::now())
     }
@@ -132,6 +159,7 @@ impl ObjectStore {
     /// stock `curl` container with nothing to report back through, so the
     /// authoritative size is whatever the bucket ended up holding.
     pub async fn size(&self, key: &str) -> Result<Option<u64>> {
+        check_key(key)?;
         let url = self.presign("HEAD", key, Duration::from_secs(60), &[], Utc::now())?;
         let resp = self
             .client
@@ -157,6 +185,7 @@ impl ObjectStore {
     /// Remove an object. Deleting one that is already gone succeeds: retention
     /// pruning has to be safe to retry.
     pub async fn delete(&self, key: &str) -> Result<()> {
+        check_key(key)?;
         let url = self.presign("DELETE", key, Duration::from_secs(60), &[], Utc::now())?;
         let resp = self
             .client
@@ -182,9 +211,6 @@ impl ObjectStore {
         extra_query: &[(String, String)],
         now: DateTime<Utc>,
     ) -> Result<String> {
-        if key.is_empty() {
-            bail!("object key is empty");
-        }
         if expires_in.is_zero() || expires_in > MAX_PRESIGN_EXPIRY {
             bail!(
                 "presign expiry must be between 1 second and {} seconds",
@@ -273,7 +299,8 @@ impl ObjectStore {
                     self.config.endpoint
                 )
             })?;
-        // Each path segment is encoded, but the separators are not.
+        // Each path segment is encoded, but the separators are not. An empty
+        // key addresses the bucket itself, which is what creating one does.
         let encoded_key = key.split('/').map(uri_encode).collect::<Vec<_>>().join("/");
         if self.config.path_style {
             Ok((
@@ -297,6 +324,14 @@ fn hmac(key: &[u8], data: &str) -> Result<HmacSha256> {
 
 fn hmac_key(key: &[u8]) -> Result<HmacSha256> {
     HmacSha256::new_from_slice(key).map_err(|e| anyhow!("invalid HMAC key: {e}"))
+}
+
+/// An object is always addressed by a key; only bucket-level calls have none.
+fn check_key(key: &str) -> Result<()> {
+    if key.is_empty() {
+        bail!("object key is empty");
+    }
+    Ok(())
 }
 
 /// RFC 3986 percent-encoding as SigV4 defines it: everything outside the

--- a/lnvps_api_common/tests/object_store.rs
+++ b/lnvps_api_common/tests/object_store.rs
@@ -1,0 +1,177 @@
+//! [`ObjectStore`] against a real S3-compatible server.
+//!
+//! The unit tests pin the signature against AWS's published vector, which
+//! proves the arithmetic. They cannot prove that a *server* accepts what we
+//! produce: the canonical request has to match byte for byte, and a difference
+//! in path encoding, query ordering or the signed-headers list fails as an
+//! opaque 403 at the bucket rather than as a wrong hex string in CI.
+//!
+//! So these run against the `rustfs` service in `docker-compose.e2e.yaml`,
+//! which is the same S3 implementation the app catalog ships to customers.
+//!
+//! - `LNVPS_TEST_S3_ENDPOINT`   — e.g. `http://localhost:9400`
+//! - `LNVPS_TEST_S3_ACCESS_KEY` / `LNVPS_TEST_S3_SECRET_KEY`
+//!
+//! Skipped when unset, so `cargo test --workspace` on a machine without the
+//! stack does not fail.
+
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+use lnvps_api_common::{ObjectStore, ObjectStoreConfig};
+
+fn store() -> Option<ObjectStore> {
+    let endpoint = std::env::var("LNVPS_TEST_S3_ENDPOINT").ok()?;
+    let access_key = std::env::var("LNVPS_TEST_S3_ACCESS_KEY").ok()?;
+    let secret_key = std::env::var("LNVPS_TEST_S3_SECRET_KEY").ok()?;
+    ObjectStore::new(ObjectStoreConfig {
+        endpoint,
+        region: "us-east-1".to_string(),
+        // One bucket per run: a test that deletes objects must not race another
+        // run's, and creating it is part of what is being checked.
+        bucket: format!("lnvps-backup-test-{}", run_id()),
+        access_key,
+        secret_key,
+        path_style: true,
+    })
+    .ok()
+}
+
+fn run_id() -> String {
+    std::env::var("LNVPS_E2E_RUN_ID").unwrap_or_else(|_| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis().to_string())
+            .unwrap_or_else(|_| "0".to_string())
+    })
+}
+
+macro_rules! store_or_skip {
+    () => {
+        match store() {
+            Some(s) => s,
+            None => {
+                eprintln!("skipping: LNVPS_TEST_S3_ENDPOINT / _ACCESS_KEY / _SECRET_KEY not set");
+                return Ok(());
+            }
+        }
+    };
+}
+
+/// Upload the way a backup Job does — an HTTP `PUT` to a presigned URL, with
+/// no credentials of its own — then read the artifact back the way the customer
+/// API will, and prune it the way retention does.
+#[tokio::test]
+async fn an_artifact_round_trips_through_a_presigned_url() -> Result<()> {
+    let store = store_or_skip!();
+    store.create_bucket().await?;
+    // Creating a bucket that exists is the normal case on every run after the
+    // first, and must not be an error.
+    store.create_bucket().await?;
+
+    let key = "deployments/12/run-a/route96.sql.gz";
+    // Not tiny: a single byte would pass a signature that mishandled the body.
+    let body: Vec<u8> = (0..64 * 1024).map(|i| (i % 251) as u8).collect();
+
+    let put = store.presign_put(key, Duration::from_secs(300))?;
+    let uploaded = reqwest::Client::new()
+        .put(&put)
+        .body(body.clone())
+        .send()
+        .await?;
+    if !uploaded.status().is_success() {
+        bail!(
+            "upload failed: {} {}",
+            uploaded.status(),
+            uploaded.text().await.unwrap_or_default()
+        );
+    }
+
+    // The bucket is the authority on artifact size, since the uploader is a
+    // stock container with nothing to report back through.
+    assert_eq!(store.size(key).await?, Some(body.len() as u64));
+
+    let get = store.presign_get(key, Duration::from_secs(300), Some("route96.sql.gz"))?;
+    let fetched = reqwest::Client::new().get(&get).send().await?;
+    assert!(fetched.status().is_success(), "{}", fetched.status());
+    // The download name is signed into the URL, so the server is what applies
+    // it — the customer's browser saves the artifact, not the object key's tail.
+    let disposition = fetched
+        .headers()
+        .get(reqwest::header::CONTENT_DISPOSITION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        disposition.contains("route96.sql.gz"),
+        "content-disposition was {disposition:?}"
+    );
+    assert_eq!(fetched.bytes().await?.to_vec(), body, "bytes changed");
+
+    store.delete(key).await?;
+    assert_eq!(store.size(key).await?, None, "delete left the object");
+    // Retention re-runs against rows whose objects are already gone.
+    store.delete(key).await?;
+    Ok(())
+}
+
+/// The URL handed to a backup pod is a write to one key, and nothing else. The
+/// pod runs in the customer's namespace beside their app, so this is the
+/// boundary that makes it safe to put there at all.
+#[tokio::test]
+async fn an_upload_url_grants_nothing_beyond_its_own_object() -> Result<()> {
+    let store = store_or_skip!();
+    store.create_bucket().await?;
+
+    let key = "deployments/13/run-b/db.sql.gz";
+    let put = store.presign_put(key, Duration::from_secs(300))?;
+    let client = reqwest::Client::new();
+    client.put(&put).body(vec![1u8; 16]).send().await?;
+
+    // The method is signed: an upload URL cannot read the object back.
+    let replayed = client.get(&put).send().await?;
+    assert!(
+        replayed.status().is_client_error(),
+        "a PUT URL served a GET: {}",
+        replayed.status()
+    );
+
+    // The key is signed: pointing the same signature at another deployment's
+    // object is refused.
+    let elsewhere = put.replace("deployments/13", "deployments/99");
+    let stolen = client.put(&elsewhere).body(vec![2u8; 16]).send().await?;
+    assert!(
+        stolen.status().is_client_error(),
+        "a signature was reused for another key: {}",
+        stolen.status()
+    );
+
+    store.delete(key).await?;
+    Ok(())
+}
+
+/// Expiry is what bounds a leaked URL. A server that ignored `X-Amz-Expires`
+/// would turn every backup upload into a standing grant, and nothing in the
+/// unit tests would notice.
+#[tokio::test]
+async fn a_url_stops_working_when_it_expires() -> Result<()> {
+    let store = store_or_skip!();
+    store.create_bucket().await?;
+
+    let key = "deployments/14/run-c/expiring.gz";
+    let put = store.presign_put(key, Duration::from_secs(1))?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let late = reqwest::Client::new()
+        .put(&put)
+        .body(vec![3u8; 16])
+        .send()
+        .await?;
+    assert!(
+        late.status().is_client_error(),
+        "an expired URL still uploaded: {}",
+        late.status()
+    );
+    assert_eq!(store.size(key).await?, None);
+    Ok(())
+}

--- a/lnvps_compose/src/lib.rs
+++ b/lnvps_compose/src/lib.rs
@@ -770,9 +770,21 @@ pub enum FieldType {
 }
 
 /// A service's backup method.
+///
+/// Whichever is used, the capture runs in a **separate pod**, not in the
+/// service's own container: the operator creates a Job per artifact, so a
+/// backup is not tied to a running app pod and cannot disturb it.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Backup {
     /// App-consistent dump command; stdout is captured as the artifact.
+    ///
+    /// It runs on this service's **image**, with this service's resolved env,
+    /// in its own pod. So it must reach the service **over the network**, by
+    /// the compose service name (`pg_dumpall -h db`, `mariadb-dump -h db`): a
+    /// tool left to its default connects to a unix socket that exists only
+    /// inside the service's own container, and fails there with a message
+    /// about a missing socket file. Addressing a service by name also means
+    /// that service must declare `ports:`, which is what gives it a DNS name.
     #[serde(default)]
     pub command: Option<Vec<String>>,
     /// Alternatively, raw tar of this named volume (append-only data only).

--- a/lnvps_operator/Cargo.toml
+++ b/lnvps_operator/Cargo.toml
@@ -35,3 +35,6 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 [dev-dependencies]
 wiremock = "0.6"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+# The uploader-script test stages a data directory and downloads the artifact
+# back to check it really is the archive it claims to be.
+tempfile = "3"

--- a/lnvps_operator/README.md
+++ b/lnvps_operator/README.md
@@ -196,9 +196,10 @@ environment wins when both are set.
 
 It reads nostr domains, apps, app clusters, app deployments and the
 subscription rows that decide whether a deployment is paid for, and it writes
-to three: the status and usage totals on `app_deployment`, and the per-service
-and per-volume usage breakdown, which it rewrites each pass rather than
-accumulating. It never runs migrations, so it needs no DDL:
+to four: the status and usage totals on `app_deployment`, the per-service and
+per-volume usage breakdown, which it rewrites each pass rather than
+accumulating, and `app_deployment_backup`, where it records the runs it starts
+and their outcome. It never runs migrations, so it needs no DDL:
 
 ```sql
 CREATE USER 'lnvps_operator'@'%' IDENTIFIED BY '<password>';
@@ -206,6 +207,9 @@ GRANT SELECT ON lnvps.* TO 'lnvps_operator'@'%';
 GRANT UPDATE ON lnvps.app_deployment TO 'lnvps_operator'@'%';
 GRANT INSERT, DELETE ON lnvps.app_deployment_service_usage TO 'lnvps_operator'@'%';
 GRANT INSERT, DELETE ON lnvps.app_deployment_volume_usage TO 'lnvps_operator'@'%';
+-- Backups: the operator inserts scheduled runs, updates their state, and marks
+-- pruned ones deleted. Rows are soft-deleted, so no DELETE is needed.
+GRANT INSERT, UPDATE ON lnvps.app_deployment_backup TO 'lnvps_operator'@'%';
 ```
 
 ```bash

--- a/lnvps_operator/config.yaml
+++ b/lnvps_operator/config.yaml
@@ -61,6 +61,40 @@ prometheus:
   # best-effort and must not hold up a reconcile pass.
   timeout-seconds: 10
 
+# --- App deployment backups -------------------------------------------------
+# Where backup artifacts are stored (optional). Omit the whole block to disable
+# backups: nothing is scheduled and nothing runs, which is how the operator
+# behaved before backups existed. An app opts in with a `backup:` schedule in
+# its catalog compose; the operator signs a one-key, one-method upload URL per
+# run, so the pod that captures the data never holds a bucket credential.
+backups:
+  endpoint: "https://s3.example.com"
+  # Signing region. S3-compatible services without regions still sign with one
+  # (optional, defaults to "us-east-1").
+  region: "eu-central-1"
+  bucket: "lnvps-app-backups"
+  # Credentials (optional here). Prefer the LNVPS_BACKUP_ACCESS_KEY and
+  # LNVPS_BACKUP_SECRET_KEY environment variables, which override these: this
+  # file usually lives in a ConfigMap, which is no place for a bucket key.
+  access-key: "example-access-key"
+  secret-key: "example-secret-key"
+  # Address the bucket as a path rather than a subdomain (optional, defaults to
+  # true, which is what self-hosted MinIO/Garage accept without wildcard DNS).
+  path-style: true
+  # Image that tars, compresses and uploads (optional). A stock curl image,
+  # whose busybox userland has tar and gzip. Override to pin by digest or to
+  # point at an internal mirror.
+  uploader-image: "curlimages/curl:8.11.1"
+  # How long a signed upload URL is valid, in hours (optional, defaults to 6).
+  upload-url-expiry-hours: 6
+  # How long a backup Job may run, in hours (optional, defaults to 5). Capped
+  # at the URL's life, so a Job cannot outlive the URL it was given.
+  job-deadline-hours: 5
+  # How many backup Jobs may run at once on this cluster (optional, defaults to
+  # 3). Every app on the same daily schedule comes due in the same minute, and
+  # each Job reads a whole volume on a node that is also serving apps.
+  max-concurrent: 2
+
 # Namespace the ingress controller runs in (optional, defaults to
 # "ingress-nginx"). The per-deployment isolation NetworkPolicy allows inbound
 # traffic from this namespace; it must match that namespace's

--- a/lnvps_operator/k8s-minimal.yaml
+++ b/lnvps_operator/k8s-minimal.yaml
@@ -73,7 +73,14 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "create", "patch"]
+  # `delete` removes a finished backup's upload URL, so a leaked one stops
+  # being useful as soon as the run it belonged to is over.
+  verbs: ["get", "create", "patch", "delete"]
+# Backup Jobs live and die inside the deployment's own namespace: created to
+# capture an artifact, read once to learn the outcome, then removed.
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "create", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -110,6 +117,17 @@ data:
     ingress-namespace: "ingress-nginx"
     # Encryption key: supplied via the LNVPS_ENCRYPTION_KEY env var below (must
     # match the API's key) so the operator can decrypt app_deployment.config.
+    # --- Backups (omit the whole block to disable them) ---
+    # backups:
+    #   endpoint: "https://s3.example.com"
+    #   region: "eu-central-1"
+    #   bucket: "lnvps-app-backups"
+    #   access-key: "..."
+    #   secret-key: "..."
+    #   # Override to pin the uploader by digest or point at an internal mirror.
+    #   # uploader-image: "curlimages/curl:8.11.1"
+    #   # upload-url-expiry-hours: 6
+    #   # job-deadline-hours: 5
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/lnvps_operator/src/app_backups.rs
+++ b/lnvps_operator/src/app_backups.rs
@@ -1135,6 +1135,124 @@ mod tests {
         assert!(startable(&queue, 0).is_empty());
     }
 
+    /// The uploader's script, run for real: the exact command line the Job
+    /// gives the uploader image, in that image, against a real S3 server.
+    ///
+    /// The builder tests assert what the script *says*. They cannot catch a
+    /// `tar` flag busybox does not take, a `curl` invocation that sends chunked
+    /// transfer encoding (which S3 rejects on a presigned `PUT`), or a URL the
+    /// server will not accept -- each of which is a backup that silently never
+    /// existed until a customer asked to restore one.
+    ///
+    /// Runs against the `rustfs` service in `docker-compose.e2e.yaml`; skipped
+    /// when the e2e stack is not up.
+    #[tokio::test]
+    async fn the_uploader_script_really_uploads() {
+        let Some(store) = test_store() else {
+            eprintln!("skipping: LNVPS_TEST_S3_ENDPOINT / _ACCESS_KEY / _SECRET_KEY not set");
+            return;
+        };
+        if !docker_available() {
+            eprintln!("skipping: docker is not available");
+            return;
+        }
+        store.create_bucket().await.expect("create bucket");
+
+        // A volume backup's data, as the PVC would present it.
+        let data = tempfile::tempdir().expect("tempdir");
+        std::fs::write(data.path().join("blob.bin"), vec![7u8; 4096]).unwrap();
+        std::fs::create_dir(data.path().join("nested")).unwrap();
+        std::fs::write(data.path().join("nested/inner.txt"), b"inner").unwrap();
+
+        let c = compose();
+        let env = BTreeMap::new();
+        let artifact = "blobs-files.tar.gz";
+        let job = build_backup_job(&spec(&c, "blobs", &env, artifact)).unwrap();
+        let script = job.spec.unwrap().template.spec.unwrap().containers[0]
+            .command
+            .as_ref()
+            .unwrap()[2]
+            .clone();
+
+        let key = backup_object_key(12, "run-live", artifact);
+        let url = store
+            .presign_put(&key, std::time::Duration::from_secs(300))
+            .unwrap();
+
+        // `--network host` so the container reaches the rustfs published on the
+        // host; the data mount is read-only exactly as the Job mounts the PVC,
+        // and /work is the emptyDir the Job stages into.
+        let out = std::process::Command::new("docker")
+            .args(["run", "--rm", "--network", "host"])
+            .arg("-v")
+            .arg(format!("{}:{DATA_DIR}:ro", data.path().display()))
+            .args(["--tmpfs", WORK_DIR])
+            .arg("-e")
+            .arg(format!("{UPLOAD_URL_ENV}={url}"))
+            .arg(DEFAULT_UPLOADER_IMAGE)
+            .args(["/bin/sh", "-c", &script])
+            .output()
+            .expect("run the uploader");
+        assert!(
+            out.status.success(),
+            "uploader failed: {}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // The artifact is in the bucket, and it is the archive it claims to be.
+        let size = store.size(&key).await.expect("head").expect("no artifact");
+        assert!(size > 0, "an empty artifact is not a backup");
+
+        let get = store
+            .presign_get(&key, std::time::Duration::from_secs(300), Some(artifact))
+            .unwrap();
+        let body = reqwest::get(&get)
+            .await
+            .expect("download")
+            .bytes()
+            .await
+            .expect("body");
+        let listing = tempfile::tempdir().unwrap();
+        let tarball = listing.path().join(artifact);
+        std::fs::write(&tarball, &body).unwrap();
+        let listed = std::process::Command::new("tar")
+            .arg("-tzf")
+            .arg(&tarball)
+            .output()
+            .expect("list the archive");
+        assert!(
+            listed.status.success(),
+            "the artifact is not a valid tar.gz"
+        );
+        let names = String::from_utf8_lossy(&listed.stdout);
+        assert!(names.contains("blob.bin"), "{names}");
+        assert!(names.contains("nested/inner.txt"), "{names}");
+
+        store.delete(&key).await.expect("cleanup");
+    }
+
+    fn test_store() -> Option<ObjectStore> {
+        ObjectStore::new(lnvps_api_common::ObjectStoreConfig {
+            endpoint: std::env::var("LNVPS_TEST_S3_ENDPOINT").ok()?,
+            region: "us-east-1".to_string(),
+            bucket: "lnvps-backup-uploader-test".to_string(),
+            access_key: std::env::var("LNVPS_TEST_S3_ACCESS_KEY").ok()?,
+            secret_key: std::env::var("LNVPS_TEST_S3_SECRET_KEY").ok()?,
+            path_style: true,
+        })
+        .ok()
+    }
+
+    fn docker_available() -> bool {
+        std::process::Command::new("docker")
+            .arg("info")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+    }
+
     /// A failure message is stored in a bounded column, so a Job condition with
     /// a wall of text cannot fail the write that records the failure.
     #[test]

--- a/lnvps_operator/src/app_backups.rs
+++ b/lnvps_operator/src/app_backups.rs
@@ -1,0 +1,1147 @@
+//! Capture app-deployment backups as Kubernetes Jobs
+//! (`work/app-deployments.md` increment 6).
+//!
+//! A **run** covers one deployment at one point in time; every compose service
+//! that declares a `backup:` method contributes one artifact, and each artifact
+//! is one Job and one uploaded object. Two services back up with different
+//! images and different volumes, so they cannot share a pod.
+//!
+//! Scheduling lives here rather than in a Kubernetes `CronJob` because a
+//! CronJob fires with nothing to write the run down in and no way to obtain an
+//! upload URL that has not expired. The operator evaluates the schedule, mints
+//! the row, signs a `PUT` for exactly that object, and hands the Job a URL that
+//! is good for one key and one method. A long-lived storage credential in the
+//! customer's namespace would be readable by the app's own containers, and a
+//! compromised app could then delete the backups that exist to survive it.
+//!
+//! The object **builders** are pure functions, unit-tested without a cluster;
+//! [`reconcile_app_backups`] is the loop that applies them.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use chrono::Utc;
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
+use k8s_openapi::api::core::v1::{
+    Affinity, Container, EmptyDirVolumeSource, EnvVar, EnvVarSource,
+    PersistentVolumeClaimVolumeSource, PodAffinity, PodAffinityTerm, PodSpec, PodTemplateSpec,
+    Secret, SecretKeySelector, Volume as K8sVolume, VolumeMount,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use kube::api::{Api, DeleteParams, PropagationPolicy};
+use log::{debug, error, info, warn};
+use uuid::Uuid;
+
+use lnvps_api_common::ObjectStore;
+use lnvps_api_common::k8s_names::{deployment_namespace as namespace_name, deployment_volume};
+use lnvps_compose::{Backup, Compose, Service as ComposeService, parse_bytes};
+use lnvps_db::{AppBackupMethod, AppBackupState, AppDeployment, AppDeploymentBackup, LNVpsDb};
+
+use crate::Context;
+use crate::app_deployments::{
+    GateReason, IMAGE_PULL_POLICY, apply, container_security_context_for, gate_running, labels,
+    pod_security_context_for, resolved_env, service_labels,
+};
+
+/// Where the artifact is staged inside the Job's pod before it is uploaded.
+///
+/// It is staged rather than streamed because a presigned `PUT` needs a
+/// `Content-Length`: piping `tar` straight into `curl` forces chunked transfer
+/// encoding, which S3 rejects.
+const WORK_DIR: &str = "/work";
+const WORK_VOLUME: &str = "work";
+
+/// Where a `volume:` backup mounts the customer's data, always read-only.
+const DATA_DIR: &str = "/data";
+const DATA_VOLUME: &str = "data";
+
+/// Env var carrying the presigned upload URL into the uploader container.
+///
+/// It arrives as an env var from a Secret, not as a command-line argument: an
+/// argument is visible in `ps` to everything else in the pod.
+const UPLOAD_URL_ENV: &str = "LNVPS_UPLOAD_URL";
+const UPLOAD_URL_KEY: &str = "url";
+
+/// Image that tars, compresses and uploads. A stock `curl` image, whose busybox
+/// userland already provides `tar` and `gzip`, so this increment ships without
+/// building and publishing an image of our own.
+pub const DEFAULT_UPLOADER_IMAGE: &str = "curlimages/curl:8.11.1";
+
+/// How long a signed upload URL stays valid. Long enough to cover a queued Job
+/// and a slow dump of a large volume, short enough that a leaked URL is not a
+/// standing grant.
+pub const DEFAULT_UPLOAD_URL_HOURS: u64 = 6;
+
+/// How long a backup Job may run before Kubernetes kills it. Kept under the
+/// URL's life, so a Job cannot still be running when its upload URL expires and
+/// then fail with a signature error that reads as a storage fault.
+pub const DEFAULT_JOB_DEADLINE_HOURS: u64 = 5;
+
+/// How many backup Jobs may be in flight per cluster at once.
+pub const DEFAULT_MAX_CONCURRENT_BACKUPS: usize = 3;
+
+/// Staging space for a service whose dump size cannot be inferred from its
+/// volumes.
+const DEFAULT_WORK_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Kubernetes object name for a backup's Job.
+pub fn backup_job_name(backup_id: u64) -> String {
+    format!("backup-{backup_id}")
+}
+
+/// Kubernetes object name for the Secret holding a backup's upload URL.
+pub fn backup_url_secret_name(backup_id: u64) -> String {
+    format!("backup-{backup_id}-url")
+}
+
+/// Storage key for one artifact.
+///
+/// Entirely server-derived: the deployment id, the run's UUID and the artifact
+/// filename the catalog declared. No part of it comes from a request, so a
+/// customer cannot address another customer's object by naming one.
+pub fn backup_object_key(deployment_id: u64, run_id: &str, artifact: &str) -> String {
+    format!("deployments/{deployment_id}/{run_id}/{artifact}")
+}
+
+/// Filename for a service's artifact, including the compression suffix.
+///
+/// The catalog may name the payload (`route96.sql`); the suffix is ours,
+/// because what the suffix describes is how this code compressed it.
+pub fn artifact_name(service: &str, backup: &Backup) -> String {
+    match (&backup.command, &backup.volume) {
+        (Some(_), _) => format!(
+            "{}.gz",
+            backup
+                .artifact
+                .clone()
+                .unwrap_or_else(|| format!("{service}.dump"))
+        ),
+        (_, Some(volume)) => format!(
+            "{}.tar.gz",
+            backup
+                .artifact
+                .clone()
+                .unwrap_or_else(|| format!("{service}-{volume}"))
+        ),
+        // Unreachable for a validated compose, which requires exactly one.
+        _ => format!("{service}.gz"),
+    }
+}
+
+/// Which of the two capture methods a service's `backup:` selects.
+pub fn backup_method(backup: &Backup) -> AppBackupMethod {
+    if backup.volume.is_some() {
+        AppBackupMethod::Volume
+    } else {
+        AppBackupMethod::Command
+    }
+}
+
+/// The Secret carrying one backup's upload URL into its Job.
+pub fn build_url_secret(deployment_id: u64, backup_id: u64, url: &str) -> Secret {
+    Secret {
+        metadata: ObjectMeta {
+            name: Some(backup_url_secret_name(backup_id)),
+            namespace: Some(namespace_name(deployment_id)),
+            labels: Some(labels(deployment_id)),
+            ..Default::default()
+        },
+        string_data: Some(BTreeMap::from([(
+            UPLOAD_URL_KEY.to_string(),
+            url.to_string(),
+        )])),
+        ..Default::default()
+    }
+}
+
+/// Everything one backup Job needs, gathered by the caller that already has it.
+pub struct BackupJobSpec<'a> {
+    pub deployment_id: u64,
+    pub backup_id: u64,
+    pub service_name: &'a str,
+    pub service: &'a ComposeService,
+    pub backup: &'a Backup,
+    /// The service's resolved env, so a dump command can authenticate with the
+    /// same generated password the running service uses.
+    pub env: &'a BTreeMap<String, String>,
+    pub artifact: &'a str,
+    pub uploader_image: &'a str,
+    /// Size multiplier of the deployment, applied to staging space the same way
+    /// it is applied to the volumes being captured.
+    pub multiplier: u32,
+    pub deadline: Duration,
+}
+
+/// The Job that captures one artifact and uploads it.
+///
+/// A `volume:` backup is one container: tar the read-only mount and upload it.
+/// A `command:` backup is two: the dump runs in an init container on the
+/// **app's own image** (only that image has `pg_dumpall` or `mariadb-dump`),
+/// writing to a shared `emptyDir`, and the uploader — which is the only image
+/// here with an HTTP client — compresses and sends it.
+pub fn build_backup_job(spec: &BackupJobSpec) -> Result<Job> {
+    let mut sel = labels(spec.deployment_id);
+    sel.insert("lnvps.io/backup".to_string(), spec.backup_id.to_string());
+
+    let work_size = staging_size(spec.service, spec.multiplier);
+    let mut volumes = vec![K8sVolume {
+        name: WORK_VOLUME.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource {
+            size_limit: Some(Quantity(format!("{work_size}"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }];
+    let work_mount = VolumeMount {
+        name: WORK_VOLUME.to_string(),
+        mount_path: WORK_DIR.to_string(),
+        ..Default::default()
+    };
+
+    let mut init_containers: Vec<Container> = Vec::new();
+    let mut upload_mounts = vec![work_mount.clone()];
+    let mut affinity = None;
+
+    let script = match (&spec.backup.command, &spec.backup.volume) {
+        (Some(command), _) => {
+            if command.is_empty() {
+                return Err(anyhow!(
+                    "service '{}': backup command is empty",
+                    spec.service_name
+                ));
+            }
+            // The dump's payload name is the artifact without our `.gz`.
+            let payload = spec.artifact.trim_end_matches(".gz");
+            init_containers.push(Container {
+                name: "dump".to_string(),
+                image: Some(spec.service.image.clone()),
+                image_pull_policy: Some(IMAGE_PULL_POLICY.to_string()),
+                // The catalog's command is an argv; it is re-quoted into a
+                // shell so its stdout can be redirected to the staging file.
+                command: Some(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    format!("{} > {WORK_DIR}/{payload}", shell_join(command)),
+                ]),
+                env: Some(env_vars(spec.env)),
+                volume_mounts: Some(vec![work_mount.clone()]),
+                security_context: Some(container_security_context_for(
+                    !spec.service.runs_as_root(),
+                    spec.service.run_as_user(),
+                )),
+                ..Default::default()
+            });
+            format!(
+                "set -e; gzip -n {WORK_DIR}/{payload}; \
+                 curl -fsS --upload-file {WORK_DIR}/{} \"${UPLOAD_URL_ENV}\"",
+                spec.artifact
+            )
+        }
+        (_, Some(volume)) => {
+            let claim = deployment_volume(spec.service_name, volume);
+            volumes.push(K8sVolume {
+                name: DATA_VOLUME.to_string(),
+                persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                    claim_name: claim,
+                    // Read-only at the volume source as well as the mount: a
+                    // backup of a compromised app must not be able to write to
+                    // the data it is capturing.
+                    read_only: Some(true),
+                }),
+                ..Default::default()
+            });
+            upload_mounts.push(VolumeMount {
+                name: DATA_VOLUME.to_string(),
+                mount_path: DATA_DIR.to_string(),
+                read_only: Some(true),
+                ..Default::default()
+            });
+            // A ReadWriteOnce claim can only be mounted by pods on the node
+            // that already has it attached, so the Job is pinned to the app's
+            // node. Without this it schedules anywhere and sits in
+            // `Multi-Attach error` until the deadline kills it.
+            affinity = Some(Affinity {
+                pod_affinity: Some(PodAffinity {
+                    required_during_scheduling_ignored_during_execution: Some(vec![
+                        PodAffinityTerm {
+                            label_selector: Some(LabelSelector {
+                                match_labels: Some(service_labels(
+                                    spec.deployment_id,
+                                    spec.service_name,
+                                )),
+                                ..Default::default()
+                            }),
+                            topology_key: "kubernetes.io/hostname".to_string(),
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            format!(
+                "set -e; tar -czf {WORK_DIR}/{artifact} -C {DATA_DIR} .; \
+                 curl -fsS --upload-file {WORK_DIR}/{artifact} \"${UPLOAD_URL_ENV}\"",
+                artifact = spec.artifact
+            )
+        }
+        _ => {
+            return Err(anyhow!(
+                "service '{}': backup declares neither command nor volume",
+                spec.service_name
+            ));
+        }
+    };
+
+    let uploader = Container {
+        name: "upload".to_string(),
+        image: Some(spec.uploader_image.to_string()),
+        image_pull_policy: Some(IMAGE_PULL_POLICY.to_string()),
+        command: Some(vec!["/bin/sh".to_string(), "-c".to_string(), script]),
+        env: Some(vec![EnvVar {
+            name: UPLOAD_URL_ENV.to_string(),
+            value_from: Some(EnvVarSource {
+                secret_key_ref: Some(SecretKeySelector {
+                    name: backup_url_secret_name(spec.backup_id),
+                    key: UPLOAD_URL_KEY.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]),
+        volume_mounts: Some(upload_mounts),
+        // Runs as whoever owns the data: the files on a PVC belong to the uid
+        // the service writes them as, and a read-only mount gets no `fsGroup`
+        // remap, so any other uid would tar an unreadable tree.
+        security_context: Some(container_security_context_for(
+            !spec.service.runs_as_root(),
+            spec.service.run_as_user(),
+        )),
+        ..Default::default()
+    };
+
+    Ok(Job {
+        metadata: ObjectMeta {
+            name: Some(backup_job_name(spec.backup_id)),
+            namespace: Some(namespace_name(spec.deployment_id)),
+            labels: Some(sel.clone()),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            // One retry. A dump that failed on bad credentials fails again, and
+            // the second attempt would upload to the same key.
+            backoff_limit: Some(1),
+            active_deadline_seconds: Some(spec.deadline.as_secs() as i64),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(sel),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    containers: vec![uploader],
+                    init_containers: (!init_containers.is_empty()).then_some(init_containers),
+                    volumes: Some(volumes),
+                    affinity,
+                    restart_policy: Some("Never".to_string()),
+                    security_context: Some(pod_security_context_for(spec.service.run_as_user())),
+                    // Same rule as the app's own pods: nothing here talks to
+                    // the Kubernetes API, and withholding the token is enforced
+                    // by the kubelet whatever the CNI does with NetworkPolicy.
+                    automount_service_account_token: Some(false),
+                    enable_service_links: Some(false),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+}
+
+/// Staging space for the artifact: the service's own volumes, scaled the way
+/// they are, and doubled because a `command:` dump is written and then gzipped
+/// beside itself.
+fn staging_size(service: &ComposeService, multiplier: u32) -> u64 {
+    let declared: u64 = service
+        .volumes
+        .iter()
+        .filter_map(|v| parse_bytes(&v.size).ok())
+        .sum();
+    let base = if declared == 0 {
+        DEFAULT_WORK_SIZE_BYTES
+    } else {
+        declared
+    };
+    base.saturating_mul(multiplier.max(1) as u64)
+        .saturating_mul(2)
+}
+
+fn env_vars(env: &BTreeMap<String, String>) -> Vec<EnvVar> {
+    env.iter()
+        .map(|(k, v)| EnvVar {
+            name: k.clone(),
+            value: Some(v.clone()),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Re-quote an argv into a single shell word list, so it can be run by `sh -c`
+/// with its stdout redirected. Single quotes, with the usual `'\''` escape, so
+/// nothing in a catalog command is re-interpreted.
+fn shell_join(args: &[String]) -> String {
+    args.iter()
+        .map(|a| format!("'{}'", a.replace('\'', "'\\''")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Drive every backup on this operator's cluster one step: start what is
+/// pending, record what has finished, schedule what is due, prune what is past
+/// retention.
+///
+/// No-op unless the operator has both a cluster and object storage configured.
+/// Individual failures are logged and skipped rather than ending the pass: one
+/// deployment's broken backup must not stop every other deployment's.
+pub async fn reconcile_app_backups(ctx: &Context) -> Result<()> {
+    let (Some(cluster_id), Some(store)) = (ctx.settings.app_cluster_id, ctx.object_store.as_ref())
+    else {
+        return Ok(());
+    };
+    let cluster = ctx.db.get_app_cluster(cluster_id).await?;
+
+    if let Err(e) = schedule_due_backups(ctx, cluster_id).await {
+        warn!("backup scheduling failed: {e}");
+    }
+
+    let active = ctx
+        .db
+        .list_active_app_deployment_backups(cluster_id)
+        .await?;
+    let to_start = startable(&active, ctx.settings.max_concurrent_backups());
+    for backup in &active {
+        let id = backup.id;
+        let result = match backup.state {
+            AppBackupState::Pending if to_start.contains(&id) => {
+                start_backup(ctx, store, backup, &cluster.ingress_domain).await
+            }
+            // Waiting its turn. It keeps its place in the queue by staying
+            // pending, and starts on a later pass.
+            AppBackupState::Pending => continue,
+            _ => record_finished(ctx, store, backup).await,
+        };
+        if let Err(e) = result {
+            error!("backup {id} failed: {e}");
+            if let Err(e) = fail_backup(ctx, backup, &e.to_string()).await {
+                warn!("backup {id}: could not record the failure: {e}");
+            }
+        }
+    }
+
+    if let Err(e) = prune_backups(ctx, store, cluster_id).await {
+        warn!("backup retention pruning failed: {e}");
+    }
+    Ok(())
+}
+
+/// Which pending backups may start this pass, oldest first.
+///
+/// Every app on the same daily schedule comes due in the same minute, so
+/// without a cap one sweep would start a Job for every deployment on the
+/// cluster at once: each one tars a volume and pushes it at the bucket, on
+/// nodes that are also running the customers' apps. The queue is the `pending`
+/// rows themselves, so nothing is lost by making a run wait a sweep.
+fn startable(active: &[AppDeploymentBackup], limit: usize) -> Vec<u64> {
+    let running = active
+        .iter()
+        .filter(|b| b.state == AppBackupState::Running)
+        .count();
+    let budget = limit.saturating_sub(running);
+    active
+        .iter()
+        .filter(|b| b.state == AppBackupState::Pending)
+        .take(budget)
+        .map(|b| b.id)
+        .collect()
+}
+
+/// Create the rows for every deployment whose schedule has come due.
+///
+/// Rows only: the Job is created by the same path an on-demand backup takes, so
+/// there is one way a backup runs regardless of what asked for it.
+async fn schedule_due_backups(ctx: &Context, cluster_id: u64) -> Result<()> {
+    let now = Utc::now();
+    for deployment in ctx
+        .db
+        .list_all_app_deployments()
+        .await?
+        .into_iter()
+        .filter(|d| d.cluster_id == cluster_id)
+    {
+        if let Err(e) = schedule_one(ctx, &deployment, now).await {
+            warn!(
+                "app deployment {}: could not evaluate backup schedule: {e}",
+                deployment.id
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn schedule_one(
+    ctx: &Context,
+    deployment: &AppDeployment,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    let app = ctx.db.get_app(deployment.app_id).await?;
+    let compose = Compose::parse(&app.compose)?;
+    let Some(policy) = &compose.backup else {
+        return Ok(());
+    };
+
+    // Only a deployment that is actually meant to be running is backed up. An
+    // unpaid or expired one is not owed storage, and a deleted one is on its
+    // way out.
+    let sub = ctx
+        .db
+        .get_subscription_by_line_item_id(deployment.subscription_line_item_id)
+        .await
+        .ok();
+    let gate = gate_running(
+        deployment.desired_state == lnvps_db::AppDeploymentDesiredState::Running,
+        deployment.deleted,
+        sub.as_ref(),
+        None,
+        now,
+    );
+    if gate != GateReason::Running {
+        return Ok(());
+    }
+
+    // Never run before means "measure from when the deployment appeared", so a
+    // deployment created at 03:05 is not immediately backed up by an 03:00
+    // schedule.
+    let since = ctx
+        .db
+        .last_scheduled_app_deployment_backup(deployment.id)
+        .await?
+        .unwrap_or(deployment.created);
+    if !policy.is_due(since, now)? {
+        return Ok(());
+    }
+
+    let run_id = Uuid::new_v4().to_string();
+    for (service, backup) in compose.backup_services() {
+        let row = AppDeploymentBackup {
+            id: 0,
+            deployment_id: deployment.id,
+            run_id: run_id.clone(),
+            service: service.to_string(),
+            method: backup_method(backup),
+            artifact: artifact_name(service, backup),
+            object_key: None,
+            size_bytes: None,
+            state: AppBackupState::Pending,
+            message: None,
+            scheduled: true,
+            created: now,
+            started: None,
+            completed: None,
+            deleted: false,
+        };
+        ctx.db.insert_app_deployment_backup(&row).await?;
+    }
+    info!(
+        "app deployment {}: scheduled backup run {run_id}",
+        deployment.id
+    );
+    Ok(())
+}
+
+/// Sign an upload URL and create the Job that fills it.
+async fn start_backup(
+    ctx: &Context,
+    store: &ObjectStore,
+    backup: &AppDeploymentBackup,
+    ingress_domain: &str,
+) -> Result<()> {
+    let deployment = ctx.db.get_app_deployment(backup.deployment_id).await?;
+    let app = ctx.db.get_app(deployment.app_id).await?;
+    let compose = Compose::parse(&app.compose)?;
+    let service = compose
+        .services
+        .get(&backup.service)
+        .ok_or_else(|| anyhow!("service '{}' is not in the app's compose", backup.service))?;
+    let method = service
+        .backup
+        .as_ref()
+        .ok_or_else(|| anyhow!("service '{}' declares no backup method", backup.service))?;
+
+    let key = backup_object_key(deployment.id, &backup.run_id, &backup.artifact);
+    let url = store.presign_put(&key, ctx.settings.backup_url_expiry())?;
+    apply(
+        &ctx.client,
+        &build_url_secret(deployment.id, backup.id, &url),
+    )
+    .await?;
+
+    let env = resolved_env(ctx, &deployment, &compose, ingress_domain).await?;
+    let job = build_backup_job(&BackupJobSpec {
+        deployment_id: deployment.id,
+        backup_id: backup.id,
+        service_name: &backup.service,
+        service,
+        backup: method,
+        env: &env
+            .get(&backup.service)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+        artifact: &backup.artifact,
+        uploader_image: ctx.settings.backup_uploader_image(),
+        multiplier: deployment.resource_multiplier,
+        deadline: ctx.settings.backup_job_deadline(),
+    })?;
+    apply(&ctx.client, &job).await?;
+
+    let mut row = backup.clone();
+    row.object_key = Some(key);
+    row.state = AppBackupState::Running;
+    row.started = Some(Utc::now());
+    ctx.db.update_app_deployment_backup(&row).await?;
+    info!(
+        "backup {} started for deployment {} service {}",
+        backup.id, deployment.id, backup.service
+    );
+    Ok(())
+}
+
+/// Read a running backup's Job and record the outcome, if it has one.
+async fn record_finished(
+    ctx: &Context,
+    store: &ObjectStore,
+    backup: &AppDeploymentBackup,
+) -> Result<()> {
+    let api: Api<Job> = Api::namespaced(ctx.client.clone(), &namespace_name(backup.deployment_id));
+    let Some(job) = api.get_opt(&backup_job_name(backup.id)).await? else {
+        // The Job is gone without this row ever seeing it succeed. Something
+        // outside the operator removed it; the artifact cannot be trusted to
+        // exist, and leaving the row Running would retry nothing forever.
+        return fail_backup(ctx, backup, "the backup job disappeared before it finished").await;
+    };
+    let status = job.status.clone().unwrap_or_default();
+    if status.succeeded.unwrap_or(0) > 0 {
+        let key = backup
+            .object_key
+            .clone()
+            .ok_or_else(|| anyhow!("a completed backup has no object key"))?;
+        let size = store.size(&key).await?;
+        let mut row = backup.clone();
+        row.state = AppBackupState::Completed;
+        row.completed = Some(Utc::now());
+        row.size_bytes = size;
+        // A Job that reported success with nothing in the bucket is a failure
+        // that would otherwise be offered to the customer as a restore point.
+        if size.is_none() {
+            row.state = AppBackupState::Failed;
+            row.message = Some("the job finished but uploaded no artifact".to_string());
+        }
+        ctx.db.update_app_deployment_backup(&row).await?;
+        cleanup_job(ctx, backup).await;
+        info!("backup {} completed ({:?} bytes)", backup.id, size);
+        return Ok(());
+    }
+    if status.failed.unwrap_or(0) > 0 {
+        let reason = status
+            .conditions
+            .unwrap_or_default()
+            .into_iter()
+            .find(|c| c.type_ == "Failed")
+            .and_then(|c| c.message.or(c.reason))
+            .unwrap_or_else(|| "the backup job failed".to_string());
+        return fail_backup(ctx, backup, &reason).await;
+    }
+    debug!("backup {} still running", backup.id);
+    Ok(())
+}
+
+/// Mark a backup failed and clear up after it.
+async fn fail_backup(ctx: &Context, backup: &AppDeploymentBackup, message: &str) -> Result<()> {
+    let mut row = backup.clone();
+    row.state = AppBackupState::Failed;
+    row.completed = Some(Utc::now());
+    row.message = Some(truncate(message, 500));
+    ctx.db.update_app_deployment_backup(&row).await?;
+    cleanup_job(ctx, backup).await;
+    warn!("backup {} failed: {message}", backup.id);
+    Ok(())
+}
+
+/// Remove a finished backup's Job and its upload URL, so a leaked URL stops
+/// being useful the moment the run it belonged to is over.
+async fn cleanup_job(ctx: &Context, backup: &AppDeploymentBackup) {
+    let ns = namespace_name(backup.deployment_id);
+    let jobs: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
+    // Background propagation, or the Job's pod outlives it.
+    let params = DeleteParams {
+        propagation_policy: Some(PropagationPolicy::Background),
+        ..Default::default()
+    };
+    if let Err(e) = jobs.delete(&backup_job_name(backup.id), &params).await {
+        debug!("backup {}: job cleanup: {e}", backup.id);
+    }
+    let secrets: Api<Secret> = Api::namespaced(ctx.client.clone(), &ns);
+    if let Err(e) = secrets
+        .delete(&backup_url_secret_name(backup.id), &DeleteParams::default())
+        .await
+    {
+        debug!("backup {}: url secret cleanup: {e}", backup.id);
+    }
+}
+
+/// Drop runs past the app's retention, oldest first.
+///
+/// Retention counts **runs**, not artifacts: a two-service app keeps two
+/// objects per run, and a customer reading "keep 7" means seven restore points.
+async fn prune_backups(ctx: &Context, store: &ObjectStore, cluster_id: u64) -> Result<()> {
+    for deployment in ctx
+        .db
+        .list_all_app_deployments()
+        .await?
+        .into_iter()
+        .filter(|d| d.cluster_id == cluster_id)
+    {
+        let Ok(app) = ctx.db.get_app(deployment.app_id).await else {
+            continue;
+        };
+        let retention = match Compose::parse(&app.compose) {
+            Ok(c) => c.backup.as_ref().map(|p| p.retention_or_default()),
+            Err(_) => None,
+        };
+        let Some(retention) = retention else {
+            continue;
+        };
+
+        let rows = ctx.db.list_app_deployment_backups(deployment.id).await?;
+        for row in rows_past_retention(&rows, retention) {
+            if let Some(key) = &row.object_key
+                && let Err(e) = store.delete(key).await
+            {
+                // Leave the row alone: a key whose object could not be deleted
+                // has to stay visible, or the object is orphaned in the bucket
+                // with nothing pointing at it.
+                warn!("backup {}: could not delete '{key}': {e}", row.id);
+                continue;
+            }
+            ctx.db.delete_app_deployment_backup(row.id).await?;
+            info!("backup {} pruned (retention {retention})", row.id);
+        }
+    }
+    Ok(())
+}
+
+/// The rows belonging to runs older than the newest `retention` **finished**
+/// runs. Rows are newest-first, as the listing returns them.
+///
+/// Runs still in flight are never counted or pruned: an in-progress run is not
+/// yet a restore point, and counting it would drop an older one that is.
+fn rows_past_retention(rows: &[AppDeploymentBackup], retention: u32) -> Vec<&AppDeploymentBackup> {
+    let mut seen: Vec<&str> = Vec::new();
+    let mut out = Vec::new();
+    for row in rows {
+        if matches!(row.state, AppBackupState::Pending | AppBackupState::Running) {
+            continue;
+        }
+        if !seen.iter().any(|r| *r == row.run_id) {
+            seen.push(&row.run_id);
+        }
+        let position = seen.iter().position(|r| *r == row.run_id).unwrap_or(0);
+        if position >= retention as usize {
+            out.push(row);
+        }
+    }
+    out
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_string();
+    }
+    value.chars().take(max).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lnvps_compose::Compose;
+
+    fn compose() -> Compose {
+        Compose::parse(
+            "services:\n  \
+               db:\n    \
+                 image: mariadb:11\n    \
+                 user: root\n    \
+                 ports:\n      - { name: mysql, container: 3306, protocol: tcp, expose: none }\n    \
+                 env:\n      MARIADB_ROOT_PASSWORD: pw\n    \
+                 volumes:\n      - { name: data, path: /var/lib/mysql, size: 5Gi }\n    \
+                 backup:\n      \
+                   command: [\"sh\", \"-c\", \"exec mariadb-dump -h db -uroot -p$MARIADB_ROOT_PASSWORD\"]\n      \
+                   artifact: route96.sql\n  \
+               blobs:\n    \
+                 image: example/blobs:1\n    \
+                 user: \"1000\"\n    \
+                 volumes:\n      - { name: files, path: /app/data, size: 20Gi }\n    \
+                 backup:\n      volume: files\n\
+             backup: { schedule: \"0 3 * * *\", retention: 3 }\n",
+        )
+        .unwrap()
+    }
+
+    fn spec<'a>(
+        c: &'a Compose,
+        service: &'a str,
+        env: &'a BTreeMap<String, String>,
+        artifact: &'a str,
+    ) -> BackupJobSpec<'a> {
+        let svc = c.services.get(service).unwrap();
+        BackupJobSpec {
+            deployment_id: 12,
+            backup_id: 77,
+            service_name: service,
+            service: svc,
+            backup: svc.backup.as_ref().unwrap(),
+            env,
+            artifact,
+            uploader_image: DEFAULT_UPLOADER_IMAGE,
+            multiplier: 1,
+            deadline: Duration::from_secs(3600),
+        }
+    }
+
+    /// A `command:` backup runs the dump on the app's own image -- only that
+    /// image has the dump tool -- and hands the file to the one container here
+    /// that has an HTTP client.
+    #[test]
+    fn command_backup_dumps_on_the_app_image_and_uploads_separately() {
+        let c = compose();
+        let env = BTreeMap::from([("MARIADB_ROOT_PASSWORD".to_string(), "hunter2".to_string())]);
+        let job = build_backup_job(&spec(&c, "db", &env, "route96.sql.gz")).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+
+        let init = &pod.init_containers.as_ref().unwrap()[0];
+        assert_eq!(init.image.as_deref(), Some("mariadb:11"));
+        let script = init.command.as_ref().unwrap()[2].clone();
+        // The catalog's argv is re-quoted, not re-parsed, and its stdout is
+        // redirected to the staging file.
+        assert!(script.contains("'sh' '-c' 'exec mariadb-dump"), "{script}");
+        assert!(script.ends_with("> /work/route96.sql"), "{script}");
+        // The dump authenticates with the service's own resolved env.
+        let vars = init.env.as_ref().unwrap();
+        assert_eq!(
+            vars.iter()
+                .find(|e| e.name == "MARIADB_ROOT_PASSWORD")
+                .and_then(|e| e.value.clone()),
+            Some("hunter2".to_string())
+        );
+
+        let upload = &pod.containers[0];
+        assert_eq!(upload.image.as_deref(), Some(DEFAULT_UPLOADER_IMAGE));
+        let script = upload.command.as_ref().unwrap()[2].clone();
+        assert!(script.contains("gzip -n /work/route96.sql"), "{script}");
+        assert!(
+            script.contains("--upload-file /work/route96.sql.gz \"$LNVPS_UPLOAD_URL\""),
+            "{script}"
+        );
+        // No data volume is mounted: a dump reads through the service, not off
+        // the disk.
+        assert!(
+            !pod.volumes
+                .unwrap()
+                .iter()
+                .any(|v| v.persistent_volume_claim.is_some())
+        );
+        assert!(pod.affinity.is_none());
+    }
+
+    /// A `volume:` backup mounts the customer's data read-only, and is pinned
+    /// to the node already holding the claim.
+    #[test]
+    fn volume_backup_mounts_read_only_and_follows_the_claim() {
+        let c = compose();
+        let env = BTreeMap::new();
+        let job = build_backup_job(&spec(&c, "blobs", &env, "blobs-files.tar.gz")).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        assert!(pod.init_containers.is_none(), "nothing to dump");
+
+        let claim = pod
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| v.persistent_volume_claim.is_some())
+            .unwrap();
+        let pvc = claim.persistent_volume_claim.as_ref().unwrap();
+        assert_eq!(pvc.claim_name, "blobs-files");
+        assert_eq!(pvc.read_only, Some(true), "the source is never writable");
+
+        let mount = pod.containers[0]
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|m| m.name == DATA_VOLUME)
+            .unwrap();
+        assert_eq!(mount.read_only, Some(true));
+
+        let script = pod.containers[0].command.as_ref().unwrap()[2].clone();
+        assert!(
+            script.contains("tar -czf /work/blobs-files.tar.gz -C /data ."),
+            "{script}"
+        );
+
+        // ReadWriteOnce: the pod has to land on the node holding the claim.
+        let affinity = pod
+            .affinity
+            .unwrap()
+            .pod_affinity
+            .unwrap()
+            .required_during_scheduling_ignored_during_execution
+            .unwrap();
+        assert_eq!(affinity[0].topology_key, "kubernetes.io/hostname");
+        assert_eq!(
+            affinity[0]
+                .label_selector
+                .as_ref()
+                .unwrap()
+                .match_labels
+                .as_ref()
+                .unwrap(),
+            &service_labels(12, "blobs")
+        );
+    }
+
+    /// The upload URL is a credential: it arrives through a Secret rather than
+    /// on a command line, where every other process in the pod could read it.
+    #[test]
+    fn the_upload_url_never_reaches_a_command_line() {
+        let c = compose();
+        let env = BTreeMap::new();
+        let job = build_backup_job(&spec(&c, "blobs", &env, "a.tar.gz")).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        let container = &pod.containers[0];
+
+        let source = container.env.as_ref().unwrap()[0]
+            .value_from
+            .as_ref()
+            .unwrap()
+            .secret_key_ref
+            .as_ref()
+            .unwrap()
+            .clone();
+        assert_eq!(source.name, "backup-77-url");
+        assert_eq!(source.key, UPLOAD_URL_KEY);
+        assert!(container.env.as_ref().unwrap()[0].value.is_none());
+        assert!(
+            container.command.as_ref().unwrap()[2].contains("\"$LNVPS_UPLOAD_URL\""),
+            "the URL is dereferenced from the environment, not interpolated"
+        );
+
+        let secret = build_url_secret(12, 77, "https://s3.example.com/put?sig=abc");
+        assert_eq!(secret.metadata.name.as_deref(), Some("backup-77-url"));
+        assert_eq!(secret.metadata.namespace.as_deref(), Some("app-12"));
+    }
+
+    /// The Job is hardened like the app's own pods, and cannot outlive its
+    /// upload URL.
+    #[test]
+    fn backup_pods_are_hardened_and_bounded() {
+        let c = compose();
+        let env = BTreeMap::new();
+        let job = build_backup_job(&spec(&c, "blobs", &env, "a.tar.gz")).unwrap();
+        let spec_ = job.spec.unwrap();
+        assert_eq!(spec_.backoff_limit, Some(1));
+        assert_eq!(spec_.active_deadline_seconds, Some(3600));
+
+        let pod = spec_.template.spec.unwrap();
+        assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
+        assert_eq!(pod.automount_service_account_token, Some(false));
+        assert_eq!(pod.enable_service_links, Some(false));
+
+        let sc = pod.containers[0].security_context.as_ref().unwrap();
+        assert_eq!(sc.allow_privilege_escalation, Some(false));
+        assert_eq!(sc.read_only_root_filesystem, Some(true));
+        // Reads a read-only mount, which gets no fsGroup remap, so it has to be
+        // the uid that wrote the files.
+        assert_eq!(sc.run_as_user, Some(1000));
+    }
+
+    /// Staging space is sized from the data being captured, and scales with the
+    /// deployment, or a large app's dump fills the node and is evicted.
+    #[test]
+    fn staging_space_follows_the_data() {
+        let c = compose();
+        let db = c.services.get("db").unwrap();
+        // 5Gi of database, written then gzipped beside itself.
+        assert_eq!(staging_size(db, 1), 5 * 1024 * 1024 * 1024 * 2);
+        assert_eq!(staging_size(db, 4), 5 * 1024 * 1024 * 1024 * 8);
+
+        let no_volumes = Compose::parse("services:\n  a:\n    image: x\n").unwrap();
+        assert_eq!(
+            staging_size(no_volumes.services.get("a").unwrap(), 1),
+            DEFAULT_WORK_SIZE_BYTES * 2
+        );
+    }
+
+    /// Artifact names carry the catalog's payload name and our compression
+    /// suffix, and the object key is entirely server-derived.
+    #[test]
+    fn artifact_and_key_naming() {
+        let c = compose();
+        let db = c.services.get("db").unwrap().backup.as_ref().unwrap();
+        let blobs = c.services.get("blobs").unwrap().backup.as_ref().unwrap();
+        assert_eq!(artifact_name("db", db), "route96.sql.gz");
+        assert_eq!(artifact_name("blobs", blobs), "blobs-files.tar.gz");
+        assert_eq!(backup_method(db), AppBackupMethod::Command);
+        assert_eq!(backup_method(blobs), AppBackupMethod::Volume);
+
+        // An undeclared artifact name falls back to the service and volume.
+        let bare =
+            Compose::parse("services:\n  a:\n    image: x\n    backup: { command: [\"sh\"] }\n")
+                .unwrap();
+        assert_eq!(
+            artifact_name(
+                "a",
+                bare.services.get("a").unwrap().backup.as_ref().unwrap()
+            ),
+            "a.dump.gz"
+        );
+
+        assert_eq!(
+            backup_object_key(12, "run-abc", "route96.sql.gz"),
+            "deployments/12/run-abc/route96.sql.gz"
+        );
+    }
+
+    /// A catalog command is quoted, never re-parsed, so an argument containing
+    /// a quote or a shell metacharacter cannot escape into the redirect.
+    #[test]
+    fn command_arguments_cannot_escape_the_shell() {
+        assert_eq!(shell_join(&["a".into(), "b c".into()]), "'a' 'b c'");
+        assert_eq!(
+            shell_join(&["it's".into(), "x; rm -rf /".into()]),
+            r#"'it'\''s' 'x; rm -rf /'"#
+        );
+    }
+
+    /// Retention counts runs, keeps the newest, and never counts a run that is
+    /// still in flight -- doing so would drop a finished restore point in
+    /// favour of one that does not exist yet.
+    #[test]
+    fn retention_counts_finished_runs_newest_first() {
+        let row = |id: u64, run: &str, state: AppBackupState| AppDeploymentBackup {
+            id,
+            deployment_id: 1,
+            run_id: run.to_string(),
+            service: format!("s{id}"),
+            method: AppBackupMethod::Volume,
+            artifact: "a.tar.gz".to_string(),
+            object_key: Some(format!("deployments/1/{run}/a.tar.gz")),
+            size_bytes: Some(1),
+            state,
+            message: None,
+            scheduled: true,
+            created: Utc::now(),
+            started: None,
+            completed: None,
+            deleted: false,
+        };
+        // Newest first, as the listing returns them. Run "d" is still running.
+        let rows = vec![
+            row(1, "d", AppBackupState::Running),
+            row(2, "c", AppBackupState::Completed),
+            row(3, "c", AppBackupState::Completed),
+            row(4, "b", AppBackupState::Failed),
+            row(5, "a", AppBackupState::Completed),
+        ];
+
+        // Keeping two runs drops only run "a" -- "d" is not yet a restore point
+        // and does not count against the limit.
+        let pruned: Vec<u64> = rows_past_retention(&rows, 2).iter().map(|r| r.id).collect();
+        assert_eq!(pruned, vec![5]);
+
+        // Keeping one drops both older finished runs, both artifacts of "c"
+        // surviving as the newest.
+        let pruned: Vec<u64> = rows_past_retention(&rows, 1).iter().map(|r| r.id).collect();
+        assert_eq!(pruned, vec![4, 5]);
+
+        // Retention larger than the history prunes nothing.
+        assert!(rows_past_retention(&rows, 7).is_empty());
+    }
+
+    /// Every app on the same daily schedule comes due in the same minute, so
+    /// the number of Jobs in flight is capped and the rest wait their turn as
+    /// pending rows.
+    #[test]
+    fn concurrency_is_capped_and_the_queue_survives_it() {
+        let row = |id: u64, state: AppBackupState| AppDeploymentBackup {
+            id,
+            deployment_id: id,
+            run_id: format!("run-{id}"),
+            service: "db".to_string(),
+            method: AppBackupMethod::Command,
+            artifact: "a.gz".to_string(),
+            object_key: None,
+            size_bytes: None,
+            state,
+            message: None,
+            scheduled: true,
+            created: Utc::now(),
+            started: None,
+            completed: None,
+            deleted: false,
+        };
+
+        // Nothing running: the first `limit` pending rows start.
+        let queue = vec![
+            row(1, AppBackupState::Pending),
+            row(2, AppBackupState::Pending),
+            row(3, AppBackupState::Pending),
+            row(4, AppBackupState::Pending),
+        ];
+        assert_eq!(startable(&queue, 3), vec![1, 2, 3]);
+
+        // Jobs already in flight spend the budget.
+        let queue = vec![
+            row(1, AppBackupState::Running),
+            row(2, AppBackupState::Running),
+            row(3, AppBackupState::Pending),
+            row(4, AppBackupState::Pending),
+        ];
+        assert_eq!(startable(&queue, 3), vec![3]);
+
+        // At the cap, nothing new starts -- and nothing is dropped, because the
+        // queue is the pending rows themselves.
+        let queue = vec![
+            row(1, AppBackupState::Running),
+            row(2, AppBackupState::Running),
+            row(3, AppBackupState::Running),
+            row(4, AppBackupState::Pending),
+        ];
+        assert!(startable(&queue, 3).is_empty());
+        assert!(startable(&queue, 0).is_empty());
+    }
+
+    /// A failure message is stored in a bounded column, so a Job condition with
+    /// a wall of text cannot fail the write that records the failure.
+    #[test]
+    fn failure_messages_are_bounded() {
+        assert_eq!(truncate("short", 500), "short");
+        assert_eq!(truncate(&"x".repeat(600), 500).len(), 500);
+        // Counted in characters, so a multi-byte message is not cut mid-symbol.
+        assert_eq!(truncate("äöü", 2), "äö");
+    }
+}

--- a/lnvps_operator/src/app_deployments.rs
+++ b/lnvps_operator/src/app_deployments.rs
@@ -64,7 +64,7 @@ pub const MANAGED_BY: &str = "lnvps-operator";
 pub const APP_NAMESPACE_CLUSTER_ROLE: &str = "lnvps-operator-appns";
 
 /// Common labels applied to every object of a deployment.
-fn labels(deployment_id: u64) -> BTreeMap<String, String> {
+pub(crate) fn labels(deployment_id: u64) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("managed-by".to_string(), MANAGED_BY.to_string()),
         (
@@ -75,7 +75,7 @@ fn labels(deployment_id: u64) -> BTreeMap<String, String> {
 }
 
 /// Per-service selector/labels (adds the compose service name).
-fn service_labels(deployment_id: u64, service: &str) -> BTreeMap<String, String> {
+pub(crate) fn service_labels(deployment_id: u64, service: &str) -> BTreeMap<String, String> {
     let mut l = labels(deployment_id);
     l.insert(
         "app.kubernetes.io/component".to_string(),
@@ -317,7 +317,7 @@ fn scale_bytes(value: &str, multiplier: u32) -> String {
 /// Container requests == limits (Guaranteed QoS, 1:1 — no overcommit) from a
 /// compose service's `resources`, scaled by the deployment's resource
 /// multiplier (1 = the catalog app's base size).
-fn build_resource_requirements(
+pub(crate) fn build_resource_requirements(
     r: &lnvps_compose::Resources,
     multiplier: u32,
 ) -> ResourceRequirements {
@@ -387,7 +387,7 @@ async fn delete_custom_domain_ingress(client: &Client, deployment_id: u64) -> Re
 /// kubelet chowns mounted volumes to that group. Without it a freshly
 /// provisioned PVC is root-owned `0755` and a non-root process cannot write to
 /// it — the app starts and then fails on its first write.
-fn pod_security_context_for(fs_group: Option<i64>) -> PodSecurityContext {
+pub(crate) fn pod_security_context_for(fs_group: Option<i64>) -> PodSecurityContext {
     PodSecurityContext {
         run_as_non_root: Some(true),
         fs_group,
@@ -424,7 +424,7 @@ fn pod_security_context_for(fs_group: Option<i64>) -> PodSecurityContext {
 /// verifies `runAsNonRoot` against the image config and cannot resolve a name,
 /// so without an explicit UID the container is refused with "image has
 /// non-numeric user ... cannot verify user is non-root".
-fn container_security_context_for(
+pub(crate) fn container_security_context_for(
     run_as_non_root: bool,
     run_as_user: Option<i64>,
 ) -> SecurityContext {
@@ -469,7 +469,7 @@ const INIT_TMP_VOLUME: &str = "init-tmp";
 /// a cached layer set can only be the right one and re-pulling buys nothing.
 /// `IfNotPresent` also keeps a restart working when the registry is down or
 /// rate-limiting, which `Always` does not.
-const IMAGE_PULL_POLICY: &str = "IfNotPresent";
+pub(crate) const IMAGE_PULL_POLICY: &str = "IfNotPresent";
 
 /// Pod-local name for a `scratch:` path's `emptyDir` (#264).
 ///
@@ -1246,6 +1246,28 @@ pub fn build_vars(
     vars
 }
 
+/// Resolve one existing deployment's env exactly as the reconcile loop does,
+/// for callers that need to run a container beside it — a backup Job runs the
+/// service's own image and has to see the same `DATABASE_URL` and generated
+/// password the service does, or the dump command cannot authenticate.
+///
+/// Deliberately **reads** the generated secrets rather than ensuring them:
+/// this runs against a deployment that already exists, and minting a value
+/// here would hand the container a password the running app does not have.
+pub(crate) async fn resolved_env(
+    ctx: &Context,
+    deployment: &AppDeployment,
+    compose: &Compose,
+    ingress_domain: &str,
+) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, String>>> {
+    let generated = read_generated(&ctx.client, deployment.id).await?;
+    let hostname = deployment_hostname(&deployment.name, ingress_domain);
+    let public = public_hostname(&hostname, deployment);
+    let config = parse_config(&deployment.config);
+    let vars = build_vars(compose, &generated, &config, &public);
+    compose.resolve_env(&vars)
+}
+
 /// Ensure every declared secret has a value, generating any that are missing
 /// (preserving existing ones so values are stable across reconciles).
 pub fn ensure_secrets(
@@ -1270,7 +1292,7 @@ pub fn ensure_secrets(
 
 /// Server-side apply a namespaced Kubernetes object, creating or updating it
 /// idempotently.
-async fn apply<K>(client: &Client, obj: &K) -> Result<()>
+pub(crate) async fn apply<K>(client: &Client, obj: &K) -> Result<()>
 where
     K: Resource<Scope = NamespaceResourceScope> + Serialize + DeserializeOwned + Clone + Debug,
     K::DynamicType: Default,

--- a/lnvps_operator/src/main.rs
+++ b/lnvps_operator/src/main.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use clap::Parser;
 use config::{Config as ConfigBuilder, File};
 use kube::Client;
-use lnvps_api_common::{RedisWorkCommander, WorkCommander, WorkJob, app_cluster_stream};
+use lnvps_api_common::{
+    ObjectStore, ObjectStoreConfig, RedisWorkCommander, WorkCommander, WorkJob, app_cluster_stream,
+};
 use lnvps_db::{LNVpsDb, LNVpsDbMysql};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -14,6 +16,7 @@ use std::time::Duration;
 use tokio::signal;
 use tokio::sync::Notify;
 
+mod app_backups;
 mod app_deployments;
 mod metrics;
 mod nostr_domains;
@@ -28,6 +31,12 @@ const ENCRYPTION_KEY_ENV: &str = "LNVPS_ENCRYPTION_KEY";
 /// Overrides `db` from the config file, so a deployment can keep its
 /// non-sensitive settings in a ConfigMap and read the DSN from a Secret.
 const DATABASE_URL_ENV: &str = "LNVPS_DATABASE_URL";
+
+/// Object storage credentials, for the same reason as [`DATABASE_URL_ENV`]:
+/// the config file lives in a ConfigMap, and a bucket key does not belong in
+/// one. The environment wins over anything in the file.
+const BACKUP_ACCESS_KEY_ENV: &str = "LNVPS_BACKUP_ACCESS_KEY";
+const BACKUP_SECRET_KEY_ENV: &str = "LNVPS_BACKUP_SECRET_KEY";
 
 /// Database field-encryption configuration (mirrors the API's `EncryptionConfig`
 /// so both sides use the same key).
@@ -117,6 +126,11 @@ pub struct Settings {
     /// unknown; everything else reconciles as before.
     pub prometheus: Option<PrometheusConfig>,
 
+    /// Object storage for app-deployment backup artifacts (optional). Without
+    /// it, backups are disabled: nothing is scheduled and nothing runs, which
+    /// is the behaviour of every operator that shipped before backups existed.
+    pub backups: Option<BackupConfig>,
+
     /// Redis URL carrying reconcile triggers for this operator's app cluster
     /// (optional; issue #254).
     ///
@@ -126,6 +140,34 @@ pub struct Settings {
     /// exactly as before: the periodic reconcile is the only trigger, and it
     /// remains the backstop either way.
     pub redis: Option<String>,
+}
+
+/// Where backup artifacts go, and how the Jobs that produce them are bounded.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BackupConfig {
+    /// S3-compatible bucket the artifacts are uploaded to.
+    #[serde(flatten)]
+    pub store: ObjectStoreConfig,
+
+    /// Image that tars, compresses and uploads. Defaults to a stock `curl`
+    /// image, whose busybox userland already has `tar` and `gzip`. Override to
+    /// pin it by digest, or to point at an internal mirror.
+    pub uploader_image: Option<String>,
+
+    /// How long a signed upload URL stays valid, in hours (default 6).
+    pub upload_url_expiry_hours: Option<u64>,
+
+    /// How long a backup Job may run, in hours (default 5). Kept below the
+    /// URL's life so a Job cannot outlive its own upload URL and then fail
+    /// with a signature error that reads as a storage fault.
+    pub job_deadline_hours: Option<u64>,
+
+    /// How many backup Jobs may run at once on this cluster (default 3).
+    /// Every app on the same daily schedule comes due in the same minute, and
+    /// each Job reads a whole volume on a node that is also serving customers'
+    /// apps.
+    pub max_concurrent: Option<usize>,
 }
 
 /// Prometheus the operator queries for deployment usage.
@@ -155,6 +197,54 @@ pub struct Context {
     /// Usage source, built once so its connection pool survives between
     /// reconcile passes. `None` when no Prometheus is configured.
     pub metrics: Option<PrometheusClient>,
+    /// Backup artifact storage. `None` when no bucket is configured, which
+    /// disables backups entirely.
+    pub object_store: Option<ObjectStore>,
+}
+
+impl Settings {
+    /// Image the backup uploader container runs.
+    pub fn backup_uploader_image(&self) -> &str {
+        self.backups
+            .as_ref()
+            .and_then(|b| b.uploader_image.as_deref())
+            .unwrap_or(app_backups::DEFAULT_UPLOADER_IMAGE)
+    }
+
+    /// How many backup Jobs may be in flight on this cluster.
+    pub fn max_concurrent_backups(&self) -> usize {
+        self.backups
+            .as_ref()
+            .and_then(|b| b.max_concurrent)
+            .unwrap_or(app_backups::DEFAULT_MAX_CONCURRENT_BACKUPS)
+            .max(1)
+    }
+
+    /// How long a signed upload URL is good for.
+    pub fn backup_url_expiry(&self) -> Duration {
+        Duration::from_secs(
+            3600 * self
+                .backups
+                .as_ref()
+                .and_then(|b| b.upload_url_expiry_hours)
+                .unwrap_or(app_backups::DEFAULT_UPLOAD_URL_HOURS)
+                .max(1),
+        )
+    }
+
+    /// How long a backup Job may run before Kubernetes kills it. Never longer
+    /// than the upload URL it was given.
+    pub fn backup_job_deadline(&self) -> Duration {
+        let configured = Duration::from_secs(
+            3600 * self
+                .backups
+                .as_ref()
+                .and_then(|b| b.job_deadline_hours)
+                .unwrap_or(app_backups::DEFAULT_JOB_DEADLINE_HOURS)
+                .max(1),
+        );
+        configured.min(self.backup_url_expiry())
+    }
 }
 
 /// Default gap between app-deployment sweeps while something is transitioning.
@@ -184,6 +274,23 @@ fn database_url(configured: &str, from_env: Option<String>) -> Result<String> {
         );
     }
     Ok(url.to_string())
+}
+
+/// Apply environment-supplied bucket credentials over whatever the config file
+/// carried, so the keys can live in a Secret while the rest stays in a
+/// ConfigMap. An empty or unset variable leaves the file's value alone.
+fn backup_credentials(
+    mut config: ObjectStoreConfig,
+    access_key: Option<String>,
+    secret_key: Option<String>,
+) -> ObjectStoreConfig {
+    if let Some(key) = access_key.filter(|k| !k.trim().is_empty()) {
+        config.access_key = key.trim().to_string();
+    }
+    if let Some(key) = secret_key.filter(|k| !k.trim().is_empty()) {
+        config.secret_key = key.trim().to_string();
+    }
+    config
 }
 
 #[tokio::main]
@@ -234,11 +341,28 @@ async fn main() -> Result<()> {
         None => None,
     };
 
+    // Backups are opt-in: without a bucket, nothing is scheduled and nothing
+    // runs, which is how every operator behaved before backups existed.
+    let object_store = match settings.backups.as_ref() {
+        Some(cfg) => Some(ObjectStore::new(backup_credentials(
+            cfg.store.clone(),
+            std::env::var(BACKUP_ACCESS_KEY_ENV).ok(),
+            std::env::var(BACKUP_SECRET_KEY_ENV).ok(),
+        ))?),
+        None => {
+            if settings.app_cluster_id.is_some() {
+                info!("No backup storage configured; app deployment backups are disabled");
+            }
+            None
+        }
+    };
+
     let context = Arc::new(Context {
         client: client.clone(),
         db: Arc::new(db) as Arc<dyn LNVpsDb>,
         settings: settings.clone(),
         metrics,
+        object_store,
     });
 
     info!("LNVPS Operator is running and watching for resources...");
@@ -318,6 +442,11 @@ async fn main() -> Result<()> {
                     // An unknown outcome is not a reason to poll fast forever.
                     app_transitioning.lock().unwrap().clear();
                 }
+            }
+            // After the deployments, so a backup Job is only ever created for a
+            // deployment this pass has already reconciled.
+            if let Err(e) = app_backups::reconcile_app_backups(&app_context).await {
+                error!("Failed to reconcile app backups: {}", e);
             }
         }
     };
@@ -491,9 +620,17 @@ mod tests {
         assert_eq!(prom.url, "http://prometheus.monitoring:9090");
         assert_eq!(prom.timeout_seconds, Some(10));
         assert_eq!(
-            full.encryption.unwrap().key_file,
+            full.encryption.clone().unwrap().key_file,
             PathBuf::from("/etc/lnvps/encryption.key")
         );
+        let backups = full.backups.clone().expect("backups example");
+        assert_eq!(backups.store.bucket, "lnvps-app-backups");
+        assert_eq!(backups.store.region, "eu-central-1");
+        assert!(backups.store.path_style);
+        assert_eq!(full.backup_url_expiry(), Duration::from_secs(6 * 3600));
+        assert_eq!(full.backup_job_deadline(), Duration::from_secs(5 * 3600));
+        assert_eq!(full.backup_uploader_image(), "curlimages/curl:8.11.1");
+        assert_eq!(full.max_concurrent_backups(), 2);
 
         // Minimal config (app-deployment keys commented out) still loads.
         let minimal = load("config.minimal.yaml");
@@ -504,5 +641,92 @@ mod tests {
         assert!(minimal.redis.is_none());
         // No prometheus: no usage is collected and the API reports it unknown.
         assert!(minimal.prometheus.is_none());
+        // No backups: nothing is scheduled and nothing runs.
+        assert!(minimal.backups.is_none());
+        // The defaults still answer, so the code paths that read them do not
+        // have to care whether backups are configured.
+        assert_eq!(minimal.backup_url_expiry(), Duration::from_secs(6 * 3600));
+        assert_eq!(
+            minimal.backup_uploader_image(),
+            app_backups::DEFAULT_UPLOADER_IMAGE
+        );
+    }
+
+    /// A bucket key does not belong in a ConfigMap, so the environment wins --
+    /// but an unset or blank variable must not blank a configured credential.
+    #[test]
+    fn backup_credentials_prefer_the_environment() {
+        let base = ObjectStoreConfig {
+            endpoint: "https://s3.example.com".to_string(),
+            region: "us-east-1".to_string(),
+            bucket: "b".to_string(),
+            access_key: "from-config".to_string(),
+            secret_key: "from-config".to_string(),
+            path_style: true,
+        };
+        let overridden = backup_credentials(
+            base.clone(),
+            Some("from-env".to_string()),
+            Some("  secret  ".to_string()),
+        );
+        assert_eq!(overridden.access_key, "from-env");
+        assert_eq!(overridden.secret_key, "secret");
+
+        let untouched = backup_credentials(base, None, Some("   ".to_string()));
+        assert_eq!(untouched.access_key, "from-config");
+        assert_eq!(untouched.secret_key, "from-config");
+    }
+
+    /// A Job that outlived its upload URL would fail with a signature error
+    /// that reads as a storage fault, so the deadline is capped at the URL.
+    #[test]
+    fn a_job_never_outlives_its_upload_url() {
+        let settings = |url_hours: u64, job_hours: u64| Settings {
+            db: String::new(),
+            namespace: None,
+            app_cluster_id: None,
+            reconcile_interval: None,
+            transition_reconcile_interval: None,
+            error_retry_interval: None,
+            verbose: None,
+            service_name: None,
+            port_name: None,
+            cluster_issuer: None,
+            ingress_class: None,
+            app_tls_secret: None,
+            ingress_namespace: None,
+            annotations: None,
+            encryption: None,
+            prometheus: None,
+            backups: Some(BackupConfig {
+                store: ObjectStoreConfig {
+                    endpoint: "https://s3.example.com".to_string(),
+                    region: "us-east-1".to_string(),
+                    bucket: "b".to_string(),
+                    access_key: "k".to_string(),
+                    secret_key: "s".to_string(),
+                    path_style: true,
+                },
+                uploader_image: None,
+                upload_url_expiry_hours: Some(url_hours),
+                job_deadline_hours: Some(job_hours),
+                max_concurrent: None,
+            }),
+            redis: None,
+        };
+        assert_eq!(
+            settings(2, 9).backup_job_deadline(),
+            Duration::from_secs(2 * 3600),
+            "a longer deadline than the URL is capped at the URL"
+        );
+        assert_eq!(
+            settings(9, 2).backup_job_deadline(),
+            Duration::from_secs(2 * 3600)
+        );
+        // Zero is not a duration anything can finish in.
+        assert_eq!(
+            settings(0, 0).backup_url_expiry(),
+            Duration::from_secs(3600)
+        );
     }
 }

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -417,3 +417,36 @@ echo "=== Running SshClient integration tests ==="
 LNVPS_TEST_SSH_ADDR="${LNVPS_TEST_SSH_ADDR:-localhost:2222}" \
 LNVPS_TEST_SSH_KEY="$SSH_KEY" \
     cargo test -p lnvps_api_common --features linux-ssh --test ssh_client
+
+# ---------------------------------------------------------------------------
+# 11. ObjectStore integration tests against the compose rustfs
+#
+# The unit tests pin our SigV4 output against AWS's published vector, which
+# proves the arithmetic but not that a server accepts it: a canonical request
+# that differs by one byte of path encoding fails as an opaque 403 at the
+# bucket. rustfs is the same S3 implementation the app catalog ships, so backup
+# uploads are exercised against a real one here.
+# ---------------------------------------------------------------------------
+echo "=== Running ObjectStore integration tests ==="
+# An unauthenticated request to the root is a 403, which is a healthy S3 and
+# not a failure — what matters is that something answered at all.
+if [[ "$(curl -s -o /dev/null -w '%{http_code}' \
+    "${LNVPS_TEST_S3_ENDPOINT:-http://localhost:9400}")" == "000" ]]; then
+    # The tests skip themselves without these variables, so an unreachable
+    # rustfs would otherwise pass the run without a single upload happening.
+    echo "ERROR: rustfs is not answering on ${LNVPS_TEST_S3_ENDPOINT:-http://localhost:9400}" >&2
+    docker compose -f "$COMPOSE_FILE" logs --tail=40 rustfs >&2 || true
+    exit 1
+fi
+export LNVPS_TEST_S3_ENDPOINT="${LNVPS_TEST_S3_ENDPOINT:-http://localhost:9400}"
+export LNVPS_TEST_S3_ACCESS_KEY="${LNVPS_TEST_S3_ACCESS_KEY:-e2eaccesskey}"
+export LNVPS_TEST_S3_SECRET_KEY="${LNVPS_TEST_S3_SECRET_KEY:-e2esecretkey}"
+cargo test -p lnvps_api_common --test object_store -- --test-threads=1
+
+# The backup uploader's own command line, run in the image the operator names,
+# against the same rustfs. The builder unit tests assert what the script says;
+# only this catches a busybox `tar` flag or a `curl` invocation that a real S3
+# server refuses -- a backup that silently never existed until somebody tries
+# to restore it.
+echo "=== Running backup uploader integration test ==="
+cargo test -p lnvps_operator the_uploader_script_really_uploads -- --test-threads=1

--- a/work/app-deployments.md
+++ b/work/app-deployments.md
@@ -197,11 +197,25 @@ Design (see "Backup execution" below for the detail):
 - [ ] Config wiring lands with its consumers: the operator in 6c, the API in 6d.
 
 #### 6c — Operator: run the backups
-- [ ] Build a per-artifact Job in the deployment namespace: `volume:` tars the PVC mounted
-      **read-only**; `command:` runs the dump in an init container on the app image with the
-      service's env, into a shared `emptyDir`; an uploader container `PUT`s the file.
-- [ ] Schedule evaluation + retention pruning (delete the object, tombstone the row).
-- [ ] Job status → DB write-back (size from a signed `HEAD`), and GC of finished Jobs.
+- [x] `lnvps_operator/src/app_backups.rs`: per-artifact Job in the deployment namespace.
+      `volume:` tars the PVC mounted **read-only**, pinned by pod affinity to the node already
+      holding the RWO claim (without it the Job schedules anywhere and sits in `Multi-Attach
+      error`). `command:` runs the dump in an init container on the app's own image with the
+      service's resolved env into a shared `emptyDir`; the uploader container gzips and `PUT`s it.
+- [x] The upload URL arrives as an env var from a Secret, never on a command line where every
+      other process in the pod could read it, and the Secret is deleted with the Job.
+- [x] Schedule evaluation + retention pruning (delete the object, then tombstone the row; a
+      failed delete keeps the row, or the object is orphaned with nothing pointing at it).
+- [x] Job status → DB write-back (size from a signed `HEAD`; a Job that "succeeded" with nothing
+      in the bucket is recorded as failed rather than offered as a restore point).
+- [x] Concurrency cap (default 3/cluster): every app on the same daily schedule comes due in the
+      same minute, and the pending rows are the queue, so waiting a sweep loses nothing.
+- [x] Operator config (`backups:` block, credentials overridable from the environment because the
+      config file lives in a ConfigMap), RBAC for `batch/jobs` and Secret `delete` in the
+      per-namespace role, and the DB grant on `app_deployment_backup`.
+- [x] **A `command:` runs in its own pod**, so it must address its service over the network
+      (`-h db`) rather than the default unix socket. Documented in the compose grammar and fixed
+      in `catalog/route96.yaml` and `catalog/buzz.yaml`, which both now carry a daily schedule.
 
 #### 6d — Customer API + docs
 - [ ] `POST /api/v1/app-deployments/{id}/backups` (start a run), `GET .../backups` (list),

--- a/work/app-deployments.md
+++ b/work/app-deployments.md
@@ -194,7 +194,11 @@ Design (see "Backup execution" below for the detail):
 - [x] Unit tests: the published AWS SigV4 presign vector, path vs virtual-hosted signing, method
       and key separation, filename sanitising, and wiremock coverage of `size`/`delete`
       (missing object → `None`, absent object → delete still succeeds, 403 → error).
-- [ ] Config wiring lands with its consumers: the operator in 6c, the API in 6d.
+- [x] Config wiring lands with its consumers: the operator in 6c, the API in 6d.
+- [x] Checked against a **real** S3 server (the compose `rustfs`, the same implementation the app
+      catalog ships): presigned round trip, an upload URL granting nothing beyond its own key or
+      method, and expiry actually being enforced. The AWS vector proves the arithmetic; only a
+      server proves the canonical request. Run by `scripts/run-e2e.sh`, skipped without the stack.
 
 #### 6c — Operator: run the backups
 - [x] `lnvps_operator/src/app_backups.rs`: per-artifact Job in the deployment namespace.
@@ -213,6 +217,10 @@ Design (see "Backup execution" below for the detail):
 - [x] Operator config (`backups:` block, credentials overridable from the environment because the
       config file lives in a ConfigMap), RBAC for `batch/jobs` and Secret `delete` in the
       per-namespace role, and the DB grant on `app_deployment_backup`.
+- [x] The uploader's **actual command line** is run in the image the Job names, against rustfs,
+      and the artifact is downloaded back and checked to be the archive it claims to be. A
+      busybox `tar` flag or a `curl` invocation a real S3 server refuses would otherwise be a
+      backup that silently never existed until somebody tried to restore it.
 - [x] **A `command:` runs in its own pod**, so it must address its service over the network
       (`-h db`) rather than the default unix socket. Documented in the compose grammar and fixed
       in `catalog/route96.yaml` and `catalog/buzz.yaml`, which both now carry a daily schedule.


### PR DESCRIPTION
Increment 6c of app-deployment backups (`work/app-deployments.md`), after #403 (schema) and #405
(signing). This is the part that actually captures data. The customer API is 6d, and restore is a
later increment.

Backups are opt-in per operator: with no `backups:` config block, nothing is scheduled and nothing
runs, which is how every operator has behaved until now.

## How a run executes

A run covers one deployment at one point in time. Every service declaring a `backup:` method
contributes one artifact, and each artifact is one Job and one object, because two services back
up with different images and different volumes and cannot share a pod.

- **`volume:`** tars the claim mounted read-only, pinned by pod affinity to the node already
  holding it. A ReadWriteOnce claim can only be mounted where it is already attached; without the
  affinity the Job schedules anywhere and sits in `Multi-Attach error` until the deadline kills it.
- **`command:`** runs the dump in an init container on the app's own image, since only that image
  has `pg_dumpall` or `mariadb-dump`, with the service's resolved env so a generated password is
  available to it exactly as the running app has it. The uploader is a separate container because
  the app's image is not guaranteed to contain an HTTP client.

The pod is hardened like the app's own: no service-account token, no service links, read-only
root, dropped capabilities, and it runs as the uid that owns the data (a read-only mount gets no
`fsGroup` remap, so any other uid would tar an unreadable tree).

## Why the operator schedules, not a CronJob

A CronJob fires with nothing to write the run down in and no way to hold an upload URL that has not
expired. The operator mints the row, signs a `PUT` for that one key, and hands the Job the URL
through a Secret-backed env var rather than a command line where every other process in the pod
could read it, then deletes the Secret with the Job. Due-ness is measured from the last run, so a
deployment down through several occurrences gets one catch-up run rather than one per missed slot.

Jobs in flight are capped per cluster (default 3). Every app on the same daily schedule comes due
in the same minute, and each Job reads a whole volume on a node that is also serving apps. The
pending rows are the queue, so a run that waits a sweep loses nothing.

## Failure handling

- A Job that reports success with **nothing in the bucket** is recorded as failed. The alternative
  is offering the customer a restore point that does not exist.
- Retention deletes the object before tombstoning the row, and keeps the row if that delete fails,
  or the object is orphaned in the bucket with nothing pointing at it.
- Retention counts finished **runs**, and never counts one still in flight: doing so would drop a
  real restore point in favour of one that does not exist yet.

## Catalog fix worth flagging

The dump does not run inside the service's container, so `pg_dumpall` / `mariadb-dump` left to
their defaults connect to a unix socket that exists only there. Both catalog entries would have
failed on their first scheduled run. They now address the service over the network (`-h db`), the
rule is documented next to the grammar, and both apps carry the schedule the feature exists for:
daily at 03:00 UTC, keeping a week.

## Operations

- New `backups:` block in the operator config (endpoint, bucket, credentials, uploader image, URL
  expiry, Job deadline, concurrency). Credentials can come from `LNVPS_BACKUP_ACCESS_KEY` /
  `LNVPS_BACKUP_SECRET_KEY`, because the config file lives in a ConfigMap.
- RBAC: `batch/jobs` (get/create/patch/delete) and Secret `delete`, both in the **per-namespace**
  role, not cluster-wide.
- DB: `GRANT INSERT, UPDATE ON lnvps.app_deployment_backup`.

## Testing

10 new unit tests over the pure builders: both capture shapes, read-only claim + node affinity,
the URL never reaching a command line, pod hardening and deadlines, staging size, artifact and key
naming, shell quoting of a catalog argv, the retention window, and the concurrency cap. The
cluster-touching functions are untested here, consistent with the rest of this crate.

`cargo test --workspace --exclude lnvps_e2e -- --test-threads=1`, clippy and fmt are clean, and
every `catalog/*.yaml` still validates.