### PR TITLE
build(vpn): package lvd as a Debian package on its own release tag

### DIFF
--- a/.github/workflows/lvd-deb.yml
+++ b/.github/workflows/lvd-deb.yml
@@ -1,0 +1,82 @@
+name: Build lvd .deb
+
+# Builds the LNVPS VPN route server daemon into a Debian package: the binary, a
+# systemd unit and the example config. On a tag the .deb is attached to the
+# GitHub release.
+#
+# Triggers on the main `v*` API tags, not on a prefix of its own. That follows
+# from lnvps_vpn being a root workspace member: it inherits
+# `[workspace.package] version`, so it has no version to tag independently, and
+# a separate tag would have to carry the same number as the API release it was
+# cut from.
+#
+# The trade-off, stated because it is a real one: two lvd versions can be
+# identical binaries when a release changed only the API. Nothing breaks --
+# there is no self-upgrade check comparing versions, unlike lnvps_fw -- but an
+# operator cannot tell from the version alone whether an upgrade matters. If
+# route servers ever need their own cadence, give lnvps_vpn its own `version`
+# instead of inheriting, and move this to an `lvd-v*` trigger.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo + build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: lvddeb-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            lvddeb-${{ runner.os }}-
+
+      - name: Install cargo-deb
+        run: command -v cargo-deb >/dev/null || cargo install cargo-deb --locked
+
+      - name: Build .deb
+        # From the package directory: cargo-deb resolves the workspace target
+        # dir itself, which is why the asset path is spelled "target/release/lvd"
+        # rather than "../target/release/lvd" (the latter is not recognised as a
+        # Cargo target and would package whatever happened to be on disk).
+        working-directory: lnvps_vpn
+        run: cargo deb
+
+      - name: Show package contents
+        run: |
+          DEB=$(ls target/debian/*.deb | head -1)
+          dpkg-deb --info "$DEB"
+          dpkg-deb --contents "$DEB"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: lvd-deb
+          path: target/debian/*.deb
+
+      - name: Attach to release
+        # Only on a tag: a manual dispatch build is an artifact, never a release.
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: target/debian/*.deb

--- a/.github/workflows/lvd-deb.yml
+++ b/.github/workflows/lvd-deb.yml
@@ -66,13 +66,38 @@ jobs:
       - name: Install cargo-deb
         run: command -v cargo-deb >/dev/null || cargo install cargo-deb --locked
 
+      - name: Work out the Debian version
+        # Semver and Debian disagree about pre-releases, and the disagreement is
+        # silent until the final release fails to install.
+        #
+        # Cargo says 0.1.0-rc1 comes *before* 0.1.0. dpkg says it comes after,
+        # because a hyphen carries no special meaning to it and a longer string
+        # sorts higher. `~` is the only character that sorts before nothing at
+        # all, so a Debian pre-release is 0.1.0~rc1. Shipping the semver spelling
+        # would mean apt refusing to "upgrade" from rc1 to the release it is a
+        # candidate for.
+        #
+        # Only the first hyphen is rewritten, which is exactly the semver
+        # pre-release separator; a plain 0.1.0 has none and passes through.
+        id: version
+        run: |
+          VER=$(awk '/^\[package\]/{f=1} f&&/^version[[:space:]]*=/{gsub(/.*=[[:space:]]*"|".*/,"");print;exit}' lnvps_vpn/Cargo.toml)
+          DEB_VER=$(echo "$VER" | sed 's/-/~/')
+          echo "cargo=$VER  deb=${DEB_VER}-1"
+          echo "deb_version=${DEB_VER}-1" >> "$GITHUB_OUTPUT"
+          # A semver pre-release is what marks the GitHub release as one.
+          case "$VER" in
+            *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Build .deb
         # From the package directory: cargo-deb resolves the workspace target
         # dir itself, which is why the asset path is spelled "target/release/lvd"
         # rather than "../target/release/lvd" (the latter is not recognised as a
         # Cargo target and would package whatever happened to be on disk).
         working-directory: lnvps_vpn
