### PR TITLE
fix(dns): a forward record is named by its assignment

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -34,6 +34,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`dns_forward` now reaches DNS.** `PATCH /api/admin/v1/vm_ip_assignments/{id}` accepted a forward name, wrote it to the database and never sent it on: the A/AAAA record was named from the VM id, so the row said one thing and the nameserver answered for another. Setting `dns_forward` now renames the record, and the old name stops resolving. Clearing it returns to the derived `vm-{id}` name.
+
+  A stored name must be a full FQDN, as reverse names already must. A bare label would be expanded against the zone, turning `host` into `host.example.com.example.com`.
+
 - **Address allocation was quadratic in the number of allocations** — the shared allocator restarted its overlap search at the first allocation for every candidate slot, so a densely packed range cost `O(n^2)`: 20k allocations took 355ms of CPU per call and quadrupled with each doubling. It is now linear, dominated by the sort, at 5.5ms for the same case. Affects VM IP assignment, marketplace tunnel links and VPN device registration, which share the allocator.
 
 ### Security

--- a/lnvps_api_common/src/dns/mod.rs
+++ b/lnvps_api_common/src/dns/mod.rs
@@ -134,10 +134,33 @@ impl Display for RecordType {
 }
 
 impl BasicRecord {
+    /// The A/AAAA record for an assignment.
+    ///
+    /// `dns_forward` names the record when it is set, so an assignment that has
+    /// been given a name keeps it. It used to be derived from the VM id alone,
+    /// which meant the admin API could store a name that DNS never received and
+    /// a hand-edited record was renamed back on the next sync.
+    ///
+    /// A stored name is a full FQDN, as the reverse path already requires: this
+    /// is what a create writes back, since providers return the record's
+    /// resolved name. A bare label would be expanded against the zone, so
+    /// accepting one would silently produce `host.example.com.example.com` on
+    /// every record in a shared zone. Falling back to the derived `vm-{id}`
+    /// label is the one place a label is still correct, because there is no
+    /// stored name for the zone to disagree with.
     pub fn forward(ip: &VmIpAssignment, zone: DnsRef) -> Result<Self> {
         let addr = IpAddr::from_str(&ip.ip)?;
+        let name = match ip.dns_forward.as_deref() {
+            Some(name) => {
+                if !is_valid_fqdn(name) {
+                    bail!("Forward DNS name {name:?} is not a valid FQDN");
+                }
+                name.to_string()
+            }
+            None => format!("vm-{}", &ip.vm_id),
+        };
         Ok(Self {
-            name: format!("vm-{}", &ip.vm_id),
+            name,
             value: addr.to_string(),
             id: ip.dns_forward_ref.clone().map(DnsRef::Id),
             kind: match addr {
@@ -258,6 +281,52 @@ mod tests {
             dns_reverse: Some("host.example.com".to_string()),
             ..Default::default()
         }
+    }
+
+    /// A named assignment gets the name it was given.
+    ///
+    /// `PATCH /vm_ip_assignments/{id}` stored `dns_forward` and DNS never saw
+    /// it: the record name was derived from the VM id, so the row said
+    /// `ie-01.vpn.lnvps.cloud` while the nameserver still answered for
+    /// `vm-1940.lnvps.cloud` and nothing resolved the new name.
+    #[test]
+    fn a_forward_record_is_named_by_the_assignment() -> anyhow::Result<()> {
+        let zone = DnsRef::Id("z".to_string());
+
+        // Unnamed: derived from the VM id, as it always was.
+        let mut ip = v4_assignment();
+        ip.dns_forward = None;
+        assert_eq!(BasicRecord::forward(&ip, zone.clone())?.name, "vm-42");
+
+        // Named: the stored name wins, and the record keeps its provider
+        // reference so the existing record is renamed rather than duplicated.
+        ip.dns_forward = Some("ie-01.vpn.example.com".to_string());
+        ip.dns_forward_ref = Some("rec-1".to_string());
+        let rec = BasicRecord::forward(&ip, zone.clone())?;
+        assert_eq!(rec.name, "ie-01.vpn.example.com");
+        assert_eq!(rec.id, Some(DnsRef::Id("rec-1".to_string())));
+        assert_eq!(rec.value, "10.0.0.5");
+        assert!(matches!(rec.kind, RecordType::A));
+
+        // The name every un-renamed row already holds, which must keep
+        // producing the record it produces today: `vm-42` expanded by the zone
+        // and `vm-42.lnvps.cloud` are the same record.
+        ip.dns_forward = Some("vm-42.lnvps.cloud".to_string());
+        assert_eq!(
+            BasicRecord::forward(&ip, zone.clone())?.name,
+            "vm-42.lnvps.cloud"
+        );
+
+        // A bare label is refused rather than sent. Cloudflare would expand it
+        // against the zone into `host.lnvps.cloud.lnvps.cloud`.
+        ip.dns_forward = Some("host".to_string());
+        assert!(
+            BasicRecord::forward(&ip, zone)
+                .unwrap_err()
+                .to_string()
+                .contains("not a valid FQDN")
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
`PATCH /api/admin/v1/vm_ip_assignments/{id}` accepted `dns_forward`, documented it as the forward FQDN, wrote it to the database and never sent it to DNS. `BasicRecord::forward` derived the record name from the VM id and never read the stored value, so the row and the nameserver disagreed. Reverse worked, because `reverse_to_fwd` does read its stored value.

`forward` now uses `dns_forward` when set, falling back to the derived `vm-{id}` label when it is not, so clearing the field restores the old name.

## The FQDN question

The issue flagged this as the thing not to guess at, and it is the only real decision here. The derived name is a bare **label** that Cloudflare expands against the zone. Accepting a label as a stored name would turn `host` into `host.lnvps.cloud.lnvps.cloud` on live records for every VM in a shared zone, not only the one being renamed.

So a stored name must be a full FQDN, as reverse names already must. That is also what a create writes back, since providers return the record's resolved name. The fallback stays a label because there is no stored name for the zone to disagree with.

## Checked against production rather than assumed

Of 1787 assignments: 1348 have no forward name, 439 hold an FQDN, **none hold a bare label**, so nothing starts failing validation.

Of the 439, the only rows whose name is not already `vm-{vm_id}.<zone>` are the six belonging to the three route servers, which are the rows the bug was found on. For every other row the record produced is unchanged.

## Test

`a_forward_record_is_named_by_the_assignment` covers the derived name, the stored name (keeping its provider reference, so the record is renamed rather than duplicated), the `vm-42.lnvps.cloud` form every un-renamed row already holds, and the rejected bare label. Verified to fail with `left: "vm-42", right: "ie-01.vpn.example.com"` when the fix is reverted.

2052 pass, clippy clean.

Fixes #410