-        run: cargo deb
+        run: cargo deb --deb-version "${{ steps.version.outputs.deb_version }}"
 
       - name: Show package contents
         run: |
@@ -92,3 +117,4 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: target/debian/*.deb
+          prerelease: ${{ steps.version.outputs.prerelease }}

--- a/.github/workflows/lvd-deb.yml
+++ b/.github/workflows/lvd-deb.yml
@@ -4,22 +4,19 @@ name: Build lvd .deb
 # systemd unit and the example config. On a tag the .deb is attached to the
 # GitHub release.
 #
-# Triggers on the main `v*` API tags, not on a prefix of its own. That follows
-# from lnvps_vpn being a root workspace member: it inherits
-# `[workspace.package] version`, so it has no version to tag independently, and
-# a separate tag would have to carry the same number as the API release it was
-# cut from.
+# Triggers on a dedicated tag prefix (lvd-v*), the same convention as
+# lnvps_fw-v* and nixos-image-v*, so it does NOT run on the main `v*` API
+# release tags. A route server's upgrade cadence has nothing to do with the
+# API's: these are machines in other countries, upgraded deliberately, and a
+# package published on every API release would leave an operator unable to tell
+# from the version whether an upgrade mattered.
 #
-# The trade-off, stated because it is a real one: two lvd versions can be
-# identical binaries when a release changed only the API. Nothing breaks --
-# there is no self-upgrade check comparing versions, unlike lnvps_fw -- but an
-# operator cannot tell from the version alone whether an upgrade matters. If
-# route servers ever need their own cadence, give lnvps_vpn its own `version`
-# instead of inheriting, and move this to an `lvd-v*` trigger.
+# `lnvps_vpn` therefore does not inherit the workspace version. See its
+# Cargo.toml.
 on:
   push:
     tags:
-      - "v*"
+      - "lvd-v*"
   workflow_dispatch:
 
 permissions:
@@ -35,6 +32,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Assert Cargo.toml version matches the release tag
+        # A .deb whose version disagrees with the release it is attached to is
+        # worse than no .deb: `dpkg -l` would report something that cannot be
+        # found in any release, and the next upgrade would be decided against a
+        # number nobody wrote.
+        if: startsWith(github.ref, 'refs/tags/lvd-v')
+        run: |
+          TAG="${GITHUB_REF_NAME#lvd-v}"
+          VER=$(awk '/^\[package\]/{f=1} f&&/^version[[:space:]]*=/{gsub(/.*=[[:space:]]*"|".*/,"");print;exit}' lnvps_vpn/Cargo.toml)
+          echo "tag=$TAG  lnvps_vpn/Cargo.toml=$VER"
+          if [ "$VER" != "$TAG" ]; then
+            echo "::error::lnvps_vpn/Cargo.toml version ($VER) != release tag ($TAG). Bump it before tagging lvd-v$VER."
+            exit 1
+          fi
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -76,7 +88,7 @@ jobs:
 
       - name: Attach to release
         # Only on a tag: a manual dispatch build is an artifact, never a release.
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/lvd-v')
         uses: softprops/action-gh-release@v3
         with:
           files: target/debian/*.deb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,24 @@ When the user asks to create a release:
 4. **Create an annotated tag** — `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
 5. **Push commit and tag** — `git push https://github.com/LNVPS/api.git && git push https://github.com/LNVPS/api.git vX.Y.Z`
 
-The `vX.Y.Z` tag covers the API and its images only. `lnvps_fw` and the NixOS cloud image are **separate artifacts on their own tags** — releasing the API neither builds nor publishes them.
+The `vX.Y.Z` tag covers the API, its images, and the `lvd` Debian package. `lnvps_fw` and the NixOS cloud image are **separate artifacts on their own tags**: releasing the API neither builds nor publishes them.
+
+`lvd` (the VPN route server daemon, `lnvps_vpn`) rides the API tag because it is a root workspace member and inherits `[workspace.package] version`, so it has no version of its own to tag. `.github/workflows/lvd-deb.yml` builds `lnvps-lvd_<version>_amd64.deb` and attaches it to the release. Consequence worth knowing: consecutive `lvd` versions can be identical binaries when a release changed only the API. Nothing breaks, since there is no self-upgrade check comparing versions, but an operator cannot tell from the version alone whether an upgrade matters. If route servers ever need their own cadence, give `lnvps_vpn` an explicit `version` instead of inheriting and move the workflow to an `lvd-v*` trigger.
+
+## Installing a route server
+
+```
+apt install ./lnvps-lvd_<version>_amd64.deb
+cp /etc/lvd/config.example.yaml /etc/lvd/config.yaml
+# api-url, and token as <router_id>.<secret> from the router row
+chmod 600 /etc/lvd/config.yaml
+lvd --config /etc/lvd/config.yaml check
+systemctl enable --now lvd
+```
+
+The daemon holds no state: interface keys, addresses and the peer set are all
+fetched, so a rebuilt route server needs its config file and nothing else. It
+also opens no listening socket, so no inbound port or firewall rule is required.
 
 ## `lnvps_fw` Release Procedure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,21 @@ When the user asks to create a release:
 4. **Create an annotated tag** — `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
 5. **Push commit and tag** — `git push https://github.com/LNVPS/api.git && git push https://github.com/LNVPS/api.git vX.Y.Z`
 
-The `vX.Y.Z` tag covers the API, its images, and the `lvd` Debian package. `lnvps_fw` and the NixOS cloud image are **separate artifacts on their own tags**: releasing the API neither builds nor publishes them.
+The `vX.Y.Z` tag covers the API and its images only. `lnvps_fw`, `lvd` and the NixOS cloud image are **separate artifacts on their own tags**: releasing the API neither builds nor publishes them.
 
-`lvd` (the VPN route server daemon, `lnvps_vpn`) rides the API tag because it is a root workspace member and inherits `[workspace.package] version`, so it has no version of its own to tag. `.github/workflows/lvd-deb.yml` builds `lnvps-lvd_<version>_amd64.deb` and attaches it to the release. Consequence worth knowing: consecutive `lvd` versions can be identical binaries when a release changed only the API. Nothing breaks, since there is no self-upgrade check comparing versions, but an operator cannot tell from the version alone whether an upgrade matters. If route servers ever need their own cadence, give `lnvps_vpn` an explicit `version` instead of inheriting and move the workflow to an `lvd-v*` trigger.
+## `lvd` Release Procedure
+
+`lvd` is the VPN route server daemon (crate `lnvps_vpn`). It is a root workspace member, sharing the lockfile and CI, but it releases on its own `lvd-v*` tag: a route server's upgrade cadence has nothing to do with the API's. These are machines in other countries, upgraded deliberately, and a package published on every API release would leave an operator unable to tell from the version whether an upgrade mattered.
+
+For that reason `lnvps_vpn/Cargo.toml` carries an explicit `version` and does **not** inherit `[workspace.package]`. Its version is independent of the API's: bump it when the daemon changes, leave it alone when it does not.
+
+1. **Bump `lnvps_vpn/Cargo.toml`** — the `version` field.
+2. **Commit** — `git commit -m "chore(lvd): release lvd-vX.Y.Z"`
+3. **Tag and push** — `git tag -a lvd-vX.Y.Z -m "lvd vX.Y.Z"` then `git push https://github.com/LNVPS/api.git && git push https://github.com/LNVPS/api.git lvd-vX.Y.Z`
+
+Pushing the tag triggers `.github/workflows/lvd-deb.yml`, which builds `lnvps-lvd_<version>_amd64.deb` with `cargo deb` and attaches it to the GitHub release. The workflow **fails the build** if `lnvps_vpn/Cargo.toml` does not match the tag, so do step 1 before tagging: a package whose version disagrees with the release it hangs off is worse than no package, because `dpkg -l` then reports something that exists in no release.
+
+Unlike `lnvps_fw` there is no self-upgrade endpoint, so nothing on a route server compares its version against the newest release. Upgrading is `apt install ./lnvps-lvd_*.deb` on a box LNVPS already has access to.
 
 ## Installing a route server
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_vpn"
-version = "0.1.0"
+version = "0.1.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "lnvps_vpn"
-version = "0.4.7"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lnvps_vpn/Cargo.toml
+++ b/lnvps_vpn/Cargo.toml
@@ -2,10 +2,47 @@
 name = "lnvps_vpn"
 version.workspace = true
 edition.workspace = true
+# Both required by `cargo deb`, which builds a package with neither rather than
+# refusing, so the omission only shows up in the installed metadata.
+license = "MIT"
+description = "LNVPS VPN route server daemon"
 
 [[bin]]
 name = "lvd"
 path = "src/main.rs"
+
+# Packaged with `cargo deb`, run from this directory. Route servers are Debian
+# boxes LNVPS runs, so a .deb plus a systemd unit is the whole deployment: no
+# container, no orchestrator, nothing to schedule.
+#
+# There is no self-upgrade, unlike lnvps_fw. That exists because firewall
+# daemons are installed on many hosts, some of which LNVPS does not administer.
+# Route servers are few and ours, and a daemon that can replace its own binary
+# on a machine terminating customer traffic is a bigger thing to own than
+# `apt upgrade` on a box we already have access to.
+[package.metadata.deb]
+name = "lnvps-lvd"
+maintainer = "LNVPS <admin@lnvps.net>"
+copyright = "LNVPS"
+section = "net"
+priority = "optional"
+extended-description = """\
+The LNVPS VPN route server daemon. Asks LNVPS which WireGuard interfaces this \
+machine should carry and which customer devices are peers on them, and \
+configures the kernel to match. Outbound only: nothing connects to it, so it \
+runs behind any NAT with no inbound port and no certificate of its own."""
+depends = "$auto"
+maintainer-scripts = "debian/"
+assets = [
+    # Exactly "target/release/..." so cargo-deb recognises it as a Cargo
+    # target and builds it; it resolves the workspace target dir itself. Any
+    # other spelling silently packages whatever happens to be on disk.
+    ["target/release/lvd", "usr/bin/lvd", "755"],
+    ["systemd/lvd.service", "lib/systemd/system/lvd.service", "644"],
+    # The example only. The real config carries this route server's credential,
+    # so it is written by hand at 0600 rather than shipped in a package.
+    ["config.example.yaml", "etc/lvd/config.example.yaml", "644"],
+]
 
 [dependencies]
 # How to make a kernel carry a WireGuard data plane. Shared with lnvps_node so

--- a/lnvps_vpn/Cargo.toml
+++ b/lnvps_vpn/Cargo.toml
@@ -1,6 +1,16 @@
 [package]
 name = "lnvps_vpn"
-version.workspace = true
+# Deliberately *not* `version.workspace = true`, unlike every other member of
+# this workspace. `lvd` releases on its own `lvd-v*` tag, the same convention as
+# lnvps_fw and the NixOS image, because a route server's upgrade cadence has
+# nothing to do with the API's: inheriting the workspace version would publish a
+# new package on every API release, and two consecutive versions could be
+# identical binaries with no way for an operator to tell whether an upgrade
+# mattered.
+#
+# Bump this when the daemon changes; leave it alone when it does not. The
+# release workflow fails if it disagrees with the tag.
+version = "0.1.0"
 edition.workspace = true
 # Both required by `cargo deb`, which builds a package with neither rather than
 # refusing, so the omission only shows up in the installed metadata.

--- a/lnvps_vpn/Cargo.toml
+++ b/lnvps_vpn/Cargo.toml
@@ -10,7 +10,7 @@ name = "lnvps_vpn"
 #
 # Bump this when the daemon changes; leave it alone when it does not. The
 # release workflow fails if it disagrees with the tag.
-version = "0.1.0"
+version = "0.1.0-rc1"
 edition.workspace = true
 # Both required by `cargo deb`, which builds a package with neither rather than
 # refusing, so the omission only shows up in the installed metadata.

--- a/lnvps_vpn/debian/postinst
+++ b/lnvps_vpn/debian/postinst
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "configure" ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || true
+    if [ ! -f /etc/lvd/config.yaml ]; then
+        echo "lvd: no /etc/lvd/config.yaml found." >&2
+        echo "     Copy /etc/lvd/config.example.yaml to config.yaml, set api-url and" >&2
+        echo "     token (the token is <router_id>.<secret> from the LNVPS router row)," >&2
+        echo "     then run:" >&2
+        echo "         chmod 600 /etc/lvd/config.yaml" >&2
+        echo "         lvd --config /etc/lvd/config.yaml check" >&2
+        echo "         systemctl enable --now lvd" >&2
+    else
+        # An upgrade of a configured machine restarts into the new binary. Safe
+        # to do unprompted: the daemon holds no state, and the interfaces it
+        # built keep carrying traffic while it is not running.
+        systemctl try-restart lvd.service >/dev/null 2>&1 || true
+    fi
+fi
+
+exit 0

--- a/lnvps_vpn/debian/postrm
+++ b/lnvps_vpn/debian/postrm
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || true
+fi
+# The WireGuard interfaces lvd built are left alone: removing the package
+# should not drop every customer on a route server that is only being upgraded
+# by hand. `ip link del wgln<id>` is the deliberate act.
+
+exit 0

--- a/lnvps_vpn/debian/prerm
+++ b/lnvps_vpn/debian/prerm
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ]; then
+    systemctl stop lvd.service >/dev/null 2>&1 || true
+    systemctl disable lvd.service >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/lnvps_vpn/systemd/lvd.service
+++ b/lnvps_vpn/systemd/lvd.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=LNVPS VPN route server daemon
+Documentation=https://github.com/LNVPS/api
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/lvd --config /etc/lvd/config.yaml run
+# Always, not on-failure: the daemon's whole job is to keep asking LNVPS what
+# this machine should be. A clean exit is still a route server that has stopped
+# hearing about revocations.
+Restart=always
+RestartSec=5
+
+# Without this the unit is silent. env_logger defaults to errors only, and
+# every way this daemon fails in the field -- a rejected token, an unreachable
+# API, a refused apply -- is logged at warn or info. The unit would sit there
+# green, doing nothing, saying nothing. Override per-machine with
+# `systemctl edit lvd` if a quieter or noisier level is wanted.
+Environment=RUST_LOG=info
+
+# No StateDirectory, deliberately. lvd holds nothing across restarts: the
+# interface keys, the addresses and the peer set are all fetched, and the one
+# thing it does not fetch is its own config. A rebuilt route server needs that
+# file and nothing else.
+
+# Creating WireGuard interfaces, addressing them and routing through them is
+# all CAP_NET_ADMIN. It runs as root because the config file holds the
+# credential and is root-only, but nothing beyond networking is reachable.
+User=root
+CapabilityBoundingSet=CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_ADMIN
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=strict
+# The config is the only thing it reads and it never writes anywhere.
+ReadOnlyPaths=/etc/lvd
+PrivateTmp=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/work/vpn-service.md
+++ b/work/vpn-service.md
@@ -356,7 +356,15 @@ Notes:
       `configure_wireguard_interface`, and `WgObserved` carrying port, key, per-peer allowed
       IPs, endpoint and byte counters.
 - [x] `config.example.yaml`, with a test asserting this build accepts it.
+- [x] **Packaging**: `cargo deb` metadata, a systemd unit, maintainer scripts, and
+      `.github/workflows/lvd-deb.yml` building `lnvps-lvd_<version>_amd64.deb` on the API's
+      `v*` tag. Built, installed, started, upgraded and purged on a real machine.
 - [x] 26 unit tests. `client.rs`, `config.rs` and `scrub.rs` at 100% function coverage.
+
+**No self-upgrade**, unlike `lnvps_fw`. That exists because firewall daemons run on many hosts,
+some of which LNVPS does not administer. Route servers are few and ours, and a daemon that can
+replace its own binary on a machine terminating customer traffic is a bigger thing to own than
+`apt upgrade` on a box we already have access to.
 
 **No inbound control listener.** The original sketch had one for immediate re-pull. It is not
 needed and it is not wanted: long-poll already delivers a change in one round trip, and an
@@ -369,8 +377,16 @@ Notes:
 - **An interface the document does not mention is left alone.** A route server is not
   necessarily only a route server, and tearing down what LNVPS has not heard of would let a
   bug here take out the operator's own networking.
-- **`main.rs` is uncovered**, as `lnvps_node`'s is: it is the loop and the CLI. Increment 9
-  must exercise it.
+- **`main.rs` is uncovered** by unit tests, as `lnvps_node`'s is; the netns harness runs it as
+  a real process instead.
+- Installing the package surfaced a fault nothing else would have: `env_logger` defaults to
+  errors only, so the unit ran green and silent while failing every fetch. Every way this
+  daemon fails in the field is logged at `warn` or `info`. The unit sets `RUST_LOG=info`.
+- The unit runs as root but with `CapabilityBoundingSet=CAP_NET_ADMIN` and `ProtectSystem=strict`.
+  Verified under `systemd-run` with the same properties that creating a WireGuard interface,
+  addressing it and routing through it all still work.
+- No `StateDirectory`: the daemon holds nothing across restarts, so a rebuilt route server needs
+  only its config file.
 - Still open from increment 6: `POST /api/v1/routeserver/counters`. The counters are read
   from the kernel now (`WgPeerState::rx_bytes`/`tx_bytes`); nothing reports them yet.
 

--- a/work/vpn-service.md
+++ b/work/vpn-service.md
@@ -357,8 +357,11 @@ Notes:
       IPs, endpoint and byte counters.
 - [x] `config.example.yaml`, with a test asserting this build accepts it.
 - [x] **Packaging**: `cargo deb` metadata, a systemd unit, maintainer scripts, and
-      `.github/workflows/lvd-deb.yml` building `lnvps-lvd_<version>_amd64.deb` on the API's
-      `v*` tag. Built, installed, started, upgraded and purged on a real machine.
+      `.github/workflows/lvd-deb.yml` building `lnvps-lvd_<version>_amd64.deb` on its own
+      `lvd-v*` tag. Built, installed, started, upgraded and purged on a real machine.
+      `lnvps_vpn` carries an explicit `version` rather than inheriting the workspace's, so a
+      route server's upgrade cadence is its own: publishing a package on every API release
+      would leave an operator unable to tell from the version whether an upgrade mattered.
 - [x] 26 unit tests. `client.rs`, `config.rs` and `scrub.rs` at 100% function coverage.
 
 **No self-upgrade**, unlike `lnvps_fw`. That exists because firewall daemons run on many hosts,


### PR DESCRIPTION
Packages `lvd`, the VPN route server daemon, as a Debian package on its own release tag.

A route server is a Debian box LNVPS runs, so a `.deb` plus a systemd unit is the whole deployment: no container, no orchestrator, nothing to schedule.

## Its own tag, not the API's

`lnvps_vpn` carries an explicit `version` instead of inheriting `[workspace.package]`, and the workflow triggers on `lvd-v*` rather than `v*`, matching `lnvps_fw-v*` and `nixos-image-v*`. It stays a root workspace member: what changes is the release cadence, not the build layout.

A route server's upgrade cadence has nothing to do with the API's. These are machines in other countries, upgraded deliberately, and a package published on every API release would leave two consecutive versions as identical binaries with no way to tell whether an upgrade mattered. Starting at 0.1.0; it was 0.4.7 only because that is where the API happens to be, which is exactly the coupling being removed.

The workflow fails the build when `Cargo.toml` disagrees with the tag, as the firewall's does. A package whose version does not match the release it hangs off is worse than no package: `dpkg -l` reports something that exists in no release. The awk that extracts the version was checked against the real file, both that it reads `0.1.0` and that it rejects a mismatched tag.

## Semver and Debian disagree about pre-releases

This one is silent until the final release fails to install. Cargo says `0.1.0-rc1` precedes `0.1.0`; dpkg says it *follows* it, because a hyphen means nothing special to dpkg and a longer string sorts higher. `~` is the only character that sorts before nothing at all.

Shipping the semver spelling would mean apt refusing to "upgrade" from a release candidate to the release it is a candidate for. The workflow rewrites the first hyphen, which is exactly the semver pre-release separator, so `0.1.0-rc1` becomes `0.1.0~rc1` and a plain `0.1.0` passes through untouched. Verified with `dpkg --compare-versions` in both spellings rather than reasoned about. A semver pre-release also marks the GitHub release as one.

## No self-upgrade, deliberately

`lnvps_fw` has one because firewall daemons run on many hosts, some of which LNVPS does not administer. Route servers are few and ours, and a daemon that can replace its own binary on a machine terminating customer traffic is a bigger thing to own than `apt upgrade` on a box we already have access to.

## Built, installed and run, not just inspected

Which found a fault nothing else would have. `env_logger` defaults to errors only, and every way this daemon fails in the field -- a rejected token, an unreachable API, a refused apply -- is logged at warn or info. The unit sat there green and silent while failing every fetch. It now sets `RUST_LOG=info`.

The unit runs as root, because the config holds the credential and is root-only, but with `CapabilityBoundingSet=CAP_NET_ADMIN` and `ProtectSystem=strict`. Checked under `systemd-run` with those exact properties that creating a WireGuard interface, addressing it and routing through it all still work, rather than assuming a hardening directive was harmless.

No `StateDirectory`: the daemon holds nothing across restarts, so a rebuilt route server needs its config file and nothing else. `postrm` leaves the WireGuard interfaces alone, because removing the package should not drop every customer on a box that is only being upgraded by hand.

## Proven in production

`lvd-v0.1.0-rc1` is published as a pre-release with this workflow, and that artifact was downloaded and installed on a real route server (`ie-01`, Dublin), where it built its interface from the published data plane and is now carrying a customer device: ~186 MiB sent across 224 flows at the time of writing.

Two things worth recording from that deployment, neither of them changes in this PR:

- **`lvd` does not configure NAT or egress filtering**, by design, and the route server needs both. Forwarding, masquerade and MSS clamping were set up by hand on the box.
- **The pool MTU default of 1420 is wrong for this DC.** The VM's `eth0` is 1450, so the tunnel must be 1370. At 1420 the handshake, keepalives and DNS all fit while anything larger is silently dropped, which presents as `wg show` looking perfectly healthy while pages hang half-loaded. Either the default should change or a pool's MTU should be validated against the route server's own interface, because the next person to create a pool hits it identically with no useful error.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-features --all-targets` and `cargo test --workspace --all-features --exclude lnvps_e2e -- --test-threads=1` are clean: 2049 tests pass. `cargo deb` produces `lnvps-lvd_0.1.0~rc1-1_amd64.deb`, which installs, configures, starts under systemd, upgrades in place and purges cleanly.
